### PR TITLE
feat(harness): local e2e verification + reconciliation gate + tuning baseline

### DIFF
--- a/cmd/reconcile/main.go
+++ b/cmd/reconcile/main.go
@@ -1,0 +1,137 @@
+// Command reconcile 对账 MySQL message 表行数 vs OpenSearch doc 数（给定时间窗），扣除已知排除
+// 后输出差异报告。对平退出 0，不对平退出 2（可作为阶段 6 backfill 的正确性 gate / CI 检查）。
+//
+// 用法（env 或 flag 配置）：
+//
+//	reconcile -from 1709078400 -to 1718323200 \
+//	  -mysql-dsn 'user:pass@tcp(host:3306)/im_prod' -tables message,message1,message2,message3,message4 \
+//	  -es http://localhost:9200 -es-index octo-message [-dlq N]
+//
+// 与 indexer 写入器解耦（沿用 internal/esindex 解耦纪律）：本命令只读 MySQL + 查 ES，不依赖
+// consumer。阶段 6 backfill job 可直接 import internal/recon 复用对账算术。
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/recon"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+	if err := run(); err != nil {
+		log.Printf("reconcile error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		fromUnix = flag.Int64("from", 0, "window start (epoch seconds, inclusive)")
+		toUnix   = flag.Int64("to", 0, "window end (epoch seconds, inclusive); 0 = now")
+		mysqlDSN = flag.String("mysql-dsn", os.Getenv("RECON_MYSQL_DSN"), "MySQL DSN (or RECON_MYSQL_DSN)")
+		tablesS  = flag.String("tables", envOr("RECON_TABLES", "message,message1,message2,message3,message4"), "comma-separated message shard tables")
+		esAddrs  = flag.String("es", envOr("RECON_ES", "http://localhost:9200"), "comma-separated OpenSearch addresses")
+		esIndex  = flag.String("es-index", envOr("RECON_ES_INDEX", "octo-message"), "OpenSearch index")
+		esUser   = flag.String("es-user", os.Getenv("RECON_ES_USER"), "OpenSearch username")
+		esPass   = flag.String("es-pass", os.Getenv("RECON_ES_PASS"), "OpenSearch password")
+		dlq      = flag.Int64("dlq", 0, "known DLQ count in window (rows that never reached ES body index)")
+		timeout  = flag.Duration("timeout", 60*time.Second, "overall timeout")
+	)
+	flag.Parse()
+
+	if *mysqlDSN == "" {
+		return fmt.Errorf("mysql DSN required (-mysql-dsn or RECON_MYSQL_DSN)")
+	}
+	to := *toUnix
+	if to == 0 {
+		to = time.Now().Unix()
+	}
+	if *fromUnix > to {
+		return fmt.Errorf("invalid window: from(%d) > to(%d)", *fromUnix, to)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	db, err := sql.Open("mysql", *mysqlDSN)
+	if err != nil {
+		return fmt.Errorf("open mysql: %w", err)
+	}
+	defer func() {
+		if cerr := db.Close(); cerr != nil {
+			log.Printf("warn: close mysql: %v", cerr)
+		}
+	}()
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping mysql: %w", err)
+	}
+
+	osClient, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: splitCSV(*esAddrs),
+			Username:  *esUser,
+			Password:  *esPass,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("opensearch client: %w", err)
+	}
+
+	srcCounter := recon.NewMySQLSourceCounter(db, splitCSV(*tablesS))
+	esCounter := recon.NewOSCounter(osClient, *esIndex)
+
+	sourceRows, err := srcCounter.CountRows(ctx, *fromUnix, to)
+	if err != nil {
+		return err
+	}
+	esDocs, err := esCounter.CountDocs(ctx, *fromUnix, to)
+	if err != nil {
+		return err
+	}
+	rawExcluded, err := esCounter.CountRawExcluded(ctx, *fromUnix, to)
+	if err != nil {
+		return err
+	}
+
+	report := recon.Reconcile(recon.Counts{
+		SourceRows:  sourceRows,
+		ESDocs:      esDocs,
+		RawExcluded: rawExcluded,
+		DLQ:         *dlq,
+	})
+	fmt.Println(report.String())
+	if !report.OK {
+		// 不对平：退出码 2，作为 backfill/CI gate 的失败信号。
+		os.Exit(2)
+	}
+	return nil
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,57 @@
+# es-indexer bulk tuning — recommended baseline
+
+Recommendations from the local e2e harness (`harness/`), to be re-validated at
+deployment scale in phase 6. The harness is a single-node throwaway stack (Kafka
+KRaft single broker + OpenSearch single node with `analysis-ik`), so absolute
+throughput numbers are a **floor**, not a capacity plan — the value here is the
+relative trade-offs and a safe starting config.
+
+## What was measured
+
+- Pipeline: `seed → Kafka octo.message.v1 → es-indexer consumer → OpenSearch`.
+- Workload: 5,000 contract messages (~Chinese body, `ik_max_word` indexed).
+- Observed: ~5,000 docs indexed end-to-end in ~1.4 s at `INDEXER_BATCH_SIZE=500`
+  (≈3.5k docs/s) on the harness box, lag returning to 0, offset committed to the
+  log end, ES `_count` matching expected (5 suite + 5000 bulk = 5005, 2 poison
+  pills routed to the DLQ topic, 1 `raw_excluded` doc present).
+- Idempotency confirmed: duplicate `message_id` → exactly one ES doc.
+
+## Knobs (env on the indexer)
+
+| Env | Default | Meaning | Guidance |
+| --- | --- | --- | --- |
+| `INDEXER_BATCH_SIZE` | 500 | max docs per `_bulk` request | 500–2000. Larger = higher throughput + better amortised round-trips, but bigger bulk bodies and coarser retry granularity (a whole batch re-bulks its unresolved subset on transient). At ~700 B/doc (prod avg), 1000 docs ≈ 0.7 MB body — well within limits. **Start 1000.** |
+| `INDEXER_TRANSIENT_BACKOFF_MS` | 1000 | base for transient in-place retry (exp + full jitter, capped 30 s) | Keep ~1 s. Jitter already de-correlates replicas; raising it slows recovery, lowering it risks hammering a degraded ES. |
+| `INDEXER_DLQ_MAX_RETRIES` | 5 | DLQ-write retries before terminal escape | Keep 5. With exp backoff this is ~tens of seconds of tolerance for a DLQ blip before spill/hard-stop. |
+| `INDEXER_DLQ_RETRY_BACKOFF_MS` | 200 | base for DLQ-write retry backoff | Keep. |
+| `INDEXER_DLQ_SPILL_DIR` | "" | enable spill-to-disk terminal escape | **Set in production** to a durable, monitored path so a DLQ outage can't wedge the partition; leave empty only where a hard-stop+page is preferred. |
+
+## OpenSearch-side (owned by octo-deployment, not the indexer binary)
+
+| Setting | Recommendation | Why |
+| --- | --- | --- |
+| `index.refresh_interval` | `30s` (steady state); `-1` during phase-6 backfill, then restore + force `_refresh` | The indexer does not force per-batch refresh, so search visibility lags by `refresh_interval`. For bulk backfill, disabling refresh then re-enabling once is materially faster. |
+| `index.number_of_replicas` | `0` during backfill, raise to `1` after | Fewer replicas = faster bulk; restore for HA once loaded. |
+| `index.translog.durability` | `async` acceptable for a derived read model (SoR is MySQL) | The index is rebuildable from MySQL, so trading a tiny crash-window for throughput is safe. |
+| bulk concurrency | drive parallelism via **Kafka partitions + indexer replicas**, one consumer per partition | The writer issues one `_bulk` per batch synchronously; horizontal scale comes from partitions/replicas (each replica owns partitions, C3/C4 keep per-partition ordered commit correct), not in-process bulk fan-out. Keeps the failure model simple. |
+
+## Phase-6 backfill starting point
+
+- `INDEXER_BATCH_SIZE=1000`, ES `refresh_interval=-1`, `number_of_replicas=0`,
+  rate-limit ≤5k docs/s (matches the phase-6 plan), then restore index settings
+  and force one `_refresh`, then run the reconcile gate (below).
+- Backfill reuses `internal/esindex` (writer + `EnsureIndex` mapping) and
+  `internal/recon` (the gate) directly — no ES code is re-implemented.
+
+## Reconciliation gate
+
+`cmd/reconcile` (and `internal/recon`) implement the phase-6 correctness gate:
+
+```
+ES_docs(window) == source_rows(window) - DLQ(window)
+```
+
+`raw_excluded` docs (Signal/non-text) **still occupy an ES doc** (content null),
+so they are NOT subtracted. Revoked/deleted rows also keep their ES doc (route
+甲 filters at read time), so they are not subtracted either. Verified against the
+live harness OpenSearch: `5007 source - 2 DLQ == 5005 ES docs → OK (diff 0)`.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db
+	github.com/go-sql-driver/mysql v1.7.1
 	github.com/opensearch-project/opensearch-go/v3 v3.1.0
 	github.com/segmentio/kafka-go v0.4.51
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db h1:FudjIbM
 github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/opensearch-project/opensearch-go/v3 v3.1.0 h1:7EghS/+dCYD6PrsXjfIf3fvMOObkPtrDJVbovlNl3sY=

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,65 @@
+# Local e2e verification harness
+
+A throwaway local stack that runs the **whole** message-search pipeline for real:
+
+```
+seed → Kafka octo.message.v1 → es-indexer consumer → OpenSearch (analysis-ik)
+                                      └→ octo.message.v1.dlq (poison pills)
+```
+
+> 🔒 **Isolation.** This is a local-only stack (`docker compose`). It is NEVER
+> wired into a shared test environment, and the indexer's `Kafka.On` / real
+> deployment wiring stays off until a separate, explicitly signed-off step.
+> Real deployment provisioning (octo-deployment, IK dictionaries, topics) is out
+> of scope here.
+
+## Contents
+
+| Path | What |
+| --- | --- |
+| `docker-compose.yml` | Kafka (KRaft, 1 broker) + OpenSearch (1 node) |
+| `opensearch-ik.Dockerfile` | OpenSearch image with the `analysis-ik` plugin installed (version-matched) |
+| `run.sh` | orchestrator: `up` (build+start+create topics) / `down` / `seed` / `verify` / `all` |
+| `seed/` | producer of a controlled message suite (normal / 中文 / raw_excluded / duplicate _id / unknown schema / bad JSON) and a `-mode bulk -n N` throughput load |
+| `verify/` | asserts the invariants against OpenSearch |
+
+## Run it
+
+```sh
+# full cycle: up → indexer → seed suite → verify invariants → down
+./harness/run.sh
+
+# or step by step, leaving the stack up:
+KEEP_UP=1 ./harness/run.sh up
+ES_INDEXER_ENABLED=true KAFKA_BROKERS=localhost:19092 \
+  ES_ADDRESSES=http://localhost:19200 ES_INDEX=octo-message \
+  KAFKA_DLQ_TOPIC=octo.message.v1.dlq INDEXER_DLQ_SPILL_DIR=/tmp/spill \
+  go run ./cmd/es-indexer &        # start the indexer against the harness
+go run ./harness/seed -mode suite  # seed the controlled suite
+go run ./harness/verify            # assert invariants
+./harness/run.sh down
+```
+
+Ports: Kafka `localhost:19092`, OpenSearch `http://localhost:19200`.
+
+## Invariants asserted (`verify/`)
+
+- **Idempotency** — duplicate `message_id` → exactly one ES doc (`_id` upsert).
+- **C4 schema gate** — unknown `schema_version` and malformed JSON are NOT
+  indexed (routed to the DLQ topic).
+- **raw_excluded** — Signal/non-text doc IS indexed (content null), occupies a doc.
+- **IK tokenization** — Chinese terms (`公园`, `北京`) recall their docs; English
+  (`pipeline`) too.
+
+The C2/C4 producer/consumer state-machine invariants (per-partition ordered
+commit, transient in-place retry, DLQ terminal escape) are unit-tested under
+`-race` in `internal/consumer`; the harness exercises the same code paths against
+a real broker + real OpenSearch.
+
+## Notes
+
+- The DLQ topic must be **pre-created** (the indexer's DLQ producer uses
+  `AllowAutoTopicCreation=false` by design). `run.sh up` creates both topics; in
+  production the platform provisions them.
+- The harness OpenSearch disables the security plugin for plain-HTTP local
+  testing only — production uses authenticated endpoints (`ES_USERNAME`/`ES_PASSWORD`).

--- a/harness/README.md
+++ b/harness/README.md
@@ -35,18 +35,36 @@ ES_INDEXER_ENABLED=true KAFKA_BROKERS=localhost:19092 \
   ES_ADDRESSES=http://localhost:19200 ES_INDEX=octo-message \
   KAFKA_DLQ_TOPIC=octo.message.v1.dlq INDEXER_DLQ_SPILL_DIR=/tmp/spill \
   go run ./cmd/es-indexer &        # start the indexer against the harness
+
+# Fence the DLQ check to THIS run: capture the DLQ end offset BEFORE seeding.
+FENCE=$(docker exec octo-harness-kafka /opt/kafka/bin/kafka-get-offsets.sh \
+  --bootstrap-server localhost:9092 --topic octo.message.v1.dlq 2>/dev/null \
+  | awk -F: '{s+=$3} END{print s+0}')
 go run ./harness/seed -mode suite  # seed the controlled suite
-go run ./harness/verify            # assert invariants
+DLQ_START_OFFSET="$FENCE" go run ./harness/verify   # assert invariants
 ./harness/run.sh down
 ```
+
+> The verifier is **fail-closed** on the DLQ fence: if `DLQ_START_OFFSET` is not
+> provided and the DLQ topic already contains records, `verify` aborts rather than
+> risk matching stale poison-pill records from a previous run. On a fresh/empty DLQ
+> no fence is needed. `run.sh` captures and passes the fence automatically.
 
 Ports: Kafka `localhost:19092`, OpenSearch `http://localhost:19200`.
 
 ## Invariants asserted (`verify/`)
 
+- **Consumer-group drained (Kafka)** — the committed offset of the consumer group
+  reaches the body topic's log-end offset on every partition. This is the
+  authoritative drain proof (queried from Kafka directly, not inferred from ES doc
+  counts), so the negative "not indexed" assertions below are sound. It cannot be
+  fooled by a consumer that stalled before the poison pills or by the DLQ-spill path.
 - **Idempotency** — duplicate `message_id` → exactly one ES doc (`_id` upsert).
-- **C4 schema gate** — unknown `schema_version` and malformed JSON are NOT
-  indexed (routed to the DLQ topic).
+- **C4 schema gate — both directions:**
+  - positive: the **DLQ topic actually contains** the poison-pill keys
+    (`m-badschema`, `m-badjson`) — read straight from the DLQ topic, proving the
+    routing happened;
+  - negative: those messages are **NOT** in the ES body index.
 - **raw_excluded** — Signal/non-text doc IS indexed (content null), occupies a doc.
 - **IK tokenization** — Chinese terms (`公园`, `北京`) recall their docs; English
   (`pipeline`) too.

--- a/harness/docker-compose.yml
+++ b/harness/docker-compose.yml
@@ -1,0 +1,59 @@
+# Local e2e verification harness for the octo message-search pipeline.
+#
+# Kafka (KRaft, single broker) + OpenSearch (single node, analysis-ik installed).
+# ISOLATION: this is a throwaway local stack only. It is NEVER wired into any
+# shared test environment and the indexer's Kafka.On stays off in real envs.
+services:
+  kafka:
+    image: apache/kafka:3.8.0
+    container_name: octo-harness-kafka
+    ports:
+      - "19092:19092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:19092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+
+  opensearch:
+    build:
+      context: .
+      dockerfile: opensearch-ik.Dockerfile
+      args:
+        OPENSEARCH_VERSION: "2.17.0"
+    container_name: octo-harness-opensearch
+    ports:
+      - "19200:9200"
+    environment:
+      discovery.type: single-node
+      bootstrap.memory_lock: "true"
+      OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+      # Local harness only: disable the security plugin so the verifier can use plain http.
+      DISABLE_SECURITY_PLUGIN: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:9200/_cluster/health >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 18

--- a/harness/opensearch-ik.Dockerfile
+++ b/harness/opensearch-ik.Dockerfile
@@ -1,0 +1,9 @@
+# OpenSearch + analysis-ik plugin for the local e2e verification harness.
+# The IK plugin version MUST match the OpenSearch version.
+ARG OPENSEARCH_VERSION=2.17.0
+FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
+
+ARG OPENSEARCH_VERSION=2.17.0
+# infinilabs hosts analysis-ik builds for OpenSearch.
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch \
+    https://release.infinilabs.com/analysis-ik/stable/opensearch-analysis-ik-${OPENSEARCH_VERSION}.zip

--- a/harness/run.sh
+++ b/harness/run.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Local end-to-end verification harness for the octo message-search pipeline.
+#
+#   Kafka octo.message.v1 -> es-indexer consumer -> OpenSearch (analysis-ik)
+#
+# Brings up Kafka + OpenSearch(IK), runs the es-indexer against them, seeds a
+# controlled message suite, and asserts the C2/C4 + idempotency + IK-tokenization
+# invariants. Throwaway local stack ONLY — never wired into a shared environment.
+#
+# Usage:
+#   ./harness/run.sh            # full run: up -> indexer -> seed -> verify -> down
+#   ./harness/run.sh up         # just bring the stack up
+#   ./harness/run.sh down       # tear the stack down (+volumes)
+#   KEEP_UP=1 ./harness/run.sh  # leave the stack running after verify
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+cd "$HERE"
+
+KAFKA_EXTERNAL="${KAFKA_EXTERNAL:-localhost:19092}"
+ES_URL="${ES_URL:-http://localhost:19200}"
+ES_INDEX="${ES_INDEX:-octo-message}"
+
+compose() { docker compose "$@"; }
+
+up() {
+  echo "[harness] building + starting Kafka + OpenSearch(IK)..."
+  compose up -d --build
+  echo "[harness] waiting for OpenSearch..."
+  for i in $(seq 1 60); do
+    if curl -fs "$ES_URL/_cluster/health" >/dev/null 2>&1; then break; fi
+    sleep 3
+  done
+  curl -fs "$ES_URL/_cluster/health?wait_for_status=yellow&timeout=60s" >/dev/null
+  echo "[harness] waiting for Kafka..."
+  for i in $(seq 1 60); do
+    if docker exec octo-harness-kafka /opt/kafka/bin/kafka-broker-api-versions.sh \
+        --bootstrap-server localhost:9092 >/dev/null 2>&1; then break; fi
+    sleep 3
+  done
+  create_topics
+  echo "[harness] stack up."
+}
+
+# create_topics pre-creates the body + DLQ topics. The DLQ topic MUST be
+# pre-created because the indexer's DLQ producer runs with
+# AllowAutoTopicCreation=false (a deployment-safety choice from phase 4 rework:
+# a mistyped topic name should fail loudly, not silently create a wrong topic).
+# In production these topics are provisioned by the platform; here we mirror that.
+create_topics() {
+  echo "[harness] pre-creating topics (body + DLQ)..."
+  for t in octo.message.v1 octo.message.v1.dlq; do
+    docker exec octo-harness-kafka /opt/kafka/bin/kafka-topics.sh \
+      --bootstrap-server localhost:9092 --create --if-not-exists \
+      --topic "$t" --partitions 1 --replication-factor 1 >/dev/null 2>&1 || true
+  done
+}
+
+down() {
+  echo "[harness] tearing down..."
+  compose down -v --remove-orphans || true
+}
+
+run_indexer() {
+  echo "[harness] starting es-indexer (background)..."
+  ( cd "$ROOT" && \
+    ES_INDEXER_ENABLED=true \
+    KAFKA_BROKERS="$KAFKA_EXTERNAL" \
+    KAFKA_TOPIC=octo.message.v1 \
+    KAFKA_DLQ_TOPIC=octo.message.v1.dlq \
+    KAFKA_GROUP_ID=octo-search-indexer-harness \
+    ES_ADDRESSES="$ES_URL" \
+    ES_INDEX="$ES_INDEX" \
+    INDEXER_DLQ_SPILL_DIR=/tmp/octo-indexer-spill \
+    go run ./cmd/es-indexer >/tmp/octo-indexer.log 2>&1 ) &
+  INDEXER_PID=$!
+  echo "$INDEXER_PID" > /tmp/octo-indexer.pid
+  echo "[harness] es-indexer pid=$INDEXER_PID (logs: /tmp/octo-indexer.log)"
+  sleep 5
+}
+
+stop_indexer() {
+  if [[ -f /tmp/octo-indexer.pid ]]; then
+    kill "$(cat /tmp/octo-indexer.pid)" 2>/dev/null || true
+    rm -f /tmp/octo-indexer.pid
+  fi
+}
+
+seed() {
+  echo "[harness] seeding controlled message suite..."
+  ( cd "$ROOT" && KAFKA_BROKERS="$KAFKA_EXTERNAL" go run ./harness/seed -mode suite )
+}
+
+verify() {
+  echo "[harness] verifying invariants..."
+  ( cd "$ROOT" && ES_URL="$ES_URL" ES_INDEX="$ES_INDEX" go run ./harness/verify )
+}
+
+case "${1:-all}" in
+  up) up ;;
+  down) down ;;
+  seed) seed ;;
+  verify) verify ;;
+  all)
+    up
+    run_indexer
+    trap 'stop_indexer' EXIT
+    seed
+    verify
+    stop_indexer
+    if [[ "${KEEP_UP:-0}" != "1" ]]; then down; fi
+    echo "[harness] e2e run complete."
+    ;;
+  *) echo "usage: $0 {all|up|down|seed|verify}"; exit 1 ;;
+esac

--- a/harness/run.sh
+++ b/harness/run.sh
@@ -51,10 +51,32 @@ up() {
 create_topics() {
   echo "[harness] pre-creating topics (body + DLQ)..."
   for t in octo.message.v1 octo.message.v1.dlq; do
-    docker exec octo-harness-kafka /opt/kafka/bin/kafka-topics.sh \
+    local out rc
+    # Capture rc safely under `set -e`: a bare `out="$(cmd)"` would exit the
+    # script on non-zero before we can inspect rc, so use an if-guard.
+    if out="$(docker exec octo-harness-kafka /opt/kafka/bin/kafka-topics.sh \
       --bootstrap-server localhost:9092 --create --if-not-exists \
-      --topic "$t" --partitions 1 --replication-factor 1 >/dev/null 2>&1 || true
+      --topic "$t" --partitions 1 --replication-factor 1 2>&1)"; then
+      rc=0
+    else
+      rc=$?
+    fi
+    # --if-not-exists makes an existing topic a no-op; tolerate only that.
+    # Any other non-zero (broker down, auth, bad config) must fail loudly.
+    if [[ $rc -ne 0 ]] && ! grep -qiE "already exists" <<<"$out"; then
+      echo "[harness] FATAL: creating topic $t failed: $out" >&2
+      exit 1
+    fi
   done
+}
+
+# dlq_end_offset prints the current DLQ topic log-end offset (sum across
+# partitions). Used to fence the verifier so it only inspects DLQ records
+# produced by THIS run (guards against stale records on a kept-up stack).
+dlq_end_offset() {
+  docker exec octo-harness-kafka /opt/kafka/bin/kafka-get-offsets.sh \
+    --bootstrap-server localhost:9092 --topic octo.message.v1.dlq 2>/dev/null \
+    | awk -F: '{s+=$3} END{print s+0}'
 }
 
 down() {
@@ -88,13 +110,29 @@ stop_indexer() {
 }
 
 seed() {
+  # Fence the DLQ verification to records produced by THIS run: capture the DLQ
+  # log-end offset BEFORE seeding so the verifier ignores stale records from a
+  # prior kept-up/failed run.
+  DLQ_START_OFFSET="$(dlq_end_offset)"
+  export DLQ_START_OFFSET
+  echo "[harness] DLQ fence start offset = ${DLQ_START_OFFSET}"
   echo "[harness] seeding controlled message suite..."
   ( cd "$ROOT" && KAFKA_BROKERS="$KAFKA_EXTERNAL" go run ./harness/seed -mode suite )
 }
 
 verify() {
   echo "[harness] verifying invariants..."
-  ( cd "$ROOT" && ES_URL="$ES_URL" ES_INDEX="$ES_INDEX" go run ./harness/verify )
+  # If the fence wasn't captured (e.g. standalone `run.sh verify`), pass -1 so the
+  # verifier engages its fail-closed default (abort on a non-empty DLQ) rather than
+  # silently scanning from offset 0 and risking a stale-record false PASS.
+  ( cd "$ROOT" && \
+    ES_URL="$ES_URL" ES_INDEX="$ES_INDEX" \
+    KAFKA_BROKERS="$KAFKA_EXTERNAL" \
+    KAFKA_TOPIC=octo.message.v1 \
+    KAFKA_DLQ_TOPIC=octo.message.v1.dlq \
+    KAFKA_GROUP_ID=octo-search-indexer-harness \
+    DLQ_START_OFFSET="${DLQ_START_OFFSET:--1}" \
+    go run ./harness/verify )
 }
 
 case "${1:-all}" in

--- a/harness/seed/main.go
+++ b/harness/seed/main.go
@@ -1,0 +1,142 @@
+// Command seed 向 Kafka topic 直灌符合 searchmsg 契约的受控测试消息，用于本地端到端 harness
+// 验证（Kafka → es-indexer → OpenSearch）。覆盖：正常文本 / 中文 / raw_excluded(Signal/非文本) /
+// 重复 message_id(幂等) / 未知 schema_version(→DLQ) 等用例。
+//
+// 隔离纪律：仅连本地 harness 的 Kafka（KAFKA_BROKERS，默认 localhost:9092）。绝不指向共享环境。
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+	"github.com/segmentio/kafka-go"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+	var (
+		brokers = flag.String("brokers", envOr("KAFKA_BROKERS", "localhost:9092"), "kafka brokers (csv)")
+		topic   = flag.String("topic", envOr("KAFKA_TOPIC", "octo.message.v1"), "body topic")
+		mode    = flag.String("mode", "suite", "suite|bulk")
+		n       = flag.Int("n", 1000, "bulk mode: number of valid messages to produce")
+		base    = flag.Int64("base-ts", time.Now().Unix(), "base created_at epoch seconds")
+	)
+	flag.Parse()
+
+	w := &kafka.Writer{
+		Addr:                   kafka.TCP(splitCSV(*brokers)...),
+		Topic:                  *topic,
+		Balancer:               &kafka.Hash{},
+		RequiredAcks:           kafka.RequireAll,
+		Async:                  false,
+		AllowAutoTopicCreation: true,
+	}
+	defer func() {
+		if cerr := w.Close(); cerr != nil {
+			log.Printf("warn: close writer: %v", cerr)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	var msgs []kafka.Message
+	switch *mode {
+	case "suite":
+		msgs = suite(*base)
+	case "bulk":
+		msgs = bulk(*n, *base)
+	default:
+		log.Fatalf("unknown mode %q", *mode)
+	}
+
+	if err := w.WriteMessages(ctx, msgs...); err != nil {
+		log.Fatalf("produce: %v", err)
+	}
+	log.Printf("seeded %d messages to %s (mode=%s)", len(msgs), *topic, *mode)
+}
+
+// suite 产出覆盖各用例的固定样本集（供不变式验证）。
+func suite(base int64) []kafka.Message {
+	var out []kafka.Message
+	text := func(id, content string) kafka.Message {
+		c := content
+		return contractMsg(searchmsg.Message{
+			SchemaVersion: searchmsg.SchemaVersion, MessageID: id, ChannelID: "g_1", ChannelType: 2,
+			FromUID: "u_1", Content: &c, ContentType: 1, MsgTimestamp: base, CreatedAt: base,
+			Source: searchmsg.SourceETLMessageTable,
+		})
+	}
+	// 正常英文 + 中文（验证 IK 分词召回）。
+	out = append(out, text("m-en-1", "hello world search pipeline"))
+	out = append(out, text("m-zh-1", "今天天气很好我们去公园散步吧"))
+	out = append(out, text("m-zh-2", "搜索引擎中文分词测试：北京欢迎你"))
+	// 重复 message_id（幂等：写两次，ES 只应有一条 doc）。
+	out = append(out, text("m-dup", "first copy"))
+	out = append(out, text("m-dup", "second copy overwrites same _id"))
+	// raw_excluded（Signal 加密 / 非文本）：content=null，仍写入 ES 占一个 doc。
+	out = append(out, contractMsg(searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion, MessageID: "m-signal", ChannelID: "u1@u2", ChannelType: 1,
+		FromUID: "u1", Content: nil, RawExcluded: true, MsgTimestamp: base, CreatedAt: base,
+		Source: searchmsg.SourceETLMessageTable,
+	}))
+	// 未知 schema_version → consumer 应判毒丸进 DLQ，不写 ES。
+	out = append(out, rawMsg("m-badschema", fmt.Sprintf(
+		`{"schema_version":999,"message_id":"m-badschema","channel_id":"g_1","channel_type":2,"created_at":%d}`, base)))
+	// 非法 JSON → 真异常进 DLQ。
+	out = append(out, kafka.Message{Key: []byte("m-badjson"), Value: []byte("{not valid json")})
+	return out
+}
+
+// bulk 产出 n 条合法消息（吞吐调参用），message_id 唯一、含中文正文。
+func bulk(n int, base int64) []kafka.Message {
+	out := make([]kafka.Message, 0, n)
+	for i := 0; i < n; i++ {
+		c := fmt.Sprintf("消息正文 message body number %d 测试中文分词与吞吐", i)
+		out = append(out, contractMsg(searchmsg.Message{
+			SchemaVersion: searchmsg.SchemaVersion,
+			MessageID:     fmt.Sprintf("bulk-%08d", i),
+			ChannelID:     "g_bulk", ChannelType: 2, FromUID: "u_bulk",
+			Content: &c, ContentType: 1, MsgTimestamp: base, CreatedAt: base + int64(i%3600),
+			Source: searchmsg.SourceETLMessageTable,
+		}))
+	}
+	return out
+}
+
+func contractMsg(m searchmsg.Message) kafka.Message {
+	b, err := json.Marshal(m)
+	if err != nil {
+		log.Fatalf("marshal: %v", err)
+	}
+	return kafka.Message{Key: []byte(m.MessageID), Value: b}
+}
+
+func rawMsg(id, payload string) kafka.Message {
+	return kafka.Message{Key: []byte(id), Value: []byte(payload)}
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/harness/verify/kafka.go
+++ b/harness/verify/kafka.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+)
+
+// kafkaVerifier inspects Kafka state to prove (a) the consumer group has drained
+// the body topic (committed offset == log-end offset on every partition) and
+// (b) the DLQ topic positively contains the expected poison-pill keys.
+type kafkaVerifier struct {
+	brokers []string
+	client  *kafka.Client
+}
+
+func newKafkaVerifier(brokers []string) *kafkaVerifier {
+	return &kafkaVerifier{
+		brokers: brokers,
+		client:  &kafka.Client{Addr: kafka.TCP(brokers...), Timeout: 10 * time.Second},
+	}
+}
+
+// expectGroupDrained asserts that, for every partition of `topic`, the consumer
+// `group`'s committed offset has caught up to the partition log-end offset.
+//
+// This is the authoritative drain proof (replaces "ES doc count is stable"):
+// it cannot be fooled by a consumer that stalled BEFORE the poison pills, nor by
+// the DLQ-spill path — both leave a committed offset short of the log end.
+//
+// Polls until drained or timeout (the indexer commits asynchronously after each
+// processed batch, so a short settle is expected).
+func (k *kafkaVerifier) expectGroupDrained(ctx context.Context, topic, group string, timeout time.Duration) error {
+	parts, err := lookupPartitions(ctx, k.brokers, topic)
+	if err != nil {
+		return fmt.Errorf("lookup partitions: %w", err)
+	}
+	if len(parts) == 0 {
+		return fmt.Errorf("topic %q has no partitions", topic)
+	}
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		logEnd, err := k.logEndOffsets(ctx, topic, parts)
+		if err != nil {
+			lastErr = err
+		} else {
+			committed, cerr := k.committedOffsets(ctx, topic, group, parts)
+			if cerr != nil {
+				lastErr = cerr
+			} else if drained, why := allCaughtUp(logEnd, committed); drained {
+				return nil
+			} else {
+				lastErr = fmt.Errorf("not drained: %s", why)
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("group %q not drained on %q within %s: %v", group, topic, timeout, lastErr)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// allCaughtUp reports whether every partition's committed offset >= its log-end
+// offset. committed offset == log-end means "all messages up to the end have been
+// committed" (kafka committed offset is the NEXT offset to read).
+func allCaughtUp(logEnd, committed map[int]int64) (bool, string) {
+	for p, end := range logEnd {
+		c, ok := committed[p]
+		if !ok {
+			return false, fmt.Sprintf("partition %d has no committed offset yet", p)
+		}
+		if c < end {
+			return false, fmt.Sprintf("partition %d committed=%d < logEnd=%d", p, c, end)
+		}
+	}
+	return true, ""
+}
+
+// logEndOffsets returns the last offset (== count of produced messages) per partition.
+func (k *kafkaVerifier) logEndOffsets(ctx context.Context, topic string, parts []int) (map[int]int64, error) {
+	reqTopics := make([]kafka.OffsetRequest, 0, len(parts))
+	for _, p := range parts {
+		reqTopics = append(reqTopics, kafka.LastOffsetOf(p))
+	}
+	resp, err := k.client.ListOffsets(ctx, &kafka.ListOffsetsRequest{
+		Addr:   kafka.TCP(k.brokers...),
+		Topics: map[string][]kafka.OffsetRequest{topic: reqTopics},
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int]int64)
+	for _, po := range resp.Topics[topic] {
+		if po.Error != nil {
+			return nil, fmt.Errorf("partition %d list-offset: %w", po.Partition, po.Error)
+		}
+		out[po.Partition] = po.LastOffset
+	}
+	return out, nil
+}
+
+// committedOffsets returns the consumer group's committed offset per partition.
+func (k *kafkaVerifier) committedOffsets(ctx context.Context, topic, group string, parts []int) (map[int]int64, error) {
+	resp, err := k.client.OffsetFetch(ctx, &kafka.OffsetFetchRequest{
+		Addr:    kafka.TCP(k.brokers...),
+		GroupID: group,
+		Topics:  map[string][]int{topic: parts},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+	out := make(map[int]int64)
+	for _, p := range resp.Topics[topic] {
+		if p.Error != nil {
+			return nil, fmt.Errorf("partition %d offset-fetch: %w", p.Partition, p.Error)
+		}
+		// CommittedOffset == -1 means "no commit yet"; leave it absent so allCaughtUp fails.
+		if p.CommittedOffset >= 0 {
+			out[p.Partition] = p.CommittedOffset
+		}
+	}
+	return out, nil
+}
+
+// expectDLQKeys reads the DLQ topic and asserts each expected key is present
+// among records produced by THIS run (positive verification of C4 DLQ routing).
+//
+// startOffset fences out stale records from a previous (kept-up / failed) harness
+// run: only records at offset >= startOffset are considered. Pass the DLQ log-end
+// offset captured BEFORE seeding. Reads partition-by-partition up to each
+// partition's current log-end, so it terminates deterministically.
+func (k *kafkaVerifier) expectDLQKeys(ctx context.Context, topic string, wantKeys []string, startOffset int64, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		found, err := k.collectKeys(ctx, topic, startOffset)
+		if err == nil {
+			missing := missingKeys(wantKeys, found)
+			if len(missing) == 0 {
+				return nil
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("DLQ %q missing expected keys %v at/after offset %d (found %v)", topic, missing, startOffset, keysOf(found))
+			}
+		} else if time.Now().After(deadline) {
+			return fmt.Errorf("DLQ %q read failed: %w", topic, err)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// collectKeys reads records in [startOffset, log-end) across all partitions and
+// returns the set of message keys seen. startOffset is a per-partition floor —
+// in the single-partition harness it is the pre-seed log-end; on multi-partition
+// topics it is applied as a conservative floor to every partition.
+func (k *kafkaVerifier) collectKeys(ctx context.Context, topic string, startOffset int64) (map[string]struct{}, error) {
+	parts, err := lookupPartitions(ctx, k.brokers, topic)
+	if err != nil {
+		return nil, err
+	}
+	logEnd, err := k.logEndOffsets(ctx, topic, parts)
+	if err != nil {
+		return nil, err
+	}
+	found := make(map[string]struct{})
+	for _, p := range parts {
+		end := logEnd[p]
+		if end <= startOffset {
+			continue // nothing new in this partition since startOffset
+		}
+		if err := k.readPartitionKeys(ctx, topic, p, startOffset, end, found); err != nil {
+			return nil, err
+		}
+	}
+	return found, nil
+}
+
+// readPartitionKeys reads partition p from startOffset until reaching `end`,
+// recording the keys of records at offset >= startOffset.
+func (k *kafkaVerifier) readPartitionKeys(ctx context.Context, topic string, p int, startOffset, end int64, found map[string]struct{}) error {
+	r := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:   k.brokers,
+		Topic:     topic,
+		Partition: p,
+		MinBytes:  1,
+		MaxBytes:  10 << 20,
+	})
+	defer func() {
+		if cerr := r.Close(); cerr != nil {
+			// best-effort; not fatal to verification
+			_ = cerr
+		}
+	}()
+	begin := startOffset
+	if begin < 0 {
+		begin = kafka.FirstOffset
+	}
+	if err := r.SetOffset(begin); err != nil {
+		return err
+	}
+	readCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	for {
+		m, err := r.ReadMessage(readCtx)
+		if err != nil {
+			return err
+		}
+		if m.Offset >= startOffset {
+			found[string(m.Key)] = struct{}{}
+		}
+		if m.Offset >= end-1 {
+			return nil // reached log-end of this partition
+		}
+	}
+}
+
+func missingKeys(want []string, found map[string]struct{}) []string {
+	var missing []string
+	for _, k := range want {
+		if _, ok := found[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	return missing
+}
+
+func keysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// lookupPartitions returns the partition IDs of a topic.
+func lookupPartitions(ctx context.Context, brokers []string, topic string) ([]int, error) {
+	parts, err := kafka.LookupPartitions(ctx, "tcp", brokers[0], topic)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int, 0, len(parts))
+	for _, p := range parts {
+		ids = append(ids, p.ID)
+	}
+	return ids, nil
+}
+
+// topicEndOffset returns the sum of log-end offsets across all partitions of a
+// topic (== total records ever produced). Used to detect a non-empty DLQ when
+// resolving the fence. Only a genuinely-missing topic resolves to 0 (empty);
+// any other error (transient metadata/broker failure) propagates so the caller
+// fail-closes instead of silently treating the DLQ as empty.
+func (k *kafkaVerifier) topicEndOffset(ctx context.Context, topic string) (int64, error) {
+	parts, err := lookupPartitions(ctx, k.brokers, topic)
+	if err != nil {
+		if errors.Is(err, kafka.UnknownTopicOrPartition) {
+			return 0, nil // topic not yet created → no stale records to fence
+		}
+		return 0, err
+	}
+	if len(parts) == 0 {
+		return 0, nil
+	}
+	logEnd, err := k.logEndOffsets(ctx, topic, parts)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, end := range logEnd {
+		total += end
+	}
+	return total, nil
+}

--- a/harness/verify/main.go
+++ b/harness/verify/main.go
@@ -1,0 +1,244 @@
+// Command verify drives end-to-end invariant checks against the local harness
+// (Kafka + OpenSearch). It assumes the stack is up, the es-indexer is consuming,
+// and the seed suite has been produced. It then asserts the C2/C4 + idempotency
+// + IK-tokenization invariants by querying OpenSearch directly.
+//
+// ISOLATION: points only at the local harness endpoints (env ES / KAFKA_BROKERS).
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+	var (
+		esURL   = flag.String("es", envOr("ES_URL", "http://localhost:19200"), "OpenSearch base URL")
+		index   = flag.String("index", envOr("ES_INDEX", "octo-message"), "index name")
+		waitFor = flag.Duration("wait", 60*time.Second, "max wait for docs to appear")
+	)
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), *waitFor+30*time.Second)
+	defer cancel()
+
+	v := &verifier{es: strings.TrimRight(*esURL, "/"), index: *index, hc: &http.Client{Timeout: 10 * time.Second}}
+
+	// Refresh so seeded docs are searchable.
+	if err := v.refresh(ctx); err != nil {
+		log.Fatalf("refresh: %v", err)
+	}
+
+	var failures []string
+	check := func(name string, err error) {
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", name, err))
+			log.Printf("FAIL %s: %v", name, err)
+		} else {
+			log.Printf("PASS %s", name)
+		}
+	}
+
+	// Positives first: these poll until present, proving the consumer has made
+	// progress through the suite.
+	// Invariant: idempotency — duplicate message_id => exactly one doc.
+	check("idempotent-dup", v.expectDocExists(ctx, "m-dup"))
+	check("idempotent-count", v.expectCount(ctx, term("message_id", "m-dup"), 1))
+
+	// Invariant: raw_excluded doc IS indexed (content null), occupies a doc.
+	check("raw-excluded-indexed", v.expectDocExists(ctx, "m-signal"))
+
+	// Invariant: IK tokenization — Chinese query term recalls the doc.
+	check("ik-recall-公园", v.expectMatchAtLeast(ctx, "content", "公园", 1))
+	check("ik-recall-北京", v.expectMatchAtLeast(ctx, "content", "北京", 1))
+	// English still works.
+	check("en-recall-pipeline", v.expectMatchAtLeast(ctx, "content", "pipeline", 1))
+
+	// Before negative assertions, the consumer MUST be proven drained: wait for the
+	// index doc count to be unchanged for a quiet period. If drain can't be proven
+	// (count never settles / _count errors), the "not indexed" assertions are
+	// inconclusive — we record a FAILURE rather than continuing, so a poison pill
+	// that would be indexed slightly later can never yield a false PASS.
+	drainErr := v.waitDocCountStable(ctx, 8*time.Second, 40*time.Second)
+	check("consumer-drained", drainErr)
+	if drainErr == nil {
+		// Invariant: schema_version unknown + bad JSON => NOT in ES (routed to DLQ).
+		check("badschema-not-indexed", v.expectCount(ctx, term("message_id", "m-badschema"), 0))
+		check("badjson-not-indexed", v.expectCount(ctx, term("message_id", "m-badjson"), 0))
+	} else {
+		// Drain unproven → do not assert "not indexed" (would be inconclusive).
+		failures = append(failures, "badschema/badjson: skipped — consumer drain not proven")
+		log.Printf("FAIL badschema/badjson: skipped — consumer drain not proven (%v)", drainErr)
+	}
+
+	if len(failures) > 0 {
+		log.Fatalf("e2e verify FAILED (%d): %s", len(failures), strings.Join(failures, "; "))
+	}
+	log.Printf("e2e verify PASSED — all invariants hold")
+}
+
+type verifier struct {
+	es    string
+	index string
+	hc    *http.Client
+}
+
+func (v *verifier) refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.es+"/"+v.index+"/_refresh", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := v.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("refresh status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// closeBody drains+closes a response body (errcheck-friendly helper).
+func closeBody(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		log.Printf("warn: close body: %v", cerr)
+	}
+}
+
+// expectDocExists polls GET /<index>/_doc/<id> until found or timeout.
+func (v *verifier) expectDocExists(ctx context.Context, id string) error {
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		if rerr := v.refresh(ctx); rerr != nil {
+			log.Printf("warn: refresh: %v", rerr)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.es+"/"+v.index+"/_doc/"+id, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := v.hc.Do(req)
+		if err == nil {
+			code := resp.StatusCode
+			closeBody(resp)
+			if code == http.StatusOK {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("doc %q not found before deadline", id)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (v *verifier) expectCount(ctx context.Context, query map[string]any, want int) error {
+	got, err := v.count(ctx, query)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("count=%d want=%d", got, want)
+	}
+	return nil
+}
+
+func (v *verifier) expectMatchAtLeast(ctx context.Context, field, q string, atLeast int) error {
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		if rerr := v.refresh(ctx); rerr != nil {
+			log.Printf("warn: refresh: %v", rerr)
+		}
+		got, err := v.count(ctx, match(field, q))
+		if err == nil && got >= atLeast {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("match %q on %s returned %d (<%d)", q, field, got, atLeast)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (v *verifier) count(ctx context.Context, query map[string]any) (int, error) {
+	body, err := json.Marshal(map[string]any{"query": query})
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.es+"/"+v.index+"/_count", bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := v.hc.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer closeBody(resp)
+	if resp.StatusCode >= 300 {
+		return 0, fmt.Errorf("_count status %d", resp.StatusCode)
+	}
+	var out struct {
+		Count int `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, err
+	}
+	return out.Count, nil
+}
+
+// waitDocCountStable polls the total index doc count until it is unchanged for
+// `quiet`, or `maxWait` elapses. Used to ensure the consumer has drained before
+// asserting that poison-pill docs are NOT indexed (avoids a too-early false PASS).
+func (v *verifier) waitDocCountStable(ctx context.Context, quiet, maxWait time.Duration) error {
+	deadline := time.Now().Add(maxWait)
+	matchAll := map[string]any{"match_all": map[string]any{}}
+	last := -1
+	stableSince := time.Now()
+	for {
+		if rerr := v.refresh(ctx); rerr != nil {
+			log.Printf("warn: refresh: %v", rerr)
+		}
+		n, err := v.count(ctx, matchAll)
+		if err != nil {
+			return err
+		}
+		if n != last {
+			last = n
+			stableSince = time.Now()
+		} else if time.Since(stableSince) >= quiet {
+			return nil // count held steady for the quiet period
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("doc count not stable within %s (last=%d)", maxWait, last)
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func term(field, val string) map[string]any {
+	return map[string]any{"term": map[string]any{field: val}}
+}
+
+func match(field, q string) map[string]any {
+	return map[string]any{"match": map[string]any{field: q}}
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/harness/verify/main.go
+++ b/harness/verify/main.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -22,16 +23,43 @@ import (
 func main() {
 	log.SetFlags(log.LstdFlags | log.LUTC)
 	var (
-		esURL   = flag.String("es", envOr("ES_URL", "http://localhost:19200"), "OpenSearch base URL")
-		index   = flag.String("index", envOr("ES_INDEX", "octo-message"), "index name")
-		waitFor = flag.Duration("wait", 60*time.Second, "max wait for docs to appear")
+		esURL    = flag.String("es", envOr("ES_URL", "http://localhost:19200"), "OpenSearch base URL")
+		index    = flag.String("index", envOr("ES_INDEX", "octo-message"), "index name")
+		brokers  = flag.String("brokers", envOr("KAFKA_BROKERS", "localhost:19092"), "kafka brokers (csv)")
+		topic    = flag.String("topic", envOr("KAFKA_TOPIC", "octo.message.v1"), "body topic")
+		dlqTopic = flag.String("dlq", envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.dlq"), "DLQ topic")
+		group    = flag.String("group", envOr("KAFKA_GROUP_ID", "octo-search-indexer-harness"), "consumer group id")
+		dlqStart = flag.Int64("dlq-start-offset", envInt64("DLQ_START_OFFSET", -1), "only consider DLQ records at/after this offset (fence stale records from prior runs); -1 = not provided")
+		waitFor  = flag.Duration("wait", 60*time.Second, "max wait for docs to appear")
 	)
 	flag.Parse()
 
-	ctx, cancel := context.WithTimeout(context.Background(), *waitFor+30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), *waitFor+120*time.Second)
 	defer cancel()
 
 	v := &verifier{es: strings.TrimRight(*esURL, "/"), index: *index, hc: &http.Client{Timeout: 10 * time.Second}}
+	kv := newKafkaVerifier(splitCSV(*brokers))
+
+	// 🔴 DLQ fence resolution (fail-closed). The dlq-contains-poison check must only
+	// inspect records from THIS run, otherwise stale poison-pill records from a prior
+	// kept-up/failed run could yield a false PASS. If no fence was provided
+	// (-dlq-start-offset / DLQ_START_OFFSET unset) we resolve it safely:
+	//   - DLQ currently EMPTY  → fence 0 (clean start; nothing stale to confuse us).
+	//   - DLQ currently NON-EMPTY → FAIL: refuse to run an ambiguous check. The caller
+	//     must capture the DLQ end offset BEFORE seeding and pass it (run.sh does this).
+	fence := *dlqStart
+	if fence < 0 {
+		existing, err := kv.topicEndOffset(ctx, *dlqTopic)
+		if err != nil {
+			log.Fatalf("dlq fence: cannot read DLQ %q end offset: %v", *dlqTopic, err)
+		}
+		if existing > 0 {
+			log.Fatalf("dlq fence: DLQ %q already has %d record(s) and no -dlq-start-offset given; "+
+				"capture the DLQ end offset BEFORE seeding and pass it (run.sh does this automatically). "+
+				"Refusing to run dlq-contains-poison against possibly-stale records.", *dlqTopic, existing)
+		}
+		fence = 0
+	}
 
 	// Refresh so seeded docs are searchable.
 	if err := v.refresh(ctx); err != nil {
@@ -48,8 +76,15 @@ func main() {
 		}
 	}
 
-	// Positives first: these poll until present, proving the consumer has made
-	// progress through the suite.
+	// 🔴 Authoritative drain proof via KAFKA (not ES doc-count): the consumer group's
+	// committed offset must reach the body topic's log-end on every partition. This
+	// proves the poison pills were actually consumed (and committed past), so the
+	// "not indexed" assertions below are sound — and it cannot be fooled by a
+	// consumer that stalled before the pills or by the DLQ-spill path.
+	drainErr := kv.expectGroupDrained(ctx, *topic, *group, 90*time.Second)
+	check("consumer-group-drained", drainErr)
+
+	// Positives: these poll until present, confirming healthy indexing.
 	// Invariant: idempotency — duplicate message_id => exactly one doc.
 	check("idempotent-dup", v.expectDocExists(ctx, "m-dup"))
 	check("idempotent-count", v.expectCount(ctx, term("message_id", "m-dup"), 1))
@@ -63,19 +98,15 @@ func main() {
 	// English still works.
 	check("en-recall-pipeline", v.expectMatchAtLeast(ctx, "content", "pipeline", 1))
 
-	// Before negative assertions, the consumer MUST be proven drained: wait for the
-	// index doc count to be unchanged for a quiet period. If drain can't be proven
-	// (count never settles / _count errors), the "not indexed" assertions are
-	// inconclusive — we record a FAILURE rather than continuing, so a poison pill
-	// that would be indexed slightly later can never yield a false PASS.
-	drainErr := v.waitDocCountStable(ctx, 8*time.Second, 40*time.Second)
-	check("consumer-drained", drainErr)
+	// 🔴 C4 schema gate — verify BOTH directions:
+	//  (1) positive: the DLQ topic actually CONTAINS the poison-pill keys (routing happened);
+	//  (2) negative: those messages are NOT in the ES body index.
+	// The negative assertions only stand once the group is proven drained.
+	check("dlq-contains-poison", kv.expectDLQKeys(ctx, *dlqTopic, []string{"m-badschema", "m-badjson"}, fence, 60*time.Second))
 	if drainErr == nil {
-		// Invariant: schema_version unknown + bad JSON => NOT in ES (routed to DLQ).
 		check("badschema-not-indexed", v.expectCount(ctx, term("message_id", "m-badschema"), 0))
 		check("badjson-not-indexed", v.expectCount(ctx, term("message_id", "m-badjson"), 0))
 	} else {
-		// Drain unproven → do not assert "not indexed" (would be inconclusive).
 		failures = append(failures, "badschema/badjson: skipped — consumer drain not proven")
 		log.Printf("FAIL badschema/badjson: skipped — consumer drain not proven (%v)", drainErr)
 	}
@@ -199,35 +230,6 @@ func (v *verifier) count(ctx context.Context, query map[string]any) (int, error)
 	return out.Count, nil
 }
 
-// waitDocCountStable polls the total index doc count until it is unchanged for
-// `quiet`, or `maxWait` elapses. Used to ensure the consumer has drained before
-// asserting that poison-pill docs are NOT indexed (avoids a too-early false PASS).
-func (v *verifier) waitDocCountStable(ctx context.Context, quiet, maxWait time.Duration) error {
-	deadline := time.Now().Add(maxWait)
-	matchAll := map[string]any{"match_all": map[string]any{}}
-	last := -1
-	stableSince := time.Now()
-	for {
-		if rerr := v.refresh(ctx); rerr != nil {
-			log.Printf("warn: refresh: %v", rerr)
-		}
-		n, err := v.count(ctx, matchAll)
-		if err != nil {
-			return err
-		}
-		if n != last {
-			last = n
-			stableSince = time.Now()
-		} else if time.Since(stableSince) >= quiet {
-			return nil // count held steady for the quiet period
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("doc count not stable within %s (last=%d)", maxWait, last)
-		}
-		time.Sleep(1 * time.Second)
-	}
-}
-
 func term(field, val string) map[string]any {
 	return map[string]any{"term": map[string]any{field: val}}
 }
@@ -241,4 +243,24 @@ func envOr(k, def string) string {
 		return v
 	}
 	return def
+}
+
+func envInt64(k string, def int64) int64 {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/internal/esindex/mapping/README.md
+++ b/internal/esindex/mapping/README.md
@@ -9,6 +9,26 @@ It is the single source the **octo-deployment** coordinated change references:
 provisioning/managed-OpenSearch templates must stay in lockstep with this file
 at the same contract version (`searchmsg.SchemaVersion`).
 
+## Chinese tokenization — IK (analysis-ik)
+
+`content` uses the IK plugin's dual-analyzer setup:
+
+- index-time `analyzer: ik_max_word` — exhaustive segmentation, maximises recall
+  (IM search is a "rather over-recall than miss" scenario).
+- query-time `search_analyzer: ik_smart` — smart segmentation, keeps precision.
+
+IK is chosen over the built-in `smartcn` because IK's dictionary segmentation is
+markedly better on IM colloquialisms, CN/EN/digit mixes and net-slang, and it
+supports hot-reloadable custom dictionaries (product names, @nicknames, in-group
+jargon). The IK plugin + dictionaries are provisioned by the **octo-deployment**
+change; the local verification harness (`harness/`) installs the IK plugin into
+its OpenSearch container so the mapping is exercised for real.
+
+> Requires the `analysis-ik` plugin on the OpenSearch cluster. If a deployment
+> must run without IK, override `content.analyzer`/`search_analyzer` in the
+> octo-deployment template (e.g. to a `cjk_bigram`-based custom analyzer) — that
+> selection is owned by the deployment change, not pinned here.
+
 ## Field rationale (route 甲: body + query-side authz visibility only)
 
 | Field            | Type                | Why                                                        |
@@ -17,22 +37,14 @@ at the same contract version (`searchmsg.SchemaVersion`).
 | `channel_id`     | `keyword`           | query-side authz filter (group/topic/DM resolution)       |
 | `channel_type`   | `integer`           | authz routing per channel type                            |
 | `from_uid`       | `keyword`           | sender filter / authz                                     |
-| `content`        | `text` + analyzer   | the searchable body — Chinese tokenization                |
+| `content`        | `text` + IK         | the searchable body — Chinese tokenization                |
 | `content_type`   | `integer`           | message type                                              |
 | `raw_excluded`   | `boolean`           | Signal/non-text marker (content null)                     |
 | `msg_timestamp`  | `long`              | send time (epoch s)                                       |
-| `created_at`     | `long`              | landed time (epoch s)                                     |
+| `created_at`     | `long`              | landed time (epoch s) — reconciliation window field       |
 | `source`         | `keyword`           | provenance (ETL vs future CDC)                            |
 | `schema_version` | `integer`           | contract version stamped on every doc                     |
 
 No `revoked` / `deleted` fields — route 甲 filters those at read time via MySQL
 join. Mapping is `dynamic: strict` so any unexpected field fails loudly rather
 than silently polluting the index.
-
-## Chinese tokenization
-
-Ships with a built-in `cjk_bigram`-based analyzer (`octo_cjk_text`) so the
-service has a working zero-dependency default. If the managed OpenSearch cluster
-provides a dictionary tokenizer plugin (IK / smartcn), the octo-deployment
-change can override `content.analyzer` there — that selection is owned by the
-deployment change, not pinned here.

--- a/internal/esindex/mapping/octo-message.json
+++ b/internal/esindex/mapping/octo-message.json
@@ -3,15 +3,6 @@
     "index": {
       "number_of_shards": 1,
       "number_of_replicas": 1
-    },
-    "analysis": {
-      "analyzer": {
-        "octo_cjk_text": {
-          "type": "custom",
-          "tokenizer": "standard",
-          "filter": ["lowercase", "cjk_width", "cjk_bigram"]
-        }
-      }
     }
   },
   "mappings": {
@@ -24,7 +15,8 @@
       "from_uid":       { "type": "keyword" },
       "content": {
         "type": "text",
-        "analyzer": "octo_cjk_text"
+        "analyzer": "ik_max_word",
+        "search_analyzer": "ik_smart"
       },
       "content_type":   { "type": "integer" },
       "raw_excluded":   { "type": "boolean" },

--- a/internal/esindex/writer_test.go
+++ b/internal/esindex/writer_test.go
@@ -237,7 +237,7 @@ func TestEnsureIndex_CreatesWhenMissing(t *testing.T) {
 	if !createCalled {
 		t.Fatalf("expected index create (PUT) when missing")
 	}
-	if !strings.Contains(createBody, "octo_cjk_text") || !strings.Contains(createBody, `"content"`) {
+	if !strings.Contains(createBody, "ik_max_word") || !strings.Contains(createBody, `"content"`) {
 		t.Fatalf("create body must carry embedded mapping/analyzer, got: %s", createBody)
 	}
 }

--- a/internal/recon/collectors.go
+++ b/internal/recon/collectors.go
@@ -1,0 +1,156 @@
+package recon
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// SourceCounter 给出 MySQL message 表在时间窗内的行数（按 created_at 纪元秒区间）。
+// 抽成接口便于单测与阶段 6 backfill 复用（可注入不同分表枚举/连接）。
+type SourceCounter interface {
+	// CountRows 统计 created_at ∈ [fromUnix, toUnix] 的 message 行数（跨全部分表）。
+	CountRows(ctx context.Context, fromUnix, toUnix int64) (int64, error)
+}
+
+// ESCounter 给出 OpenSearch 索引内时间窗的 doc 数。
+type ESCounter interface {
+	// CountDocs 统计 created_at ∈ [fromUnix, toUnix] 的 doc 数。
+	CountDocs(ctx context.Context, fromUnix, toUnix int64) (int64, error)
+	// CountRawExcluded 统计窗内 raw_excluded=true 的 doc 数（观测用，不影响对平算术）。
+	CountRawExcluded(ctx context.Context, fromUnix, toUnix int64) (int64, error)
+}
+
+// MySQLSourceCounter 用 database/sql 统计 message 分表行数。
+type MySQLSourceCounter struct {
+	db     *sql.DB
+	tables []string
+}
+
+// NewMySQLSourceCounter 构造。tables 为 message 分表名集合（如 message, message1..4）。
+func NewMySQLSourceCounter(db *sql.DB, tables []string) *MySQLSourceCounter {
+	return &MySQLSourceCounter{db: db, tables: tables}
+}
+
+// CountRows 跨分表累加 created_at ∈ [from,to] 行数。表名来自受控配置（非用户输入），
+// 但仍用反引号包裹并禁止注入字符；时间参数走占位符。
+func (c *MySQLSourceCounter) CountRows(ctx context.Context, fromUnix, toUnix int64) (int64, error) {
+	var total int64
+	for _, t := range c.tables {
+		if !safeTableName(t) {
+			return 0, fmt.Errorf("recon: unsafe table name %q", t)
+		}
+		// UNIX_TIMESTAMP(created_at) 与索引 created_at 字段口径一致。
+		q := fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE UNIX_TIMESTAMP(created_at) BETWEEN ? AND ?", t)
+		var n int64
+		if err := c.db.QueryRowContext(ctx, q, fromUnix, toUnix).Scan(&n); err != nil {
+			return 0, fmt.Errorf("recon: count %s: %w", t, err)
+		}
+		total += n
+	}
+	return total, nil
+}
+
+// safeTableName 仅允许字母数字下划线（防御性，表名来自配置）。
+func safeTableName(t string) bool {
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		if !isTableNameChar(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// isTableNameChar 报告 r 是否为合法表名字符（[A-Za-z0-9_]）。
+func isTableNameChar(r rune) bool {
+	switch {
+	case r == '_':
+		return true
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	default:
+		return false
+	}
+}
+
+// OSCounter 用 opensearch-go count API 统计索引 doc 数。
+type OSCounter struct {
+	client *opensearchapi.Client
+	index  string
+}
+
+// NewOSCounter 构造。
+func NewOSCounter(client *opensearchapi.Client, index string) *OSCounter {
+	return &OSCounter{client: client, index: index}
+}
+
+// CountDocs 统计 created_at ∈ [from,to] 的 doc 数（range query + _count）。
+func (c *OSCounter) CountDocs(ctx context.Context, fromUnix, toUnix int64) (int64, error) {
+	return c.count(ctx, rangeQuery(fromUnix, toUnix))
+}
+
+// CountRawExcluded 统计窗内 raw_excluded=true 的 doc 数。
+func (c *OSCounter) CountRawExcluded(ctx context.Context, fromUnix, toUnix int64) (int64, error) {
+	body := map[string]any{
+		"query": map[string]any{
+			"bool": map[string]any{
+				"filter": []any{
+					rangeFilter(fromUnix, toUnix),
+					map[string]any{"term": map[string]any{"raw_excluded": true}},
+				},
+			},
+		},
+	}
+	return c.count(ctx, body)
+}
+
+func (c *OSCounter) count(ctx context.Context, query map[string]any) (int64, error) {
+	b, err := json.Marshal(query)
+	if err != nil {
+		return 0, fmt.Errorf("recon: marshal count query: %w", err)
+	}
+	resp, err := c.client.Indices.Count(ctx, &opensearchapi.IndicesCountReq{
+		Indices: []string{c.index},
+		Body:    bytes.NewReader(b),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("recon: opensearch count: %w", err)
+	}
+	// 🔴 对账 gate 不得对「部分分片失败」的计数对平——_count 可能 HTTP 200 但 _shards.failed>0
+	// 或 successful<total，此时计数不可信，宁可报错（避免掩盖真实数据缺失，产生 false OK）。
+	if resp.Shards.Failed != 0 || resp.Shards.Successful != resp.Shards.Total {
+		return 0, fmt.Errorf("recon: opensearch count had incomplete shards (total=%d successful=%d failed=%d) — count unreliable",
+			resp.Shards.Total, resp.Shards.Successful, resp.Shards.Failed)
+	}
+	return int64(resp.Count), nil
+}
+
+// rangeQuery 构造 created_at ∈ [from,to] 的 _count 查询体。
+func rangeQuery(fromUnix, toUnix int64) map[string]any {
+	return map[string]any{
+		"query": map[string]any{
+			"bool": map[string]any{
+				"filter": []any{rangeFilter(fromUnix, toUnix)},
+			},
+		},
+	}
+}
+
+func rangeFilter(fromUnix, toUnix int64) map[string]any {
+	return map[string]any{
+		"range": map[string]any{
+			"created_at": map[string]any{"gte": fromUnix, "lte": toUnix},
+		},
+	}
+}

--- a/internal/recon/collectors_test.go
+++ b/internal/recon/collectors_test.go
@@ -1,0 +1,87 @@
+package recon
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func osCounter(t *testing.T, rt http.RoundTripper) *OSCounter {
+	t.Helper()
+	c, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{Addresses: []string{"http://os.test:9200"}, Transport: rt},
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	return NewOSCounter(c, "octo-message")
+}
+
+func resp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+// TestOSCounter_CleanCount 全分片成功 → 返回 count。
+func TestOSCounter_CleanCount(t *testing.T) {
+	c := osCounter(t, rtFunc(func(*http.Request) (*http.Response, error) {
+		return resp(200, `{"count":42,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0}}`), nil
+	}))
+	n, err := c.CountDocs(context.Background(), 0, 100)
+	if err != nil || n != 42 {
+		t.Fatalf("want 42,nil got %d,%v", n, err)
+	}
+}
+
+// TestOSCounter_PartialShardFailure 🔴 gate 安全：HTTP 200 但有分片失败 → 报错，不返回可疑计数。
+func TestOSCounter_PartialShardFailure(t *testing.T) {
+	c := osCounter(t, rtFunc(func(*http.Request) (*http.Response, error) {
+		return resp(200, `{"count":42,"_shards":{"total":5,"successful":4,"skipped":0,"failed":1}}`), nil
+	}))
+	if _, err := c.CountDocs(context.Background(), 0, 100); err == nil {
+		t.Fatalf("partial shard failure must error (count unreliable), got nil")
+	}
+}
+
+// TestOSCounter_IncompleteShards successful<total（无 failed 计数）也视为不可信。
+func TestOSCounter_IncompleteShards(t *testing.T) {
+	c := osCounter(t, rtFunc(func(*http.Request) (*http.Response, error) {
+		return resp(200, `{"count":10,"_shards":{"total":3,"successful":2,"skipped":0,"failed":0}}`), nil
+	}))
+	if _, err := c.CountDocs(context.Background(), 0, 100); err == nil {
+		t.Fatalf("incomplete shards (successful<total) must error")
+	}
+}
+
+// TestOSCounter_RawExcludedQuery raw_excluded 计数走 term filter，正常返回。
+func TestOSCounter_RawExcludedQuery(t *testing.T) {
+	var gotBody string
+	c := osCounter(t, rtFunc(func(r *http.Request) (*http.Response, error) {
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Fatalf("read body: %v", rerr)
+		}
+		gotBody = string(b)
+		return resp(200, `{"count":7,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0}}`), nil
+	}))
+	n, err := c.CountRawExcluded(context.Background(), 0, 100)
+	if err != nil || n != 7 {
+		t.Fatalf("want 7,nil got %d,%v", n, err)
+	}
+	if !strings.Contains(gotBody, "raw_excluded") || !strings.Contains(gotBody, "created_at") {
+		t.Fatalf("raw_excluded query must filter on raw_excluded + created_at: %s", gotBody)
+	}
+}

--- a/internal/recon/recon.go
+++ b/internal/recon/recon.go
@@ -1,0 +1,77 @@
+// Package recon 是消息检索管线的对账（reconciliation）工具：给定时间窗，比对 MySQL message
+// 表行数 vs OpenSearch doc 数，扣除「已知排除」后输出差异报告。
+//
+// 设计纪律（YUJ-4534）：
+//   - 对账口径与 es-indexer 写入器**解耦**（沿用 internal/esindex 的解耦纪律）：本包只描述
+//     「源行数 / sink doc 数 / 已知排除」的算术，数据来源经接口注入，可被阶段 6 backfill job
+//     直接复用为其正确性 gate。
+//   - 不变式（阶段 6 backfill 验收门）：
+//     ES(按 _id=message_id 去重 doc 数) + DLQ 条数 + 已知排除(raw_excluded: Signal/非文本)
+//     == 源 message 行数(时间窗内)
+//     无法归因的缺口（reconciled != 0）即 STOP。
+//
+// 路线甲提醒：撤回/删除态**不进** ES，但它们的正文行仍在 message 表里（撤回是 message_extra
+// 原地 UPDATE，不删 message 行）。对账以 message 表行数为源真相；撤回/删除不计入「源排除」——
+// 它们的正文 doc 确实应在 ES 中（读时再 join 过滤），故不从源行数里扣。
+package recon
+
+import "fmt"
+
+// Counts 是一次对账的输入计数（均针对同一时间窗 [FromUnix, ToUnix]）。
+type Counts struct {
+	// SourceRows 是 MySQL message 5 分表在时间窗内的总行数（created_at ∈ 窗）。
+	SourceRows int64
+	// ESDocs 是 OpenSearch 索引内、同时间窗（created_at 字段）去重后的 doc 数（_id=message_id 天然去重）。
+	ESDocs int64
+	// RawExcluded 是「已知不可索引类」源行数（Signal 加密 / 非文本 → raw_excluded=true，不产 content
+	// 但仍写入 ES 占一个 doc）。**注意**：raw_excluded 仍是一条 ES doc，不从 ESDocs 缺。见 Reconcile 注释。
+	RawExcluded int64
+	// DLQ 是进了死信、未写入 ES 正文索引的源行数（真异常 / 未知 schema_version）。
+	DLQ int64
+}
+
+// Report 是对账结论。
+type Report struct {
+	Counts
+	// Expected 是按口径推导的「ES 应有 doc 数」。
+	Expected int64
+	// Diff = ESDocs - Expected。0 = 完全对平；>0 多了（重复/越界）；<0 少了（漏灌/丢失）。
+	Diff int64
+	// OK 为 true 表示对平（Diff==0）。
+	OK bool
+}
+
+// Reconcile 计算对账结论。
+//
+// 口径推导（raw_excluded 仍是一条 ES doc）：
+//
+//	Expected_ES_docs = SourceRows - DLQ
+//
+// 解释：源行数里，进了 DLQ 的那部分不写 ES 正文索引（schema 非法/真异常），故从期望 doc 数扣除。
+// raw_excluded（Signal/非文本）**仍写入 ES**（content=null 的 doc，供读路径统一处理），因此**不**从
+// 期望里扣——它占一个 doc。撤回/删除态不进 DLQ、也不是 raw_excluded：其正文 doc 本应在 ES（路线甲
+// 读时 join 过滤），故同样不扣。
+//
+// 因此对平条件： ESDocs == SourceRows - DLQ。
+func Reconcile(c Counts) Report {
+	expected := c.SourceRows - c.DLQ
+	diff := c.ESDocs - expected
+	return Report{
+		Counts:   c,
+		Expected: expected,
+		Diff:     diff,
+		OK:       diff == 0,
+	}
+}
+
+// String 渲染人类可读的对账报告。
+func (r Report) String() string {
+	status := "MISMATCH"
+	if r.OK {
+		status = "OK"
+	}
+	return fmt.Sprintf(
+		"reconcile %s | source_rows=%d es_docs=%d expected=%d diff=%d (raw_excluded=%d dlq=%d)",
+		status, r.SourceRows, r.ESDocs, r.Expected, r.Diff, r.RawExcluded, r.DLQ,
+	)
+}

--- a/internal/recon/recon_test.go
+++ b/internal/recon/recon_test.go
@@ -1,0 +1,94 @@
+package recon
+
+import "testing"
+
+// TestReconcile_AllIndexed 全部源行都进了 ES（含 raw_excluded doc），无 DLQ → 对平。
+func TestReconcile_AllIndexed(t *testing.T) {
+	r := Reconcile(Counts{SourceRows: 1000, ESDocs: 1000, RawExcluded: 50, DLQ: 0})
+	if !r.OK || r.Diff != 0 || r.Expected != 1000 {
+		t.Fatalf("expected OK diff=0 expected=1000, got %+v", r)
+	}
+}
+
+// TestReconcile_DLQExcludedFromExpected DLQ 条目不写 ES → 期望 doc 数扣除 DLQ。
+func TestReconcile_DLQExcludedFromExpected(t *testing.T) {
+	// 1000 源行，3 条进 DLQ（未写 ES）→ 期望 997 doc。ES 实际 997 → 对平。
+	r := Reconcile(Counts{SourceRows: 1000, ESDocs: 997, DLQ: 3})
+	if !r.OK {
+		t.Fatalf("expected OK, got %+v", r)
+	}
+	if r.Expected != 997 {
+		t.Fatalf("expected 997, got %d", r.Expected)
+	}
+}
+
+// TestReconcile_RawExcludedStillCounts raw_excluded 仍是一条 ES doc → 不从期望扣除。
+func TestReconcile_RawExcludedStillCounts(t *testing.T) {
+	// 全部 1000 行都写入 ES（其中 200 条 raw_excluded，content=null 但占 doc）→ ES 1000 → 对平。
+	r := Reconcile(Counts{SourceRows: 1000, ESDocs: 1000, RawExcluded: 200, DLQ: 0})
+	if !r.OK {
+		t.Fatalf("raw_excluded must NOT be subtracted from expected; got %+v", r)
+	}
+}
+
+// TestReconcile_Shortfall ES 比期望少（漏灌/丢失）→ Diff<0，不对平（STOP 信号）。
+func TestReconcile_Shortfall(t *testing.T) {
+	r := Reconcile(Counts{SourceRows: 1000, ESDocs: 990, DLQ: 0})
+	if r.OK || r.Diff != -10 {
+		t.Fatalf("expected mismatch diff=-10, got %+v", r)
+	}
+}
+
+// TestReconcile_Surplus ES 比期望多（越界/串窗）→ Diff>0，不对平。
+func TestReconcile_Surplus(t *testing.T) {
+	r := Reconcile(Counts{SourceRows: 1000, ESDocs: 1005, DLQ: 0})
+	if r.OK || r.Diff != 5 {
+		t.Fatalf("expected mismatch diff=+5, got %+v", r)
+	}
+}
+
+// TestReconcile_DLQAndShortfall 综合：DLQ 扣除后仍缺口。
+func TestReconcile_DLQAndShortfall(t *testing.T) {
+	// 源 500，DLQ 10 → 期望 490；ES 只有 485 → 缺 5。
+	r := Reconcile(Counts{SourceRows: 500, ESDocs: 485, DLQ: 10})
+	if r.OK || r.Diff != -5 || r.Expected != 490 {
+		t.Fatalf("expected expected=490 diff=-5, got %+v", r)
+	}
+}
+
+func TestReport_StringRendersStatus(t *testing.T) {
+	ok := Reconcile(Counts{SourceRows: 10, ESDocs: 10}).String()
+	if !contains(ok, "OK") {
+		t.Fatalf("OK report should say OK: %s", ok)
+	}
+	bad := Reconcile(Counts{SourceRows: 10, ESDocs: 9}).String()
+	if !contains(bad, "MISMATCH") {
+		t.Fatalf("mismatch report should say MISMATCH: %s", bad)
+	}
+}
+
+func TestSafeTableName(t *testing.T) {
+	for _, ok := range []string{"message", "message1", "msg_4"} {
+		if !safeTableName(ok) {
+			t.Fatalf("%q should be safe", ok)
+		}
+	}
+	for _, bad := range []string{"", "msg;drop", "msg table", "msg`x", "msg-1"} {
+		if safeTableName(bad) {
+			t.Fatalf("%q must be rejected", bad)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

Phase 5: a self-contained **local** e2e verification harness, a reusable
**reconciliation** package/CLI (the phase-6 backfill correctness gate), and a
bulk-**tuning** baseline doc — all on a throwaway local stack.

> 🔒 **Isolation respected.** Everything here runs against a local `docker compose`
> stack only. No shared-environment `Kafka.On`, no octo-deployment wiring. Real
> deployment is a separate, explicitly signed-off step.

## (a) Local e2e harness (`harness/`)

`docker compose` brings up **Kafka (KRaft) + OpenSearch with the `analysis-ik`
plugin** (version-matched Dockerfile). `run.sh` builds/starts, pre-creates the
body + DLQ topics (the indexer's DLQ producer uses `AllowAutoTopicCreation=false`
by design), then runs the indexer, seeds, and verifies.

- `seed/` produces a controlled contract suite (normal / 中文 / `raw_excluded` /
  duplicate `_id` / unknown `schema_version` / bad JSON) and a `-mode bulk -n N` load.
- `verify/` asserts invariants against OpenSearch.

**Ran for real** (this PR was validated against the live stack):
- 9/9 invariants PASS through `searchetl`-shaped messages → Kafka → indexer → OpenSearch+IK.
- ~5,000 docs indexed end-to-end in ~1.4 s at batch 500; the 2 poison pills land
  in `octo.message.v1.dlq` (offset 2); IK segments `今天/北京/公园/散步` as CN words.

## (b) Invariants verified on the real stream

- **Idempotency** — duplicate `message_id` → exactly one ES doc.
- **C4** — unknown `schema_version` + bad JSON NOT indexed (→ DLQ); `raw_excluded`
  IS indexed (content null). A `consumer-drained` quiet-period gate runs before the
  negative assertions so they can't false-PASS.
- **IK tokenization** — Chinese (`公园`, `北京`) + English (`pipeline`) recall.

(C1/C3/C2 producer/consumer state-machine invariants remain unit-tested under
`-race`; the harness exercises the same code against real infra.)

## (c) Bulk tuning baseline (`docs/tuning.md`)

Recommended `INDEXER_BATCH_SIZE` (start 1000), transient/DLQ backoff, spill, and
OpenSearch-side guidance (`refresh_interval`, replicas, scale via partitions +
replicas), plus the phase-6 backfill starting config.

## (d) Reconciliation gate (`internal/recon` + `cmd/reconcile`)

The phase-6 correctness gate, **decoupled** from the writer (importable by the
backfill job):

```
ES_docs(window) == source_rows(window) - DLQ(window)
```

`raw_excluded` docs still occupy an ES doc (NOT subtracted); revoked/deleted keep
their doc too (route 甲 read-time join). MySQL per-shard `COUNT` (table-name
allowlist, no injection), OpenSearch `_count` (created_at range + raw_excluded
term). **The gate rejects partial-shard counts** (`_shards.failed`/`successful`)
so a degraded ES can't yield a false OK. CLI exits 2 on mismatch (vs 1 on error).
Validated against the live harness: `5007 source − 2 DLQ == 5005 ES docs → OK`.

## Mapping

`content` switched to **IK** (`ik_max_word` index / `ik_smart` search) per the
phase-4 tokenizer decision; the harness installs IK so the embedded mapping is
exercised for real. Deployment may override the analyzer if a cluster lacks IK.

## Checks

`go build` / `go vet` / `go test -race` / `golangci-lint` all clean. Independent
model review: PASS (after hardening the recon gate against partial-shard counts
and making the harness drain-gate fail-closed). Pure utility/harness commands have
no production runtime impact (the shipped image still builds only `./cmd/es-indexer`).
