### PR TITLE
feat(backfill): historical message backfill job + DLQ-accounting reconcile gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ todos
 # Test binary
 *.test
 
+# Ad-hoc local build artifacts (e.g. `go build -o backfill ./cmd/backfill`)
+/backfill
+/es-indexer
+/reconcile
+
 # Output
 *.out
 

--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -1,0 +1,265 @@
+// Command backfill 是 octo-im 消息检索管线的历史回灌作业（YUJ-4534 阶段 6）。
+//
+// 它读 MySQL message 5 分表 → 复用 internal/esindex 写入器（同一套 bulk / mapping /
+// `_id=message_id`）直接幂等 bulk 写 OpenSearch，**绕开 Kafka**。与实时增量（Kafka →
+// es-indexer）并行 / 重叠安全：`_id=message_id` 幂等覆盖，同一条消息被两条路写入即覆盖同一 doc。
+//
+//	message 5 分表 → 【backfill 本作业：keyset 扫描 → esindex.Writer bulk】 → OpenSearch
+//
+// 设计纪律：
+//   - 复用 internal/esindex（不重新实现写入器）；keyset 分页（按主键 id 有序推进，不用 OFFSET）。
+//   - 限速 ≤5k docs/s（默认）；checkpoint 续传（已灌 message_id 高水位，与实时游标物理隔离）。
+//   - 真异常 / ES 永久拒绝落本地 DLQ spill 并精确计数，作为对账门权威输入。
+//   - 配置全走 flag / env。运行结束后建议跑 cmd/reconcile（或 -reconcile 内联对账门）核验。
+//
+// 🔴 隔离纪律：本作业对真实环境执行需 Yu / 运维显式 sign-off 后低峰触发，绝不自动跑生产。
+//
+// 用法：
+//
+//	backfill -mysql-dsn 'user:pass@tcp(host:3306)/im_prod' \
+//	  -tables message,message1,message2,message3,message4 \
+//	  -es http://localhost:9200 -es-index octo-message \
+//	  -spill-dir /var/lib/octo-backfill/dlq -checkpoint /var/lib/octo-backfill/checkpoint.json \
+//	  -rate 5000 -batch 1000 [-reconcile -from <epoch> -to <epoch>]
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/backfill"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/recon"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+	if err := run(); err != nil {
+		log.Printf("backfill error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		mysqlDSN   = flag.String("mysql-dsn", os.Getenv("BACKFILL_MYSQL_DSN"), "MySQL DSN (or BACKFILL_MYSQL_DSN)")
+		tablesS    = flag.String("tables", envOr("BACKFILL_TABLES", "message,message1,message2,message3,message4"), "comma-separated message shard tables")
+		esAddrs    = flag.String("es", envOr("BACKFILL_ES", "http://localhost:9200"), "comma-separated OpenSearch addresses")
+		esIndex    = flag.String("es-index", envOr("BACKFILL_ES_INDEX", "octo-message"), "OpenSearch index")
+		esUser     = flag.String("es-user", os.Getenv("BACKFILL_ES_USER"), "OpenSearch username")
+		esPass     = flag.String("es-pass", os.Getenv("BACKFILL_ES_PASS"), "OpenSearch password")
+		spillDir   = flag.String("spill-dir", envOr("BACKFILL_SPILL_DIR", ""), "REQUIRED: local DLQ spill dir for real anomalies / permanent ES rejects")
+		checkpoint = flag.String("checkpoint", envOr("BACKFILL_CHECKPOINT", ""), "checkpoint file path for resumable cursor (empty = in-memory, not resumable)")
+		batch      = flag.Int("batch", envInt("BACKFILL_BATCH", 1000), "keyset batch size")
+		rate       = flag.Float64("rate", envFloat("BACKFILL_RATE", 5000), "ingest rate limit (docs/s; <=0 = unlimited)")
+		backoffMS  = flag.Int("transient-backoff-ms", envInt("BACKFILL_TRANSIENT_BACKOFF_MS", 1000), "ES transient retry backoff base (ms)")
+		timeout    = flag.Duration("timeout", envDuration("BACKFILL_TIMEOUT", 6*time.Hour), "overall timeout")
+		doRecon    = flag.Bool("reconcile", false, "after backfill, run the reconcile gate (requires -from/-to)")
+		fromUnix   = flag.Int64("from", 0, "reconcile window start (epoch seconds, inclusive)")
+		toUnix     = flag.Int64("to", 0, "reconcile window end (epoch seconds, inclusive; 0 = now)")
+	)
+	flag.Parse()
+
+	if *mysqlDSN == "" {
+		return fmt.Errorf("mysql DSN required (-mysql-dsn or BACKFILL_MYSQL_DSN)")
+	}
+	tables := splitCSV(*tablesS)
+	if len(tables) == 0 {
+		return fmt.Errorf("at least one source table required (-tables)")
+	}
+
+	// SIGTERM / SIGINT 优雅停止：当前批结束、checkpoint 已持久化后退出，可续传。
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+
+	db, err := sql.Open("mysql", *mysqlDSN)
+	if err != nil {
+		return fmt.Errorf("open mysql: %w", err)
+	}
+	defer func() {
+		if cerr := db.Close(); cerr != nil {
+			log.Printf("warn: close mysql: %v", cerr)
+		}
+	}()
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping mysql: %w", err)
+	}
+
+	writer, err := esindex.NewWriter(esindex.Config{
+		Addresses: splitCSV(*esAddrs),
+		Index:     *esIndex,
+		Username:  *esUser,
+		Password:  *esPass,
+	})
+	if err != nil {
+		return fmt.Errorf("build ES writer: %w", err)
+	}
+	defer func() {
+		if cerr := writer.Close(); cerr != nil {
+			log.Printf("warn: close ES writer: %v", cerr)
+		}
+	}()
+
+	cp, err := backfill.OpenCheckpoint(*checkpoint)
+	if err != nil {
+		return err
+	}
+	dlq, err := backfill.OpenDLQSpill(*spillDir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := dlq.Close(); cerr != nil {
+			log.Printf("warn: close DLQ spill: %v", cerr)
+		}
+	}()
+
+	runner := backfill.NewRunner(backfill.Config{
+		Tables:           tables,
+		BatchSize:        *batch,
+		DocsPerSec:       *rate,
+		TransientBackoff: time.Duration(*backoffMS) * time.Millisecond,
+	}, backfill.NewMySQLSource(db), writer, cp, dlq)
+
+	log.Printf("backfill start: tables=%v batch=%d rate=%.0f docs/s spill=%s checkpoint=%s index=%s",
+		tables, *batch, *rate, dlq.Path(), *checkpoint, *esIndex)
+
+	stats, runErr := runner.Run(ctx)
+	log.Printf("backfill stats: read=%d indexed=%d (raw_excluded=%d) dlq=%d (payload=%d permanent=%d)",
+		stats.Read, stats.Indexed, stats.RawExcluded, stats.DLQ, stats.DLQPayload, stats.DLQPermanent)
+	if runErr != nil {
+		return fmt.Errorf("backfill run: %w", runErr)
+	}
+
+	if *doRecon {
+		return reconcile(ctx, db, splitCSV(*esAddrs), *esUser, *esPass, *esIndex, tables, *fromUnix, *toUnix, dlq)
+	}
+	log.Printf("backfill complete. Run cmd/reconcile (or re-run with -reconcile -from/-to) to gate correctness. Total DLQ count: %d", dlq.Count())
+	return nil
+}
+
+// reconcile 内联对账门：用 backfill 自己精确统计的 DLQ 计数作为权威输入，避免人工传错 -dlq。
+// 🔴 用**按窗** DLQ 计数（CountInWindow）：reconcile 窗可能不覆盖本次 run 处理的全部行
+// （如分批跑、或只校验某个时间段），用全量 dlqCount 会把窗外的 DLQ 行也减掉 → false
+// mismatch/false OK（codex review P2-window）。
+// 对平退出码 0；不对平返回错误（main 退出码 1）作为 STOP 信号。
+func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, index string, tables []string, fromUnix, toUnix int64, dlq *backfill.DLQSpill) error {
+	to := toUnix
+	if to == 0 {
+		to = time.Now().Unix()
+	}
+	if fromUnix > to {
+		return fmt.Errorf("invalid reconcile window: from(%d) > to(%d)", fromUnix, to)
+	}
+	dlqCount := dlq.CountInWindow(fromUnix, to)
+	osClient, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{Addresses: esAddrs, Username: user, Password: pass},
+	})
+	if err != nil {
+		return fmt.Errorf("opensearch client: %w", err)
+	}
+	// 强制 refresh 让刚 bulk 的 doc 对 _count 可见——否则 refresh_interval（默认 1s / backfill
+	// 期建议 -1）未到时 _count 读到旧值，会把对账门误判成漏灌（false MISMATCH）。
+	if _, rerr := osClient.Indices.Refresh(ctx, &opensearchapi.IndicesRefreshReq{Indices: []string{index}}); rerr != nil {
+		return fmt.Errorf("refresh index before reconcile: %w", rerr)
+	}
+	srcCounter := recon.NewMySQLSourceCounter(db, tables)
+	esCounter := recon.NewOSCounter(osClient, index)
+
+	sourceRows, err := srcCounter.CountRows(ctx, fromUnix, to)
+	if err != nil {
+		return err
+	}
+	esDocs, err := esCounter.CountDocs(ctx, fromUnix, to)
+	if err != nil {
+		return err
+	}
+	rawExcluded, err := esCounter.CountRawExcluded(ctx, fromUnix, to)
+	if err != nil {
+		return err
+	}
+	report, err := recon.ReconcileChecked(recon.Counts{
+		SourceRows:  sourceRows,
+		ESDocs:      esDocs,
+		RawExcluded: rawExcluded,
+		DLQ:         dlqCount,
+	})
+	if err != nil {
+		return fmt.Errorf("reconcile inputs not self-consistent: %w", err)
+	}
+	log.Printf("reconcile gate: %s", report.String())
+	if !report.OK {
+		return fmt.Errorf("reconcile MISMATCH (diff=%d): backfill correctness gate FAILED — STOP, do not proceed", report.Diff)
+	}
+	return nil
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(k string, def int) int {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+		log.Printf("backfill: invalid %s=%q, using default %d", k, v, def)
+		return def
+	}
+	return n
+}
+
+func envFloat(k string, def float64) float64 {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	var f float64
+	if _, err := fmt.Sscanf(v, "%g", &f); err != nil {
+		log.Printf("backfill: invalid %s=%q, using default %g", k, v, def)
+		return def
+	}
+	return f
+}
+
+func envDuration(k string, def time.Duration) time.Duration {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Printf("backfill: invalid %s=%q, using default %s", k, v, def)
+		return def
+	}
+	return d
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cmd/reconcile/main.go
+++ b/cmd/reconcile/main.go
@@ -104,12 +104,16 @@ func run() error {
 		return err
 	}
 
-	report := recon.Reconcile(recon.Counts{
+	report, err := recon.ReconcileChecked(recon.Counts{
 		SourceRows:  sourceRows,
 		ESDocs:      esDocs,
 		RawExcluded: rawExcluded,
 		DLQ:         *dlq,
 	})
+	if err != nil {
+		// 输入不自洽（DLQ accounting 加固，阶段 6 (f)）：拒绝在可疑计数上判 OK。
+		return err
+	}
 	fmt.Println(report.String())
 	if !report.OK {
 		// 不对平：退出码 2，作为 backfill/CI gate 的失败信号。

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -51,6 +51,13 @@ it lands two classes of "not in ES body index" rows into a **local DLQ spill fil
 That exact count is fed into the reconcile gate as the authoritative `DLQ` input, so
 legitimately-DLQ'd messages are **not** misjudged as ES-missing.
 
+**Crash recovery.** The spill is append-only; each batch fsyncs the spill and then
+atomically advances a durable offset sidecar (`<spill-dir>/backfill-dlq.synced`)
+*before* the checkpoint advances. On restart the spill is truncated to that synced
+offset, discarding the entire un-fsynced dirty suffix (whatever its torn shape) — those
+rows belong to a batch whose checkpoint never advanced, so resume re-derives them. Any
+parse error *within* the synced prefix is treated as real corruption and is fatal.
+
 ## Reconciliation gate (correctness gate)
 
 The job can run the gate inline (`-reconcile -from <epoch> -to <epoch>`) using its own

--- a/docs/backfill.md
+++ b/docs/backfill.md
@@ -1,0 +1,106 @@
+# Historical backfill runbook (`cmd/backfill`)
+
+Phase 6 of the octo message-search pipeline (YUJ-4534). One-shot job that loads the
+historical `message` shard tables into OpenSearch, **bypassing Kafka**, reusing the
+same write path as the live indexer.
+
+```
+message 5 shards → [cmd/backfill: keyset scan → internal/esindex.Writer bulk] → OpenSearch
+```
+
+## Why bypass Kafka
+
+The historical volume (~3.15M rows / ~2.14 GB at ~700 B/row) does not need to go
+through Kafka. Direct bulk-to-ES is faster and avoids any Kafka retention-deletion
+risk during a large one-shot load. The live increment keeps flowing through Kafka
+unchanged; the two paths are safe to run in parallel because the ES doc `_id =
+message_id` makes every write an idempotent upsert — the same message written by both
+paths just overwrites the same doc.
+
+Revoked/deleted messages are **not** a concern for backfill: route 甲 keeps only the
+body in ES and filters revoke/delete at read time via a MySQL join, so even if a
+historically-revoked body is loaded it is filtered on read.
+
+## What it does (correctness properties)
+
+- **Reuses `internal/esindex`** (writer + `EnsureIndex` mapping + `_id=message_id`).
+  No ES write code is re-implemented.
+- **Keyset pagination** by primary-key `id` (`WHERE id>? ORDER BY id ASC LIMIT ?`),
+  never `OFFSET` — O(1) deep-page seeks, no offset drift.
+- **Idempotent** with the live increment (`_id=message_id` upsert; overlap is safe).
+- **Resumable**: a per-shard high-watermark is persisted to a local checkpoint file
+  (atomic temp-file + rename). A watermark is advanced **only after** the batch is
+  terminal (indexed, or routed to the local DLQ spill). The checkpoint is physically
+  isolated from the live increment cursor (`octo_etl_es_cursor`).
+- **Rate-limited** (`-rate`, default ≤5000 docs/s) to avoid overrunning ES / source DB.
+- **payload extraction is byte-for-byte aligned with the live producer** (P1-d three-way
+  split): Signal-encrypted / non-text → `raw_excluded` (still occupies an ES doc, NOT a
+  loss, NOT DLQ); a real parse anomaly → local DLQ spill (counted).
+- **fail-closed**: any DLQ spill-write failure or checkpoint-persist failure STOPs the
+  whole job (real anomalies must never silently vanish — that would corrupt reconcile).
+
+## DLQ accounting (no Kafka DLQ topic on this path)
+
+The live indexer routes poison pills to a Kafka DLQ topic; backfill bypasses Kafka, so
+it lands two classes of "not in ES body index" rows into a **local DLQ spill file**
+(`<spill-dir>/backfill-dlq.ndjson`) and counts them precisely:
+
+1. `payload_unparseable` — a non-encrypted payload that should have parsed but didn't.
+2. permanent ES rejects — per-item 4xx (e.g. mapping conflict) returned by `_bulk`.
+
+That exact count is fed into the reconcile gate as the authoritative `DLQ` input, so
+legitimately-DLQ'd messages are **not** misjudged as ES-missing.
+
+## Reconciliation gate (correctness gate)
+
+The job can run the gate inline (`-reconcile -from <epoch> -to <epoch>`) using its own
+authoritative DLQ count, or you can run `cmd/reconcile` separately. Equation:
+
+```
+ES_docs(window) == source_rows(window) - DLQ(window)
+```
+
+`raw_excluded` docs still occupy an ES doc (content null) and are NOT subtracted;
+revoked/deleted rows keep their ES doc (read-time join) and are NOT subtracted; only
+the DLQ rows (which never reached the ES body index) are subtracted. The gate rejects
+self-inconsistent inputs (e.g. `DLQ > source_rows`, `raw_excluded > es_docs`) rather
+than risk a false OK, and fails (non-zero exit / error) on any mismatch → STOP.
+
+## Suggested ES settings during backfill (octo-deployment)
+
+Per `docs/tuning.md`: `index.refresh_interval=-1`, `index.number_of_replicas=0`
+during the load, then restore and force one `_refresh`, then run the gate.
+
+## Build & run
+
+`cmd/backfill` is an on-demand ops tool (like `cmd/reconcile`); it is **not** baked
+into the long-running `es-indexer` service image. Build it where you run it:
+
+```sh
+go build -o backfill ./cmd/backfill
+
+./backfill \
+  -mysql-dsn 'user:pass@tcp(host:3306)/im_prod' \
+  -tables message,message1,message2,message3,message4 \
+  -es http://opensearch:9200 -es-index octo-message \
+  -spill-dir /var/lib/octo-backfill/dlq \
+  -checkpoint /var/lib/octo-backfill/checkpoint.json \
+  -rate 5000 -batch 1000 \
+  -reconcile -from 1709078400 -to 1718323200
+```
+
+`-spill-dir` is **required** (real anomalies must be durably accounted). Env-var
+equivalents: `BACKFILL_MYSQL_DSN`, `BACKFILL_TABLES`, `BACKFILL_ES`,
+`BACKFILL_ES_INDEX`, `BACKFILL_ES_USER`, `BACKFILL_ES_PASS`, `BACKFILL_SPILL_DIR`,
+`BACKFILL_CHECKPOINT`, `BACKFILL_BATCH`, `BACKFILL_RATE`.
+
+SIGTERM/SIGINT stops cleanly after the current batch (checkpoint persisted) → resumable.
+
+## 🔴 Isolation discipline
+
+Running backfill against a **real** environment requires explicit Yu/ops sign-off and a
+low-peak window. It is never run automatically against production and is decoupled from
+code release — code ships through the normal test→prod path first; backfill is a
+deployment-time ops action verified in the local harness here. The job only **reads**
+the message tables (no schema change, no webhook write path, no binlog); it is
+idempotent, resumable, and pairs with a zero-downtime index alias rebuild.

--- a/harness/README.md
+++ b/harness/README.md
@@ -81,3 +81,37 @@ a real broker + real OpenSearch.
   production the platform provisions them.
 - The harness OpenSearch disables the security plugin for plain-HTTP local
   testing only — production uses authenticated endpoints (`ES_USERNAME`/`ES_PASSWORD`).
+
+## Phase-6 backfill harness (`run-backfill.sh` + `backfill/`)
+
+A second, self-contained e2e that exercises the historical backfill job (`cmd/backfill`)
+against a real MySQL + OpenSearch(IK), bypassing Kafka:
+
+```
+MySQL message shards → cmd/backfill (keyset scan → internal/esindex.Writer bulk) → OpenSearch
+```
+
+| Path | What |
+| --- | --- |
+| `run-backfill.sh` | orchestrator: `up` (throwaway OpenSearch(IK) + MySQL) / `seed` / `backfill` / `verify` / `down` / `all` |
+| `backfill/` | seeds a controlled 6-row suite into the `message` shard tables and verifies the ES result |
+
+The seeded suite is deliberately tiny and explicit so the gate arithmetic is obvious:
+3 text rows (incl. 中文) + 1 Signal-encrypted + 1 non-text (image) + 1 bad-JSON anomaly.
+So `source_rows=6`, expected `ES docs=5` (`6 - 1 DLQ`), `raw_excluded=2`.
+
+```sh
+./harness/run-backfill.sh          # up → seed MySQL → backfill+reconcile gate → verify → down
+KEEP_UP=1 ./harness/run-backfill.sh
+```
+
+What it proves (mirrors the unit tests against real infra):
+- reuses `internal/esindex` writer + IK mapping (`ik_max_word`/`ik_smart`), `_id=message_id`;
+- `raw_excluded` rows (Signal/non-text) still occupy an ES doc; the bad-JSON anomaly is
+  routed to the local DLQ spill and is **positively asserted absent** from ES;
+- the reconcile gate runs inline and is `OK | source_rows=6 es_docs=5 expected=5 diff=0`
+  (it force-refreshes the index first so a refresh lag can't cause a false MISMATCH);
+- re-running is a no-op via the checkpoint and idempotent (`_id` upsert) — ES count stays 5;
+- IK 中文 recall works on backfilled docs (`公园` → the 公园 row, `北京` → the 北京 row).
+
+See `docs/backfill.md` for the production runbook and isolation discipline.

--- a/harness/backfill/main.go
+++ b/harness/backfill/main.go
@@ -1,0 +1,279 @@
+// Command backfill-harness seeds a controlled set of message rows into a local MySQL
+// (mimicking the octo-im message shard schema) for the phase-6 backfill e2e, then
+// (optionally) verifies the result in OpenSearch after cmd/backfill has run.
+//
+// Isolation: connects only to the local throwaway MySQL + OpenSearch. Never a shared env.
+//
+// Modes:
+//
+//	-mode seed    create shard tables + insert a controlled suite, print the source row count
+//	-mode verify  assert ES doc count / raw_excluded / DLQ-bypassed match the seeded suite
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// Seeded suite shape (kept tiny + explicit so the gate arithmetic is obvious):
+//   - 3 normal text rows (incl. 中文)            → indexed, content present
+//   - 1 Signal-encrypted row (signal column)     → raw_excluded, still 1 ES doc
+//   - 1 non-text (image) row                     → raw_excluded, still 1 ES doc
+//   - 1 bad-JSON non-encrypted row (real anomaly)→ DLQ spill, NOT in ES
+//
+// So: source_rows=6, expected ES docs=5 (6 - 1 DLQ), raw_excluded=2.
+const (
+	wantSource      = 6
+	wantESDocs      = 5
+	wantRawExcluded = 2
+	wantDLQ         = 1
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+	var (
+		mode   = flag.String("mode", "seed", "seed|verify")
+		dsn    = flag.String("mysql-dsn", envOr("BF_MYSQL_DSN", "root:root@tcp(localhost:23307)/im_test"), "MySQL DSN")
+		esURL  = flag.String("es", envOr("BF_ES", "http://localhost:29200"), "OpenSearch URL")
+		index  = flag.String("es-index", envOr("BF_ES_INDEX", "octo-message"), "index")
+		tables = flag.String("tables", envOr("BF_TABLES", "message,message1"), "shard tables")
+		base   = flag.Int64("base-ts", time.Now().Unix(), "base created_at epoch seconds")
+	)
+	flag.Parse()
+	if err := run(*mode, *dsn, *esURL, *index, splitCSV(*tables), *base); err != nil {
+		log.Fatalf("backfill-harness %s: %v", *mode, err)
+	}
+}
+
+func run(mode, dsn, esURL, index string, tables []string, base int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	switch mode {
+	case "seed":
+		return seed(ctx, dsn, tables, base)
+	case "verify":
+		return verify(ctx, esURL, index, base)
+	default:
+		return fmt.Errorf("unknown mode %q", mode)
+	}
+}
+
+func seed(ctx context.Context, dsn string, tables []string, base int64) error {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+	defer mustClose(db)
+	if err := db.PingContext(ctx); err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		return fmt.Errorf("need at least one table")
+	}
+	for _, t := range tables {
+		if err := createTable(ctx, db, t); err != nil {
+			return err
+		}
+	}
+	// Put the 6-row suite across the shard tables (round-robin-ish; deterministic).
+	t0 := tables[0]
+	t1 := tables[len(tables)-1]
+	rows := []struct {
+		table       string
+		mid         string
+		fromUID     string
+		channelID   string
+		channelType uint8
+		setting     uint8
+		signal      int
+		payload     string
+	}{
+		{t0, "h-en", "u1", "g1", 2, 0, 0, `{"type":1,"content":"hello world pipeline"}`},
+		{t0, "h-zh1", "u1", "g1", 2, 0, 0, `{"type":1,"content":"今天天气很好我们去公园散步吧"}`},
+		{t1, "h-zh2", "u2", "g1", 2, 0, 0, `{"type":1,"content":"搜索引擎中文分词测试北京欢迎你"}`},
+		{t1, "h-signal", "u3", "u3@u4", 1, 0, 1, `ENCRYPTED-NOT-JSON`},
+		{t0, "h-image", "u1", "g1", 2, 0, 0, `{"type":2,"url":"http://x/y.png"}`},
+		{t1, "h-bad", "u2", "g1", 2, 0, 0, `{not valid json`},
+	}
+	for i, r := range rows {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(
+			"INSERT INTO `%s` (message_id, from_uid, channel_id, channel_type, setting, `signal`, `timestamp`, created_at, payload) "+
+				"VALUES (?,?,?,?,?,?,?,FROM_UNIXTIME(?),?)", r.table),
+			r.mid, r.fromUID, r.channelID, r.channelType, r.setting, r.signal, base, base+int64(i), r.payload,
+		); err != nil {
+			return fmt.Errorf("insert %s: %w", r.mid, err)
+		}
+	}
+	log.Printf("seeded %d source rows across %v (expected ES docs=%d raw_excluded=%d DLQ=%d)",
+		wantSource, tables, wantESDocs, wantRawExcluded, wantDLQ)
+	return nil
+}
+
+func createTable(ctx context.Context, db *sql.DB, table string) error {
+	// 表名来自 -tables flag（本地 harness 控制），但 DROP/CREATE 仍白名单校验防注入。
+	if !safeTableName(table) {
+		return fmt.Errorf("unsafe table name %q", table)
+	}
+	// Minimal shape mirroring the columns cmd/backfill reads.
+	_, err := db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", table))
+	if err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s` ("+
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, "+
+			"message_id VARCHAR(20) NOT NULL, "+
+			"from_uid VARCHAR(40) NOT NULL DEFAULT '', "+
+			"channel_id VARCHAR(100) NOT NULL DEFAULT '', "+
+			"channel_type TINYINT UNSIGNED NOT NULL DEFAULT 0, "+
+			"setting TINYINT UNSIGNED NOT NULL DEFAULT 0, "+
+			"`signal` INT NOT NULL DEFAULT 0, "+
+			"`timestamp` BIGINT NOT NULL DEFAULT 0, "+
+			"created_at DATETIME NOT NULL, "+
+			"payload BLOB"+
+			")", table))
+	return err
+}
+
+func verify(ctx context.Context, esURL, index string, base int64) error {
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{Addresses: []string{esURL}},
+	})
+	if err != nil {
+		return err
+	}
+	// Refresh so counts are visible.
+	if _, rerr := client.Indices.Refresh(ctx, &opensearchapi.IndicesRefreshReq{Indices: []string{index}}); rerr != nil {
+		return fmt.Errorf("refresh: %w", rerr)
+	}
+	from := base - 10
+	to := base + 100
+	total, err := count(ctx, client, index, rangeQuery(from, to))
+	if err != nil {
+		return err
+	}
+	rawEx, err := count(ctx, client, index, rawExcludedQuery(from, to))
+	if err != nil {
+		return err
+	}
+	var fail bool
+	if total != wantESDocs {
+		log.Printf("FAIL: ES doc count=%d want %d", total, wantESDocs)
+		fail = true
+	} else {
+		log.Printf("PASS: ES doc count=%d (== source %d - DLQ %d)", total, wantSource, wantDLQ)
+	}
+	if rawEx != wantRawExcluded {
+		log.Printf("FAIL: raw_excluded=%d want %d", rawEx, wantRawExcluded)
+		fail = true
+	} else {
+		log.Printf("PASS: raw_excluded=%d (Signal + non-text, still occupy ES docs)", rawEx)
+	}
+	// Positively assert the bad-JSON row is NOT in ES (it went to DLQ spill).
+	badPresent, err := count(ctx, client, index, idsQuery("h-bad"))
+	if err != nil {
+		return err
+	}
+	if badPresent != 0 {
+		log.Printf("FAIL: real-anomaly row h-bad must NOT be in ES, found %d", badPresent)
+		fail = true
+	} else {
+		log.Printf("PASS: real-anomaly row h-bad absent from ES (routed to DLQ spill)")
+	}
+	if fail {
+		return fmt.Errorf("backfill e2e verification FAILED")
+	}
+	log.Printf("backfill e2e verification PASSED")
+	return nil
+}
+
+func count(ctx context.Context, c *opensearchapi.Client, index string, q map[string]any) (int64, error) {
+	b, err := json.Marshal(q)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.Indices.Count(ctx, &opensearchapi.IndicesCountReq{
+		Indices: []string{index},
+		Body:    strings.NewReader(string(b)),
+	})
+	if err != nil {
+		return 0, err
+	}
+	if resp.Shards.Failed != 0 || resp.Shards.Successful != resp.Shards.Total {
+		return 0, fmt.Errorf("incomplete shards (total=%d ok=%d failed=%d)",
+			resp.Shards.Total, resp.Shards.Successful, resp.Shards.Failed)
+	}
+	return int64(resp.Count), nil
+}
+
+func rangeQuery(from, to int64) map[string]any {
+	return map[string]any{"query": map[string]any{"bool": map[string]any{"filter": []any{rangeFilter(from, to)}}}}
+}
+
+func rawExcludedQuery(from, to int64) map[string]any {
+	return map[string]any{"query": map[string]any{"bool": map[string]any{"filter": []any{
+		rangeFilter(from, to),
+		map[string]any{"term": map[string]any{"raw_excluded": true}},
+	}}}}
+}
+
+func idsQuery(id string) map[string]any {
+	return map[string]any{"query": map[string]any{"ids": map[string]any{"values": []string{id}}}}
+}
+
+func rangeFilter(from, to int64) map[string]any {
+	return map[string]any{"range": map[string]any{"created_at": map[string]any{"gte": from, "lte": to}}}
+}
+
+func mustClose(db *sql.DB) {
+	if err := db.Close(); err != nil {
+		log.Printf("warn: close db: %v", err)
+	}
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// safeTableName 仅允许 [A-Za-z0-9_]（DROP/CREATE 防注入；表名来自本地 harness flag）。
+func safeTableName(t string) bool {
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/harness/run-backfill.sh
+++ b/harness/run-backfill.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Local end-to-end verification for the phase-6 historical backfill (cmd/backfill).
+#
+#   MySQL message shards --(cmd/backfill: keyset scan -> esindex.Writer bulk)--> OpenSearch
+#
+# Brings up a throwaway MySQL + OpenSearch(IK), seeds a controlled message suite into
+# the shard tables, runs cmd/backfill (bypassing Kafka), runs the reconcile gate inline,
+# and asserts ES doc count / raw_excluded / DLQ-bypass + IK 中文 recall. Throwaway local
+# stack ONLY — never wired into a shared environment.
+#
+# Usage:
+#   ./harness/run-backfill.sh        # up -> seed -> backfill -> verify -> down
+#   KEEP_UP=1 ./harness/run-backfill.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+cd "$ROOT"
+
+MYSQL_DSN="${BF_MYSQL_DSN:-root:root@tcp(localhost:23307)/im_test}"
+ES_URL="${BF_ES:-http://localhost:29200}"
+ES_INDEX="${BF_ES_INDEX:-octo-message}"
+TABLES="${BF_TABLES:-message,message1}"
+SPILL="${BF_SPILL_DIR:-/tmp/octo-backfill-spill}"
+CHECKPOINT="${BF_CHECKPOINT:-/tmp/octo-backfill-cp.json}"
+
+up() {
+  echo "[backfill-harness] starting throwaway OpenSearch(IK) + MySQL..."
+  docker rm -f octo-bf-os octo-bf-mysql >/dev/null 2>&1 || true
+  docker run -d --name octo-bf-os \
+    -e discovery.type=single-node -e bootstrap.memory_lock=true \
+    -e OPENSEARCH_JAVA_OPTS="-Xms512m -Xmx512m" \
+    -e DISABLE_SECURITY_PLUGIN=true -e DISABLE_INSTALL_DEMO_CONFIG=true \
+    --ulimit memlock=-1:-1 -p 29200:9200 \
+    "$(build_os_image)" >/dev/null
+  docker run -d --name octo-bf-mysql \
+    -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=im_test \
+    -p 23307:3306 mysql:8.0 >/dev/null
+  echo "[backfill-harness] waiting for OpenSearch..."
+  for _ in $(seq 1 40); do curl -fs "$ES_URL/_cluster/health" >/dev/null 2>&1 && break; sleep 3; done
+  echo "[backfill-harness] waiting for MySQL..."
+  for _ in $(seq 1 40); do docker exec octo-bf-mysql mysqladmin ping -uroot -proot >/dev/null 2>&1 && break; sleep 3; done
+  echo "[backfill-harness] stack up."
+}
+
+# build_os_image reuses the IK-enabled OpenSearch image from the main harness.
+build_os_image() {
+  docker build -q -f "$HERE/opensearch-ik.Dockerfile" --build-arg OPENSEARCH_VERSION=2.17.0 "$HERE" >&2
+  docker build -q -f "$HERE/opensearch-ik.Dockerfile" --build-arg OPENSEARCH_VERSION=2.17.0 "$HERE"
+}
+
+down() {
+  echo "[backfill-harness] tearing down..."
+  docker rm -f octo-bf-os octo-bf-mysql >/dev/null 2>&1 || true
+}
+
+seed() {
+  echo "[backfill-harness] seeding MySQL message shards..."
+  BASE_TS="$(date +%s)"
+  export BASE_TS
+  go run ./harness/backfill -mode seed -mysql-dsn "$MYSQL_DSN" -tables "$TABLES" -base-ts "$BASE_TS"
+}
+
+backfill() {
+  echo "[backfill-harness] running cmd/backfill (bypass Kafka) + inline reconcile gate..."
+  rm -rf "$SPILL" "$CHECKPOINT"
+  go run ./cmd/backfill \
+    -mysql-dsn "$MYSQL_DSN" -tables "$TABLES" \
+    -es "$ES_URL" -es-index "$ES_INDEX" \
+    -spill-dir "$SPILL" -checkpoint "$CHECKPOINT" \
+    -rate 5000 -batch 1000 \
+    -reconcile -from "$((BASE_TS - 10))" -to "$((BASE_TS + 100))"
+}
+
+verify() {
+  echo "[backfill-harness] verifying ES result..."
+  go run ./harness/backfill -mode verify -es "$ES_URL" -es-index "$ES_INDEX" -base-ts "$BASE_TS"
+}
+
+case "${1:-all}" in
+  up) up ;;
+  down) down ;;
+  seed) seed ;;
+  backfill) backfill ;;
+  verify) verify ;;
+  all)
+    up
+    trap 'if [[ "${KEEP_UP:-0}" != "1" ]]; then down; fi' EXIT
+    seed
+    backfill
+    verify
+    echo "[backfill-harness] backfill e2e complete."
+    ;;
+  *) echo "usage: $0 {all|up|down|seed|backfill|verify}"; exit 1 ;;
+esac

--- a/internal/backfill/checkpoint.go
+++ b/internal/backfill/checkpoint.go
@@ -37,6 +37,11 @@ func OpenCheckpoint(path string) (*CheckpointStore, error) {
 	if path == "" {
 		return s, nil
 	}
+	// 提早建好父目录并 fail-fast（P2-2）：否则父目录缺失要等到第一次 Advance 写临时文件时才报错，
+	// 那时已扫了一整批白工。开局就把目录准备好，让配置错误立刻暴露。
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, fmt.Errorf("backfill: mkdir checkpoint dir: %w", err)
+	}
 	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置，非用户输入
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/backfill/checkpoint.go
+++ b/internal/backfill/checkpoint.go
@@ -149,5 +149,10 @@ func (s *CheckpointStore) persistLocked() error {
 		cleanup()
 		return fmt.Errorf("backfill: rename checkpoint into place: %w", err)
 	}
+	// rename 的目录项变更在父目录 fsync 前不保证落盘——checkpoint 推进后紧接崩溃可能丢失刚推进的
+	// 水位，削弱续传可靠性。复用 DLQ writer 同一道 fsyncDir（其 rename 后亦如此），让 rename 持久。
+	if err := fsyncDir(dir); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/backfill/checkpoint.go
+++ b/internal/backfill/checkpoint.go
@@ -1,0 +1,148 @@
+package backfill
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Checkpoint 记录每个分表已灌的 message 表自增 id 高水位（keyset 续传游标）。
+//
+// 设计纪律（阶段 6 (d) 可续传）：
+//   - 与实时增量游标表 octo_etl_es_cursor **物理隔离**——backfill 用独立的本地高水位记录，
+//     绝不读 / 写实时游标，互不污染（设计细化 comment 明确）。
+//   - 持久化为本地 JSON 文件，原子写（写临时文件 + rename），中断后从断点续跑。
+//   - 高水位只在「该批已 bulk 写 ES 成功（含 raw_excluded 写入）且真异常已落 DLQ spill」后
+//     才推进——即与对账门口径一致：推进的每个 id 都已「进 ES 或进 DLQ」终态处理。
+type Checkpoint struct {
+	// LastID[table] = 该分表已处理到的最大 message 表自增 id（含）。下批从 id>LastID 起读。
+	LastID map[string]int64 `json:"last_id"`
+}
+
+// CheckpointStore 负责 Checkpoint 的加载 / 原子持久化。
+type CheckpointStore struct {
+	path string
+	mu   sync.Mutex
+	cp   Checkpoint
+}
+
+// OpenCheckpoint 从 path 载入已有 checkpoint（不存在则空起步）。path 为空表示不持久化
+// （内存态，中断不可续——仅供测试 / 一次性小窗使用）。
+func OpenCheckpoint(path string) (*CheckpointStore, error) {
+	s := &CheckpointStore{path: path, cp: Checkpoint{LastID: map[string]int64{}}}
+	if path == "" {
+		return s, nil
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置，非用户输入
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil // 首次运行，空 checkpoint 起步
+		}
+		return nil, fmt.Errorf("backfill: read checkpoint %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return s, nil
+	}
+	var cp Checkpoint
+	if err := json.Unmarshal(data, &cp); err != nil {
+		return nil, fmt.Errorf("backfill: parse checkpoint %s: %w", path, err)
+	}
+	if cp.LastID == nil {
+		cp.LastID = map[string]int64{}
+	}
+	s.cp = cp
+	return s, nil
+}
+
+// Get 返回某分表当前高水位（不存在为 0，从头扫）。
+func (s *CheckpointStore) Get(table string) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cp.LastID[table]
+}
+
+// Advance 把某分表高水位推进到 newID 并原子持久化。
+//
+// 单调校验：newID 必须 > 当前水位才推进（防回退 / 重复推进）；newID<=当前则无声忽略
+// （幂等重跑安全）。持久化失败返回错误，调用方应 STOP（避免「内存推进了但盘上没落」导致
+// 重启后重扫 / 漏扫）。
+func (s *CheckpointStore) Advance(table string, newID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if newID <= s.cp.LastID[table] {
+		return nil
+	}
+	prev := s.cp.LastID[table]
+	s.cp.LastID[table] = newID
+	if err := s.persistLocked(); err != nil {
+		s.cp.LastID[table] = prev // 回滚内存态，保持与盘一致
+		return err
+	}
+	return nil
+}
+
+// snapshot 返回 LastID 的有序拷贝（日志 / 测试用，确定性输出）。
+func (s *CheckpointStore) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tables := make([]string, 0, len(s.cp.LastID))
+	for t := range s.cp.LastID {
+		tables = append(tables, t)
+	}
+	sort.Strings(tables)
+	out := make([]string, 0, len(tables))
+	for _, t := range tables {
+		out = append(out, fmt.Sprintf("%s=%d", t, s.cp.LastID[t]))
+	}
+	return out
+}
+
+// persistLocked 原子写 checkpoint 文件（临时文件 + rename）。调用方须持锁。
+func (s *CheckpointStore) persistLocked() error {
+	if s.path == "" {
+		return nil
+	}
+	data, err := json.Marshal(s.cp)
+	if err != nil {
+		return fmt.Errorf("backfill: marshal checkpoint: %w", err)
+	}
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".backfill-cp-*.tmp")
+	if err != nil {
+		return fmt.Errorf("backfill: create temp checkpoint: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		if rerr := os.Remove(tmpName); rerr != nil && !os.IsNotExist(rerr) {
+			log.Printf("backfill: cleanup temp checkpoint %s: %v", tmpName, rerr)
+		}
+	}
+	closeTmp := func() {
+		if cerr := tmp.Close(); cerr != nil {
+			log.Printf("backfill: close temp checkpoint %s: %v", tmpName, cerr)
+		}
+	}
+	if _, err := tmp.Write(data); err != nil {
+		closeTmp()
+		cleanup()
+		return fmt.Errorf("backfill: write temp checkpoint: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		closeTmp()
+		cleanup()
+		return fmt.Errorf("backfill: sync temp checkpoint: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("backfill: close temp checkpoint: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		cleanup()
+		return fmt.Errorf("backfill: rename checkpoint into place: %w", err)
+	}
+	return nil
+}

--- a/internal/backfill/checkpoint_test.go
+++ b/internal/backfill/checkpoint_test.go
@@ -68,3 +68,25 @@ func TestCheckpoint_MissingFileStartsEmpty(t *testing.T) {
 		t.Fatalf("missing file must yield 0 watermark")
 	}
 }
+
+// TestCheckpoint_CreatesParentDir 🔴 P2-2：父目录不存在时 OpenCheckpoint 应建好目录（fail-fast），
+// 之后 Advance 能直接持久化，不晚到第一次写才失败。
+func TestCheckpoint_CreatesParentDir(t *testing.T) {
+	// 多层尚不存在的父目录。
+	path := filepath.Join(t.TempDir(), "nested", "deep", "cp.json")
+	cp, err := OpenCheckpoint(path)
+	if err != nil {
+		t.Fatalf("OpenCheckpoint must create missing parent dirs: %v", err)
+	}
+	if err := cp.Advance("message", 5); err != nil {
+		t.Fatalf("advance must persist after dir prepared: %v", err)
+	}
+	// 重开验证已落盘。
+	cp2, err := OpenCheckpoint(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if cp2.Get("message") != 5 {
+		t.Fatalf("checkpoint not persisted into created dir: %d", cp2.Get("message"))
+	}
+}

--- a/internal/backfill/checkpoint_test.go
+++ b/internal/backfill/checkpoint_test.go
@@ -1,6 +1,7 @@
 package backfill
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -88,5 +89,42 @@ func TestCheckpoint_CreatesParentDir(t *testing.T) {
 	}
 	if cp2.Get("message") != 5 {
 		t.Fatalf("checkpoint not persisted into created dir: %d", cp2.Get("message"))
+	}
+}
+
+// TestCheckpoint_PersistLeavesDurableDir Advance 后持久化路径（写临时文件 → rename → fsync 父目录）
+// 应是干净耐久状态：只剩最终 checkpoint 文件，无残留临时文件，且内容可重载。
+// （父目录 fsync 本身在单测里不可直接观测，这里断言 persist 路径完整收尾且 rename 已生效——
+//
+//	与 DLQ writer 同一道 fsyncDir，让 rename 目录项变更落盘、续传可靠。）
+func TestCheckpoint_PersistLeavesDurableDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cp.json")
+	cp, err := OpenCheckpoint(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for i := int64(1); i <= 3; i++ {
+		if err := cp.Advance("message", i); err != nil {
+			t.Fatalf("advance %d: %v", i, err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	if len(names) != 1 || names[0] != "cp.json" {
+		t.Fatalf("persist must leave only the final checkpoint (no stray temp files), got %v", names)
+	}
+	cp2, err := OpenCheckpoint(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if cp2.Get("message") != 3 {
+		t.Fatalf("persisted watermark mismatch: %d", cp2.Get("message"))
 	}
 }

--- a/internal/backfill/checkpoint_test.go
+++ b/internal/backfill/checkpoint_test.go
@@ -1,0 +1,70 @@
+package backfill
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckpoint_PersistAndReload Advance 后重开应载入同一水位。
+func TestCheckpoint_PersistAndReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cp.json")
+	cp, err := OpenCheckpoint(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := cp.Advance("message", 10); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if err := cp.Advance("message1", 5); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	cp2, err := OpenCheckpoint(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if cp2.Get("message") != 10 || cp2.Get("message1") != 5 {
+		t.Fatalf("reload mismatch: %d %d", cp2.Get("message"), cp2.Get("message1"))
+	}
+}
+
+// TestCheckpoint_Monotonic 回退 / 同值 Advance 被忽略（幂等重跑安全）。
+func TestCheckpoint_Monotonic(t *testing.T) {
+	cp, err := OpenCheckpoint(filepath.Join(t.TempDir(), "cp.json"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := cp.Advance("message", 10); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if err := cp.Advance("message", 5); err != nil { // 回退被忽略
+		t.Fatalf("advance: %v", err)
+	}
+	if cp.Get("message") != 10 {
+		t.Fatalf("monotonic violated: %d", cp.Get("message"))
+	}
+}
+
+// TestCheckpoint_EmptyPathInMemory path 为空 → 内存态，不报错（不可续传）。
+func TestCheckpoint_EmptyPathInMemory(t *testing.T) {
+	cp, err := OpenCheckpoint("")
+	if err != nil {
+		t.Fatalf("empty path must be ok (in-memory): %v", err)
+	}
+	if err := cp.Advance("message", 3); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	if cp.Get("message") != 3 {
+		t.Fatalf("in-memory advance failed")
+	}
+}
+
+// TestCheckpoint_MissingFileStartsEmpty 文件不存在 → 空起步，不报错。
+func TestCheckpoint_MissingFileStartsEmpty(t *testing.T) {
+	cp, err := OpenCheckpoint(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing file must start empty: %v", err)
+	}
+	if cp.Get("message") != 0 {
+		t.Fatalf("missing file must yield 0 watermark")
+	}
+}

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -1,7 +1,6 @@
 package backfill
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -85,13 +84,14 @@ func OpenDLQSpill(dir string) (*DLQSpill, error) {
 //
 // 🔴 崩溃可续传性（P1）：本 job 设计为可被中断后续跑（6h / 315 万行，中途崩溃是预期失败模式）。
 // Write 是裸 append、Sync 每批一次（在 checkpoint Advance 前），故**批中途崩溃会在 spill 尾部
-// 留一条未 fsync 的半写 NDJSON 行**。replay 必须：
-//   - **只容忍最后一段「无结尾换行」的半写尾行**——把它截掉（该行所属批从未 Sync、其源 id
-//     也从未 Advance，resume 会重读重写，截断安全）；
-//   - **任何「以换行结尾」的完整行解析失败仍致命**——append-only 顺序写下，损坏只会是后缀；
-//     一条已换行结尾却解析失败的行 = 真正的内部损坏（位翻转 / 人为篡改），绝不静默放过。
+// 留一条未 fsync 的撕裂记录**。非原子写回下，这条「最后一条记录」即便结尾换行已落盘，其更早的
+// 字节也可能仍是陈旧/垃圾（换行/文件长度先于内容到盘）。replay 规则：
+//   - **只对「最后一条记录」豁免**——解析失败即把它整条截掉（不论有无结尾换行）。该记录属于
+//     未 Sync 的批、其源 id 也从未 Advance，resume 会重读重写，截断绝对安全。
+//   - **最后一条之前的任何记录解析失败仍致命**——append-only 顺序写下，那是真正的内部损坏
+//     （位翻转 / 篡改），绝不静默放过。
 //
-// 截断尾部半行还防止下次 append 把「半行 + 新行」拼成一条真损坏行（再启动就会误判致命）。
+// 截断撕裂尾记录还防止下次 append 把「半记录 + 新记录」拼成一条真损坏行。
 func loadSeen(path string) (map[string]int64, error) {
 	seen := map[string]int64{}
 	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置，非用户输入
@@ -105,35 +105,48 @@ func loadSeen(path string) (map[string]int64, error) {
 		return seen, nil
 	}
 
-	// 以最后一个换行符切分：之前（含该换行）的是「完整行」区，之后的非空残留是未 fsync 的半写尾行。
-	lastNL := bytes.LastIndexByte(data, '\n')
-	completeBytes := data[:lastNL+1] // lastNL=-1（全文件无换行）时为空切片
-	tail := data[lastNL+1:]          // 最后一个换行之后的残留（torn tail，可能为空）
-
-	sc := bufio.NewScanner(bytes.NewReader(completeBytes))
-	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // 容忍大 payload 行
-	for sc.Scan() {
-		line := sc.Bytes()
-		if len(line) == 0 {
+	// 逐条扫描（记录以 '\n' 分隔；最后一段可能无结尾换行）。解析失败时区分「是否最后一条」：
+	// 仅最后一条豁免（截断），之前的致命。
+	var truncateAt int64 = -1
+	offset := 0
+	n := len(data)
+	for offset < n {
+		nl := bytes.IndexByte(data[offset:], '\n')
+		var line []byte
+		var lineEnd int // 本条记录末尾的下一个字节下标（含换行）
+		var isLast bool
+		if nl < 0 {
+			line = data[offset:]
+			lineEnd = n
+			isLast = true // 无结尾换行 ⇒ 必是最后的撕裂尾段
+		} else {
+			line = data[offset : offset+nl]
+			lineEnd = offset + nl + 1
+			isLast = lineEnd >= n // 换行后已无更多字节 ⇒ 这是最后一条记录
+		}
+		if len(bytes.TrimSpace(line)) == 0 {
+			offset = lineEnd // 跳过空行
 			continue
 		}
 		var rec dlqRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
-			// 已换行结尾的完整行损坏 = 真损坏（非末尾豁免），致命。
-			return nil, fmt.Errorf("backfill: corrupt non-trailing spill line during replay (real corruption, not an un-fsynced partial tail): %w", err)
+			if isLast {
+				truncateAt = int64(offset) // 从这条撕裂的最后记录起整条截掉
+				break
+			}
+			// 最后一条之前的完整记录损坏 = 真损坏，致命。
+			return nil, fmt.Errorf("backfill: corrupt non-final spill record during replay (real corruption, not an un-fsynced torn final append): %w", err)
 		}
 		seen[dedupKey(rec)] = rec.CreatedAt
-	}
-	if err := sc.Err(); err != nil {
-		return nil, fmt.Errorf("backfill: scan spill during replay: %w", err)
+		offset = lineEnd
 	}
 
-	// 截掉未 fsync 的半写尾行（崩溃恢复），让文件回到「全是完整行」的状态可继续 append。
-	if len(tail) > 0 {
-		if err := os.Truncate(path, int64(len(completeBytes))); err != nil {
-			return nil, fmt.Errorf("backfill: truncate torn trailing spill line (%d bytes) during crash recovery: %w", len(tail), err)
+	// 截掉未 fsync 的撕裂尾记录（崩溃恢复），让文件回到「全是完整记录」的状态可继续 append。
+	if truncateAt >= 0 {
+		if err := os.Truncate(path, truncateAt); err != nil {
+			return nil, fmt.Errorf("backfill: truncate torn trailing spill record (from byte %d) during crash recovery: %w", truncateAt, err)
 		}
-		fmt.Fprintf(os.Stderr, "backfill: recovered spill by truncating a %d-byte un-fsynced trailing partial line\n", len(tail))
+		fmt.Fprintf(os.Stderr, "backfill: recovered spill by truncating a %d-byte un-fsynced torn final record\n", int64(n)-truncateAt)
 	}
 	return seen, nil
 }

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -41,17 +43,28 @@ type dlqRecord struct {
 // DLQ 量级极小（真异常稀少；线上实测撤回都仅 0.21%、真不可解析的更罕见），故在内存保留全部
 // 记录（去重键 → created_at）以支持按窗计数，开销可忽略。
 type DLQSpill struct {
-	path string
+	path       string
+	offsetPath string
 
-	mu      sync.Mutex
-	f       *os.File
-	seen    map[string]int64 // dedup key (message_id) -> created_at（按窗计数用）
-	nowUnix func() int64
+	mu         sync.Mutex
+	f          *os.File
+	seen       map[string]int64 // dedup key (message_id) -> created_at（按窗计数用）
+	pendingLen int64            // 当前文件总字节数（含尚未 fsync 的 append）
+	syncedLen  int64            // 已 fsync 且已记入 offset sidecar 的持久长度（字节）
+	nowUnix    func() int64
 }
 
 // OpenDLQSpill 打开（或创建）spill 文件，并从既有内容重建去重集 + 计数（resume 安全）。
 // dir 为空表示禁用 spill——此时若 backfill 遇到 DLQ 行必须硬停（见 runner），绝不允许 DLQ 行
 // 静默消失破坏对账。
+//
+// 🔴 崩溃可续传性（P1，根因修法）：用一个持久 offset sidecar（`backfill-dlq.synced`）记录
+// 「已 fsync 的 spill 字节长度」。Sync() 在每批 fsync spill 内容后，把当时长度原子写入 sidecar
+// （temp+rename）。重开时把 spill **截断到 sidecar 记录的 offset**——丢弃其后**全部**未 fsync 的
+// 脏后缀（可能是单条撕裂、也可能是一批多条 append 中途崩溃留下的多条脏记录）。这段脏后缀对应的
+// 源 id 从未 Advance 过 checkpoint（Advance 在 Sync 之后），resume 必重读重写，丢弃绝对安全。
+// 截断后只解析 [0, offset) 这段「既 fsync 又与 checkpoint 一致」的干净前缀——其中任何解析失败都是
+// 真损坏（位翻转/篡改），致命。这样彻底取代了「猜哪条是撕裂尾行」的脆弱启发式。
 func OpenDLQSpill(dir string) (*DLQSpill, error) {
 	if dir == "" {
 		return nil, fmt.Errorf("backfill: DLQ spill dir is required (DLQ rows must be durably accounted; refuse to silently drop)")
@@ -60,10 +73,17 @@ func OpenDLQSpill(dir string) (*DLQSpill, error) {
 		return nil, fmt.Errorf("backfill: mkdir spill dir: %w", err)
 	}
 	path := filepath.Join(dir, "backfill-dlq.ndjson")
-	seen, err := loadSeen(path)
+	offsetPath := filepath.Join(dir, "backfill-dlq.synced")
+
+	syncedLen, err := readSyncedOffset(offsetPath)
 	if err != nil {
 		return nil, err
 	}
+	seen, err := recoverAndLoad(path, syncedLen)
+	if err != nil {
+		return nil, err
+	}
+
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
 	if err != nil {
 		return nil, fmt.Errorf("backfill: open spill file: %w", err)
@@ -77,77 +97,82 @@ func OpenDLQSpill(dir string) (*DLQSpill, error) {
 		}
 		return nil, err
 	}
-	return &DLQSpill{path: path, f: f, seen: seen, nowUnix: func() int64 { return time.Now().Unix() }}, nil
+	return &DLQSpill{
+		path: path, offsetPath: offsetPath, f: f, seen: seen,
+		pendingLen: syncedLen, syncedLen: syncedLen,
+		nowUnix: func() int64 { return time.Now().Unix() },
+	}, nil
 }
 
-// loadSeen 从既有 spill 文件重建「去重键 → created_at」集（resume 时计数不归零、写入幂等）。
-//
-// 🔴 崩溃可续传性（P1）：本 job 设计为可被中断后续跑（6h / 315 万行，中途崩溃是预期失败模式）。
-// Write 是裸 append、Sync 每批一次（在 checkpoint Advance 前），故**批中途崩溃会在 spill 尾部
-// 留一条未 fsync 的撕裂记录**。非原子写回下，这条「最后一条记录」即便结尾换行已落盘，其更早的
-// 字节也可能仍是陈旧/垃圾（换行/文件长度先于内容到盘）。replay 规则：
-//   - **只对「最后一条记录」豁免**——解析失败即把它整条截掉（不论有无结尾换行）。该记录属于
-//     未 Sync 的批、其源 id 也从未 Advance，resume 会重读重写，截断绝对安全。
-//   - **最后一条之前的任何记录解析失败仍致命**——append-only 顺序写下，那是真正的内部损坏
-//     （位翻转 / 篡改），绝不静默放过。
-//
-// 截断撕裂尾记录还防止下次 append 把「半记录 + 新记录」拼成一条真损坏行。
-func loadSeen(path string) (map[string]int64, error) {
-	seen := map[string]int64{}
-	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置，非用户输入
+// readSyncedOffset 读 offset sidecar（不存在/空 → 0：表示尚无任何已 fsync 的 spill 前缀）。
+// sidecar 由 temp+rename 原子写，故不会出现撕裂；解析失败即真损坏 → 致命。
+func readSyncedOffset(offsetPath string) (int64, error) {
+	data, err := os.ReadFile(offsetPath) //nolint:gosec // path 来自运维配置
 	if err != nil {
 		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("backfill: read spill offset sidecar: %w", err)
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return 0, nil
+	}
+	off, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || off < 0 {
+		return 0, fmt.Errorf("backfill: corrupt spill offset sidecar %q (atomic-rename written, so this is real corruption): %v", s, err)
+	}
+	return off, nil
+}
+
+// recoverAndLoad 把 spill 截断到 syncedLen（丢弃未 fsync 的脏后缀），再严格解析 [0, syncedLen)
+// 干净前缀，重建去重集 + 计数。
+func recoverAndLoad(path string, syncedLen int64) (map[string]int64, error) {
+	seen := map[string]int64{}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if syncedLen != 0 {
+				return nil, fmt.Errorf("backfill: spill offset sidecar says %d bytes but spill file is missing (durability state lost; manual inspection required)", syncedLen)
+			}
 			return seen, nil
 		}
-		return nil, fmt.Errorf("backfill: open spill for replay: %w", err)
+		return nil, fmt.Errorf("backfill: stat spill file: %w", err)
 	}
-	if len(data) == 0 {
+	size := info.Size()
+	if size < syncedLen {
+		// 文件比已记录的同步长度还短：持久层不一致（被外部截断/损坏），不可静默放过。
+		return nil, fmt.Errorf("backfill: spill file (%d bytes) shorter than synced offset (%d) — durability state lost; manual inspection required", size, syncedLen)
+	}
+	if size > syncedLen {
+		// 丢弃 syncedLen 之后的未 fsync 脏后缀（崩溃恢复；这段对应的源 id 从未 Advance 过 checkpoint）。
+		if err := os.Truncate(path, syncedLen); err != nil {
+			return nil, fmt.Errorf("backfill: truncate un-synced dirty spill suffix (%d -> %d bytes) during crash recovery: %w", size, syncedLen, err)
+		}
+		fmt.Fprintf(os.Stderr, "backfill: recovered spill by truncating a %d-byte un-fsynced dirty suffix to synced offset %d\n", size-syncedLen, syncedLen)
+	}
+	if syncedLen == 0 {
 		return seen, nil
 	}
 
-	// 逐条扫描（记录以 '\n' 分隔；最后一段可能无结尾换行）。崩溃恢复规则：
-	//   - **无结尾换行的最后一段**：恒视为撕裂尾记录 → 截掉（即便能解析）。没有持久化的换行分隔符
-	//     就意味着下次 append 会把新记录直接拼到它后面成一条真损坏行；且该记录属未 Sync 批、源 id
-	//     未 Advance，resume 会重写，截断绝对安全。
-	//   - **有结尾换行的最后一条记录解析失败**：非原子写回下换行可能先于更早字节到盘，故也视为撕裂
-	//     → 截掉。
-	//   - **最后一条之前的任何记录解析失败**：append-only 顺序写下的真损坏（位翻转/篡改），致命。
-	var truncateAt int64 = -1
-	offset := 0
-	n := len(data)
-	for offset < n {
-		nl := bytes.IndexByte(data[offset:], '\n')
-		if nl < 0 {
-			// 无结尾换行的最后一段：撕裂尾记录，整条截掉（不论能否解析）。
-			truncateAt = int64(offset)
-			break
-		}
-		line := data[offset : offset+nl]
-		lineEnd := offset + nl + 1
-		isLast := lineEnd >= n // 换行后已无更多字节 ⇒ 这是最后一条（已带分隔符的）记录
+	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置
+	if err != nil {
+		return nil, fmt.Errorf("backfill: read spill for replay: %w", err)
+	}
+	// [0, syncedLen) 是既 fsync、又与 checkpoint 一致的干净前缀：必由完整记录构成、以换行结尾。
+	// 任何偏差（非换行结尾 / 解析失败）都是该持久区内的真损坏，致命。
+	if data[len(data)-1] != '\n' {
+		return nil, fmt.Errorf("backfill: synced spill prefix does not end at a record boundary (real corruption)")
+	}
+	for _, line := range bytes.Split(data[:len(data)-1], []byte{'\n'}) {
 		if len(bytes.TrimSpace(line)) == 0 {
-			offset = lineEnd // 跳过空行
 			continue
 		}
 		var rec dlqRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
-			if isLast {
-				truncateAt = int64(offset) // 撕裂的最后记录（换行先到盘）→ 整条截掉
-				break
-			}
-			// 最后一条之前的完整记录损坏 = 真损坏，致命。
-			return nil, fmt.Errorf("backfill: corrupt non-final spill record during replay (real corruption, not an un-fsynced torn final append): %w", err)
+			return nil, fmt.Errorf("backfill: corrupt record in synced spill prefix during replay (real corruption): %w", err)
 		}
 		seen[dedupKey(rec)] = rec.CreatedAt
-		offset = lineEnd
-	}
-
-	// 截掉未 fsync 的撕裂尾记录（崩溃恢复），让文件回到「全是带分隔符的完整记录」状态可继续 append。
-	if truncateAt >= 0 {
-		if err := os.Truncate(path, truncateAt); err != nil {
-			return nil, fmt.Errorf("backfill: truncate torn trailing spill record (from byte %d) during crash recovery: %w", truncateAt, err)
-		}
-		fmt.Fprintf(os.Stderr, "backfill: recovered spill by truncating a %d-byte un-fsynced torn final record\n", int64(n)-truncateAt)
 	}
 	return seen, nil
 }
@@ -192,9 +217,11 @@ func (s *DLQSpill) Write(rec dlqRecord) error {
 	if err != nil {
 		return fmt.Errorf("backfill: marshal dlq record (id=%d msg=%s): %w", rec.ID, rec.MessageID, err)
 	}
-	if _, err := s.f.Write(append(data, '\n')); err != nil {
+	line := append(data, '\n')
+	if _, err := s.f.Write(line); err != nil {
 		return fmt.Errorf("backfill: write dlq spill (id=%d msg=%s): %w", rec.ID, rec.MessageID, err)
 	}
+	s.pendingLen += int64(len(line))
 	s.seen[key] = rec.CreatedAt
 	return nil
 }
@@ -228,17 +255,71 @@ func (s *DLQSpill) CountInWindow(fromUnix, toUnix int64) int64 {
 	return n
 }
 
-// Sync 把已 append 的 DLQ 记录刷盘（fsync）。**必须在推进 checkpoint 前调用**：否则主机崩溃 /
-// 延迟写回失败可能让 checkpoint 跳过某些 id，而它们的 DLQ 记录尚未落盘 → resume 后 DLQ 漏计、
-// 该行不经手动回退 checkpoint 不可恢复（durability ordering：先让 DLQ 落盘，再推进游标）。
+// Sync 把已 append 的 DLQ 记录刷盘（fsync），再原子推进 offset sidecar 到当前文件长度。
+// **必须在推进 checkpoint 前调用**：否则主机崩溃 / 延迟写回失败可能让 checkpoint 跳过某些 id，
+// 而它们的 DLQ 记录尚未落盘 → resume 后 DLQ 漏计、该行不经手动回退 checkpoint 不可恢复
+// （durability ordering：先让 DLQ 落盘 + offset 记账，再推进游标）。
+//
+// 顺序保证崩溃可恢复：先 fsync spill 内容（[0,pendingLen) 全部持久），再原子写 offset=pendingLen。
+// 若崩在「fsync 后、写 sidecar 前」，offset 仍是旧值，多出的已 fsync 后缀会在重开时被当脏后缀
+// 截掉——保守但安全（那批 checkpoint 也没推进，resume 会重写）。
 func (s *DLQSpill) Sync() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.f == nil {
 		return nil
 	}
+	if s.pendingLen == s.syncedLen {
+		return nil // 无新增，免去重复 fsync / sidecar 写
+	}
 	if err := s.f.Sync(); err != nil {
 		return fmt.Errorf("backfill: sync dlq spill: %w", err)
+	}
+	if err := writeSyncedOffset(s.offsetPath, s.pendingLen); err != nil {
+		return err
+	}
+	s.syncedLen = s.pendingLen
+	return nil
+}
+
+// writeSyncedOffset 原子写 offset sidecar（temp + fsync + rename + fsync dir），使其本身崩溃可恢复。
+func writeSyncedOffset(offsetPath string, off int64) error {
+	dir := filepath.Dir(offsetPath)
+	tmp, err := os.CreateTemp(dir, ".backfill-dlq-synced-*.tmp")
+	if err != nil {
+		return fmt.Errorf("backfill: create temp offset sidecar: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		if rerr := os.Remove(tmpName); rerr != nil && !os.IsNotExist(rerr) {
+			fmt.Fprintf(os.Stderr, "backfill: cleanup temp offset sidecar %s: %v\n", tmpName, rerr)
+		}
+	}
+	closeTmp := func() {
+		if cerr := tmp.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "backfill: close temp offset sidecar %s: %v\n", tmpName, cerr)
+		}
+	}
+	if _, err := tmp.WriteString(strconv.FormatInt(off, 10)); err != nil {
+		closeTmp()
+		cleanup()
+		return fmt.Errorf("backfill: write temp offset sidecar: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		closeTmp()
+		cleanup()
+		return fmt.Errorf("backfill: sync temp offset sidecar: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("backfill: close temp offset sidecar: %w", err)
+	}
+	if err := os.Rename(tmpName, offsetPath); err != nil {
+		cleanup()
+		return fmt.Errorf("backfill: rename offset sidecar into place: %w", err)
+	}
+	if err := fsyncDir(dir); err != nil {
+		return err
 	}
 	return nil
 }
@@ -246,14 +327,25 @@ func (s *DLQSpill) Sync() error {
 // Path 返回 spill 文件路径（日志 / 运维用）。
 func (s *DLQSpill) Path() string { return s.path }
 
-// Close 把缓冲刷盘并关闭文件。
+// Close 把缓冲刷盘（fsync）、推进 offset sidecar 到当前长度，再关闭文件。
+// Close 是**优雅停止**路径（非崩溃），故把已写入的记录全部标记为持久（推进 sidecar）——
+// 与 Sync 同样的「先 fsync 内容、再原子写 sidecar」顺序，下次重开不会把这些已落盘记录当脏后缀截掉。
 func (s *DLQSpill) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.f == nil {
 		return nil
 	}
-	err := s.f.Sync()
+	var err error
+	if s.pendingLen != s.syncedLen {
+		if serr := s.f.Sync(); serr != nil {
+			err = fmt.Errorf("backfill: sync dlq spill on close: %w", serr)
+		} else if oerr := writeSyncedOffset(s.offsetPath, s.pendingLen); oerr != nil {
+			err = oerr
+		} else {
+			s.syncedLen = s.pendingLen
+		}
+	}
 	if cerr := s.f.Close(); cerr != nil && err == nil {
 		err = cerr
 	}

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -2,6 +2,7 @@ package backfill
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -81,22 +82,35 @@ func OpenDLQSpill(dir string) (*DLQSpill, error) {
 }
 
 // loadSeen 从既有 spill 文件重建「去重键 → created_at」集（resume 时计数不归零、写入幂等）。
+//
+// 🔴 崩溃可续传性（P1）：本 job 设计为可被中断后续跑（6h / 315 万行，中途崩溃是预期失败模式）。
+// Write 是裸 append、Sync 每批一次（在 checkpoint Advance 前），故**批中途崩溃会在 spill 尾部
+// 留一条未 fsync 的半写 NDJSON 行**。replay 必须：
+//   - **只容忍最后一段「无结尾换行」的半写尾行**——把它截掉（该行所属批从未 Sync、其源 id
+//     也从未 Advance，resume 会重读重写，截断安全）；
+//   - **任何「以换行结尾」的完整行解析失败仍致命**——append-only 顺序写下，损坏只会是后缀；
+//     一条已换行结尾却解析失败的行 = 真正的内部损坏（位翻转 / 人为篡改），绝不静默放过。
+//
+// 截断尾部半行还防止下次 append 把「半行 + 新行」拼成一条真损坏行（再启动就会误判致命）。
 func loadSeen(path string) (map[string]int64, error) {
 	seen := map[string]int64{}
-	f, err := os.Open(path) //nolint:gosec // path 来自运维配置，非用户输入
+	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置，非用户输入
 	if err != nil {
 		if os.IsNotExist(err) {
 			return seen, nil
 		}
 		return nil, fmt.Errorf("backfill: open spill for replay: %w", err)
 	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil {
-			// 只读句柄关闭失败不致命，但记一笔以免静默。
-			fmt.Fprintf(os.Stderr, "backfill: close spill replay handle: %v\n", cerr)
-		}
-	}()
-	sc := bufio.NewScanner(f)
+	if len(data) == 0 {
+		return seen, nil
+	}
+
+	// 以最后一个换行符切分：之前（含该换行）的是「完整行」区，之后的非空残留是未 fsync 的半写尾行。
+	lastNL := bytes.LastIndexByte(data, '\n')
+	completeBytes := data[:lastNL+1] // lastNL=-1（全文件无换行）时为空切片
+	tail := data[lastNL+1:]          // 最后一个换行之后的残留（torn tail，可能为空）
+
+	sc := bufio.NewScanner(bytes.NewReader(completeBytes))
 	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // 容忍大 payload 行
 	for sc.Scan() {
 		line := sc.Bytes()
@@ -105,12 +119,21 @@ func loadSeen(path string) (map[string]int64, error) {
 		}
 		var rec dlqRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
-			return nil, fmt.Errorf("backfill: corrupt spill line during replay: %w", err)
+			// 已换行结尾的完整行损坏 = 真损坏（非末尾豁免），致命。
+			return nil, fmt.Errorf("backfill: corrupt non-trailing spill line during replay (real corruption, not an un-fsynced partial tail): %w", err)
 		}
 		seen[dedupKey(rec)] = rec.CreatedAt
 	}
 	if err := sc.Err(); err != nil {
 		return nil, fmt.Errorf("backfill: scan spill during replay: %w", err)
+	}
+
+	// 截掉未 fsync 的半写尾行（崩溃恢复），让文件回到「全是完整行」的状态可继续 append。
+	if len(tail) > 0 {
+		if err := os.Truncate(path, int64(len(completeBytes))); err != nil {
+			return nil, fmt.Errorf("backfill: truncate torn trailing spill line (%d bytes) during crash recovery: %w", len(tail), err)
+		}
+		fmt.Fprintf(os.Stderr, "backfill: recovered spill by truncating a %d-byte un-fsynced trailing partial line\n", len(tail))
 	}
 	return seen, nil
 }

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -105,25 +105,26 @@ func loadSeen(path string) (map[string]int64, error) {
 		return seen, nil
 	}
 
-	// 逐条扫描（记录以 '\n' 分隔；最后一段可能无结尾换行）。解析失败时区分「是否最后一条」：
-	// 仅最后一条豁免（截断），之前的致命。
+	// 逐条扫描（记录以 '\n' 分隔；最后一段可能无结尾换行）。崩溃恢复规则：
+	//   - **无结尾换行的最后一段**：恒视为撕裂尾记录 → 截掉（即便能解析）。没有持久化的换行分隔符
+	//     就意味着下次 append 会把新记录直接拼到它后面成一条真损坏行；且该记录属未 Sync 批、源 id
+	//     未 Advance，resume 会重写，截断绝对安全。
+	//   - **有结尾换行的最后一条记录解析失败**：非原子写回下换行可能先于更早字节到盘，故也视为撕裂
+	//     → 截掉。
+	//   - **最后一条之前的任何记录解析失败**：append-only 顺序写下的真损坏（位翻转/篡改），致命。
 	var truncateAt int64 = -1
 	offset := 0
 	n := len(data)
 	for offset < n {
 		nl := bytes.IndexByte(data[offset:], '\n')
-		var line []byte
-		var lineEnd int // 本条记录末尾的下一个字节下标（含换行）
-		var isLast bool
 		if nl < 0 {
-			line = data[offset:]
-			lineEnd = n
-			isLast = true // 无结尾换行 ⇒ 必是最后的撕裂尾段
-		} else {
-			line = data[offset : offset+nl]
-			lineEnd = offset + nl + 1
-			isLast = lineEnd >= n // 换行后已无更多字节 ⇒ 这是最后一条记录
+			// 无结尾换行的最后一段：撕裂尾记录，整条截掉（不论能否解析）。
+			truncateAt = int64(offset)
+			break
 		}
+		line := data[offset : offset+nl]
+		lineEnd := offset + nl + 1
+		isLast := lineEnd >= n // 换行后已无更多字节 ⇒ 这是最后一条（已带分隔符的）记录
 		if len(bytes.TrimSpace(line)) == 0 {
 			offset = lineEnd // 跳过空行
 			continue
@@ -131,7 +132,7 @@ func loadSeen(path string) (map[string]int64, error) {
 		var rec dlqRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
 			if isLast {
-				truncateAt = int64(offset) // 从这条撕裂的最后记录起整条截掉
+				truncateAt = int64(offset) // 撕裂的最后记录（换行先到盘）→ 整条截掉
 				break
 			}
 			// 最后一条之前的完整记录损坏 = 真损坏，致命。
@@ -141,7 +142,7 @@ func loadSeen(path string) (map[string]int64, error) {
 		offset = lineEnd
 	}
 
-	// 截掉未 fsync 的撕裂尾记录（崩溃恢复），让文件回到「全是完整记录」的状态可继续 append。
+	// 截掉未 fsync 的撕裂尾记录（崩溃恢复），让文件回到「全是带分隔符的完整记录」状态可继续 append。
 	if truncateAt >= 0 {
 		if err := os.Truncate(path, truncateAt); err != nil {
 			return nil, fmt.Errorf("backfill: truncate torn trailing spill record (from byte %d) during crash recovery: %w", truncateAt, err)

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -1,0 +1,225 @@
+package backfill
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// dlqRecord 是 backfill 路径下「真异常 / ES 永久拒绝」消息的本地 DLQ 落地记录。
+//
+// 与实时 consumer 的区别：实时 indexer 有 Kafka DLQ topic 可投；backfill **绕开 Kafka**，
+// 这两类「没进 ES 正文索引」的行无 topic 可投，故落本地 spill 文件并精确计数。该计数是阶段 6
+// 对账门的权威 DLQ 输入（"ES 去重 + DLQ + 已知排除 == 源行数"）。
+type dlqRecord struct {
+	Reason    string `json:"reason"`     // backfill_payload_unparseable / permanent_es_reject
+	Table     string `json:"table"`      // 源分表
+	ID        int64  `json:"id"`         // 源自增 id
+	MessageID string `json:"message_id"` // 源 message_id（= 本应的 ES _id；去重键）
+	Payload   []byte `json:"payload"`    // 原始 payload 字节（供排查 / 回灌）
+	CreatedAt int64  `json:"created_at"` // 源行 created_at（纪元秒），用于按窗对账
+	SpilledAt int64  `json:"spilled_at"` // 落地时间（纪元秒）
+}
+
+// DLQSpill 把 backfill 的 DLQ 行可靠落地到本地文件并精确计数（对账门权威输入）。
+//
+// 设计（吸取 codex review 的 3 个 DLQ-accounting 缺陷）：
+//   - **spill 文件是去重后的真相源**：以 message_id 为去重键（= ES _id，每条消息唯一）。
+//     重开时**从既有文件重建去重集 + 计数**（修：resume 后 Count 归零会让 inline reconcile
+//     把已 DLQ 的行当 ES 缺失，误报 mismatch）。
+//   - **写入幂等**：同一 message_id 重复 Write 是 no-op（修：批在 DLQ 写之后、checkpoint
+//     推进之前崩溃，resume 重读同一行会重复 append/计数，膨胀 DLQ）。这与「整条管线
+//     `_id=message_id` 幂等」口径一致。
+//   - **按窗计数**：CountInWindow 只数 created_at ∈ 窗的记录（修：reconcile 窗不覆盖整个 run
+//     时，用全量 dlqCount 会把窗外的 DLQ 行也减掉 → false mismatch/false OK）。
+//   - **fail-closed**：任一 spill 写盘失败立即返回错误，调用方须 STOP（真异常绝不静默消失）。
+//
+// DLQ 量级极小（真异常稀少；线上实测撤回都仅 0.21%、真不可解析的更罕见），故在内存保留全部
+// 记录（去重键 → created_at）以支持按窗计数，开销可忽略。
+type DLQSpill struct {
+	path string
+
+	mu      sync.Mutex
+	f       *os.File
+	seen    map[string]int64 // dedup key (message_id) -> created_at（按窗计数用）
+	nowUnix func() int64
+}
+
+// OpenDLQSpill 打开（或创建）spill 文件，并从既有内容重建去重集 + 计数（resume 安全）。
+// dir 为空表示禁用 spill——此时若 backfill 遇到 DLQ 行必须硬停（见 runner），绝不允许 DLQ 行
+// 静默消失破坏对账。
+func OpenDLQSpill(dir string) (*DLQSpill, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("backfill: DLQ spill dir is required (DLQ rows must be durably accounted; refuse to silently drop)")
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("backfill: mkdir spill dir: %w", err)
+	}
+	path := filepath.Join(dir, "backfill-dlq.ndjson")
+	seen, err := loadSeen(path)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return nil, fmt.Errorf("backfill: open spill file: %w", err)
+	}
+	// fsync 父目录，让新建的 spill 文件「目录项」本身可崩溃恢复——否则 host 崩溃后 checkpoint
+	// 可能存活而 backfill-dlq.ndjson 整个消失，replay 漏计该文件里所有已被游标越过的 DLQ 行。
+	// 文件内容的 fsync 由 Sync()/Close() 负责；这里补的是目录项的 fsync（仅创建时一次性成本）。
+	if err := fsyncDir(dir); err != nil {
+		if cerr := f.Close(); cerr != nil {
+			return nil, fmt.Errorf("backfill: %w (and close spill: %v)", err, cerr)
+		}
+		return nil, err
+	}
+	return &DLQSpill{path: path, f: f, seen: seen, nowUnix: func() int64 { return time.Now().Unix() }}, nil
+}
+
+// loadSeen 从既有 spill 文件重建「去重键 → created_at」集（resume 时计数不归零、写入幂等）。
+func loadSeen(path string) (map[string]int64, error) {
+	seen := map[string]int64{}
+	f, err := os.Open(path) //nolint:gosec // path 来自运维配置，非用户输入
+	if err != nil {
+		if os.IsNotExist(err) {
+			return seen, nil
+		}
+		return nil, fmt.Errorf("backfill: open spill for replay: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			// 只读句柄关闭失败不致命，但记一笔以免静默。
+			fmt.Fprintf(os.Stderr, "backfill: close spill replay handle: %v\n", cerr)
+		}
+	}()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // 容忍大 payload 行
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec dlqRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return nil, fmt.Errorf("backfill: corrupt spill line during replay: %w", err)
+		}
+		seen[dedupKey(rec)] = rec.CreatedAt
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("backfill: scan spill during replay: %w", err)
+	}
+	return seen, nil
+}
+
+// dedupKey 以 message_id 为去重键（= ES _id，每条消息唯一）；空 message_id 退化为 table:id。
+func dedupKey(rec dlqRecord) string {
+	if rec.MessageID != "" {
+		return rec.MessageID
+	}
+	return fmt.Sprintf("%s:%d", rec.Table, rec.ID)
+}
+
+// fsyncDir 打开并 fsync 一个目录，使其下新建 / 重命名的目录项可崩溃恢复。
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir) //nolint:gosec // dir 来自运维配置，非用户输入
+	if err != nil {
+		return fmt.Errorf("backfill: open spill dir for fsync: %w", err)
+	}
+	syncErr := d.Sync()
+	closeErr := d.Close()
+	if syncErr != nil {
+		return fmt.Errorf("backfill: fsync spill dir: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("backfill: close spill dir after fsync: %w", closeErr)
+	}
+	return nil
+}
+
+// Write 幂等落地一条 DLQ 记录：同一去重键已存在则 no-op（不重复 append/计数）；否则 append
+// 并记入去重集。写盘失败返回错误（fail-closed）。
+func (s *DLQSpill) Write(rec dlqRecord) error {
+	key := dedupKey(rec)
+	rec.Reason = reasonOrDefault(rec.Reason)
+	rec.SpilledAt = s.nowUnix()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.seen[key]; ok {
+		return nil // 幂等：该源行已记账，不重复
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("backfill: marshal dlq record (id=%d msg=%s): %w", rec.ID, rec.MessageID, err)
+	}
+	if _, err := s.f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("backfill: write dlq spill (id=%d msg=%s): %w", rec.ID, rec.MessageID, err)
+	}
+	s.seen[key] = rec.CreatedAt
+	return nil
+}
+
+// reasonOrDefault 给未显式置 reason 的记录补默认（payload 不可解析）。
+func reasonOrDefault(r string) string {
+	if r == "" {
+		return "backfill_payload_unparseable"
+	}
+	return r
+}
+
+// Count 返回已记账的去重 DLQ 记录总数（日志 / 全量对账用）。
+func (s *DLQSpill) Count() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return int64(len(s.seen))
+}
+
+// CountInWindow 返回 created_at ∈ [fromUnix, toUnix] 的去重 DLQ 记录数（按窗对账门用）。
+// 与 internal/recon 的 range filter（gte/lte）口径一致。
+func (s *DLQSpill) CountInWindow(fromUnix, toUnix int64) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var n int64
+	for _, createdAt := range s.seen {
+		if createdAt >= fromUnix && createdAt <= toUnix {
+			n++
+		}
+	}
+	return n
+}
+
+// Sync 把已 append 的 DLQ 记录刷盘（fsync）。**必须在推进 checkpoint 前调用**：否则主机崩溃 /
+// 延迟写回失败可能让 checkpoint 跳过某些 id，而它们的 DLQ 记录尚未落盘 → resume 后 DLQ 漏计、
+// 该行不经手动回退 checkpoint 不可恢复（durability ordering：先让 DLQ 落盘，再推进游标）。
+func (s *DLQSpill) Sync() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.f == nil {
+		return nil
+	}
+	if err := s.f.Sync(); err != nil {
+		return fmt.Errorf("backfill: sync dlq spill: %w", err)
+	}
+	return nil
+}
+
+// Path 返回 spill 文件路径（日志 / 运维用）。
+func (s *DLQSpill) Path() string { return s.path }
+
+// Close 把缓冲刷盘并关闭文件。
+func (s *DLQSpill) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.f == nil {
+		return nil
+	}
+	err := s.f.Sync()
+	if cerr := s.f.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
+	s.f = nil
+	return err
+}

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -197,6 +198,14 @@ func writeRawSpill(t *testing.T, dir, content string) string {
 	return path
 }
 
+// writeSyncedSidecar 写 offset sidecar（模拟已 fsync 的持久长度）。
+func writeSyncedSidecar(t *testing.T, dir string, off int64) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "backfill-dlq.synced"), []byte(strconv.FormatInt(off, 10)), 0o640); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}
+
 // validLine 返回一条合法 NDJSON 记录行（含结尾换行）。
 func validLine(t *testing.T, mid string, createdAt int64) string {
 	t.Helper()
@@ -208,30 +217,29 @@ func validLine(t *testing.T, mid string, createdAt int64) string {
 	return string(b) + "\n"
 }
 
-// TestDLQSpill_RecoverTornTrailingLine 🔴 P1(a)：尾部半写行（无结尾换行）→ 优雅截断、启动成功，
-// 完整行计数正确，且文件被截到只剩完整行。
-func TestDLQSpill_RecoverTornTrailingLine(t *testing.T) {
+// TestDLQSpill_RecoverDirtySuffix 🔴 P1（根因）：sidecar 记录已 fsync 的前缀长度；崩溃留下的
+// 未 fsync 脏后缀（任意条数、任意撕裂形态）在重开时整段截到 sidecar offset，干净前缀完整保留。
+func TestDLQSpill_RecoverDirtySuffix(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")
-	// 两条完整行 + 一条未 fsync 的半写尾行（无换行结尾，且 JSON 被截断）。
-	torn := `{"reason":"backfill_payload_unparseable","message_id":"m3","created_at":300`
-	content := validLine(t, "m1", 100) + validLine(t, "m2", 200) + torn
-	path := writeRawSpill(t, dir, content)
+	clean := validLine(t, "m1", 100) + validLine(t, "m2", 200) // 已 fsync 的干净前缀
+	// 脏后缀：一条完整行 + 一条撕裂半行（模拟一批多条 append 中途崩溃）。
+	dirty := validLine(t, "m3", 300) + `{"message_id":"m4","created_at":40`
+	path := writeRawSpill(t, dir, clean+dirty)
+	writeSyncedSidecar(t, dir, int64(len(clean))) // 只有 clean 段被 fsync 过
 
 	s, err := OpenDLQSpill(dir)
 	if err != nil {
-		t.Fatalf("torn trailing line must recover, got error: %v", err)
+		t.Fatalf("dirty suffix must recover to sidecar offset, got: %v", err)
 	}
 	defer mustCloseT(t, s)
 	if s.Count() != 2 {
-		t.Fatalf("recovered count must be 2 (complete lines), got %d", s.Count())
+		t.Fatalf("recovered count must be 2 (synced prefix), got %d", s.Count())
 	}
-	// 文件应被截断到只剩两条完整行（torn 尾行已去除）。
-	data := mustRead(t, path)
-	if got := countLines(string(data)); got != 2 {
-		t.Fatalf("file must be truncated to 2 complete lines, got %d", got)
+	if got := countLines(string(mustRead(t, path))); got != 2 {
+		t.Fatalf("file must be truncated to the 2 synced lines, got %d", got)
 	}
-	// 截断后继续写一条新记录 → 仍是完整行，重开可再解析（不会和旧半行拼成损坏行）。
-	if err := s.Write(dlqRecord{MessageID: "m4", CreatedAt: 400}); err != nil {
+	// 续写后重开应得 3 条（脏后缀的 m3/m4 已被丢弃，不会拼成损坏行）。
+	if err := s.Write(dlqRecord{MessageID: "m5", CreatedAt: 500}); err != nil {
 		t.Fatalf("write after recovery: %v", err)
 	}
 	if cerr := s.Close(); cerr != nil {
@@ -247,44 +255,66 @@ func TestDLQSpill_RecoverTornTrailingLine(t *testing.T) {
 	}
 }
 
-// TestDLQSpill_NonTrailingCorruptionFatal 🔴 P1(b)：非末尾的完整行（以换行结尾）损坏 → 仍致命，
-// 拒绝启动（那是真损坏，不是未 fsync 的半行）。
-func TestDLQSpill_NonTrailingCorruptionFatal(t *testing.T) {
+// TestDLQSpill_CorruptionWithinSyncedPrefixFatal 🔴 已 fsync 前缀（[0,offset)）内的记录损坏 = 真损坏
+// （位翻转/篡改），致命拒启动——不被当作可丢弃的脏后缀。
+func TestDLQSpill_CorruptionWithinSyncedPrefixFatal(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")
-	// 第一行损坏但以换行结尾（=完整行损坏），后面跟一条合法行。
-	content := "{this is not valid json}\n" + validLine(t, "m2", 200)
-	writeRawSpill(t, dir, content)
+	// 前缀内：一条损坏完整行 + 一条合法行，整段都在 sidecar offset 之内。
+	prefix := "{this is not valid json}\n" + validLine(t, "m2", 200)
+	writeRawSpill(t, dir, prefix)
+	writeSyncedSidecar(t, dir, int64(len(prefix))) // 整个前缀都被「fsync 过」
 	if _, err := OpenDLQSpill(dir); err == nil {
-		t.Fatalf("non-trailing corrupt (newline-terminated) line must be fatal")
+		t.Fatalf("corruption within the synced prefix must be fatal")
 	}
 }
 
-// TestDLQSpill_RecoverNewlineTerminatedFinalCorrupt 🔴 P1（精修）：非原子写回下，最后一条记录
-// 即便结尾换行已落盘，更早字节也可能陈旧。故**最后一条记录**解析失败（即便以换行结尾）→ 截断恢复，
-// 不致命（它属未 Sync 批、源 id 未 Advance，resume 会重写）。
-func TestDLQSpill_RecoverNewlineTerminatedFinalCorrupt(t *testing.T) {
+// TestDLQSpill_SyncedPrefixNotEndingAtBoundaryFatal sidecar offset 落在记录中间（前缀不以换行结尾）
+// = 持久状态不一致，致命。
+func TestDLQSpill_SyncedPrefixNotEndingAtBoundaryFatal(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")
-	// 一条合法完整行 + 最后一条「以换行结尾但损坏」的记录（撕裂的最终 append）。
-	content := validLine(t, "m1", 100) + "{half-written-final-record}\n"
-	path := writeRawSpill(t, dir, content)
+	line := validLine(t, "m1", 100)
+	writeRawSpill(t, dir, line)
+	writeSyncedSidecar(t, dir, int64(len(line))-3) // 截在记录中间
+	if _, err := OpenDLQSpill(dir); err == nil {
+		t.Fatalf("synced offset not at a record boundary must be fatal")
+	}
+}
+
+// TestDLQSpill_NoSidecarTruncatesAll 无 sidecar（offset=0）+ 既有内容 → 视为全未 fsync，截到 0。
+// （首次崩溃在第一批 Sync 之前的退化情形；那批 checkpoint 也没推进，resume 重写。）
+func TestDLQSpill_NoSidecarTruncatesAll(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	path := writeRawSpill(t, dir, validLine(t, "m1", 100)+validLine(t, "m2", 200))
 	s, err := OpenDLQSpill(dir)
 	if err != nil {
-		t.Fatalf("newline-terminated torn FINAL record must recover (truncate), got: %v", err)
+		t.Fatalf("no sidecar must recover (truncate all), got: %v", err)
 	}
 	defer mustCloseT(t, s)
-	if s.Count() != 1 {
-		t.Fatalf("recovered count must be 1 (the valid line), got %d", s.Count())
+	if s.Count() != 0 {
+		t.Fatalf("no sidecar => everything un-synced => count 0, got %d", s.Count())
 	}
-	if got := countLines(string(mustRead(t, path))); got != 1 {
-		t.Fatalf("torn final record must be truncated, file should have 1 line, got %d", got)
+	if got := countLines(string(mustRead(t, path))); got != 0 {
+		t.Fatalf("file must be truncated to empty, got %d lines", got)
 	}
 }
 
-// TestDLQSpill_AllCompleteLinesNoTruncate 全是完整行（末行有换行）→ 不截断、不豁免，全部计入。
-func TestDLQSpill_AllCompleteLinesNoTruncate(t *testing.T) {
+// TestDLQSpill_FileShorterThanSidecarFatal 文件比 sidecar 记录的同步长度还短 → 持久状态丢失，致命。
+func TestDLQSpill_FileShorterThanSidecarFatal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	line := validLine(t, "m1", 100)
+	writeRawSpill(t, dir, line)
+	writeSyncedSidecar(t, dir, int64(len(line))+50) // 谎称同步长度超过文件实际大小
+	if _, err := OpenDLQSpill(dir); err == nil {
+		t.Fatalf("file shorter than synced offset must be fatal")
+	}
+}
+
+// TestDLQSpill_AllSyncedNoTruncate 全部内容都在 sidecar offset 内（已 fsync）→ 不截断、全部计入。
+func TestDLQSpill_AllSyncedNoTruncate(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")
 	content := validLine(t, "m1", 100) + validLine(t, "m2", 200)
 	path := writeRawSpill(t, dir, content)
+	writeSyncedSidecar(t, dir, int64(len(content))) // 整段都已 fsync
 	s, err := OpenDLQSpill(dir)
 	if err != nil {
 		t.Fatalf("open: %v", err)
@@ -294,11 +324,11 @@ func TestDLQSpill_AllCompleteLinesNoTruncate(t *testing.T) {
 		t.Fatalf("count=%d want 2", s.Count())
 	}
 	if got := countLines(string(mustRead(t, path))); got != 2 {
-		t.Fatalf("complete file must be untouched, got %d lines", got)
+		t.Fatalf("fully-synced file must be untouched, got %d lines", got)
 	}
 }
 
-// TestDLQSpill_TornSingleLineOnly 只有一条半写行（无完整行）→ 截断为空、启动成功、计数 0。
+// TestDLQSpill_TornSingleLineOnly 只有一条半写行（无 sidecar）→ 截断为空、启动成功、计数 0。
 func TestDLQSpill_TornSingleLineOnly(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")
 	writeRawSpill(t, dir, `{"message_id":"m1","created_at":1`)
@@ -308,45 +338,6 @@ func TestDLQSpill_TornSingleLineOnly(t *testing.T) {
 	}
 	defer mustCloseT(t, s)
 	if s.Count() != 0 {
-		t.Fatalf("count must be 0 after truncating the only (torn) line, got %d", s.Count())
-	}
-}
-
-// TestDLQSpill_ValidFinalRecordMissingNewlineTruncated 🔴 P1（精修2）：最后一条记录 JSON 完整可解析
-// 但缺结尾换行（崩溃时只丢了 '\n'）→ 仍视为撕裂截掉。否则文件无 NDJSON 分隔符，下次 append 会把
-// 新记录直接拼到它后面成一条真损坏行。截断后该源 id（未 Advance）resume 会重写，安全。
-func TestDLQSpill_ValidFinalRecordMissingNewlineTruncated(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "d")
-	// 一条带换行的完整行 + 一条「合法 JSON 但无结尾换行」的最后记录。
-	noNL := validLine(t, "m2", 200)
-	noNL = noNL[:len(noNL)-1] // 去掉结尾换行
-	content := validLine(t, "m1", 100) + noNL
-	path := writeRawSpill(t, dir, content)
-
-	s, err := OpenDLQSpill(dir)
-	if err != nil {
-		t.Fatalf("valid-but-newline-less final record must recover (truncate): %v", err)
-	}
-	// 截断后只剩第一条带分隔符的完整行。
-	if s.Count() != 1 {
-		t.Fatalf("count after truncating newline-less final record must be 1, got %d", s.Count())
-	}
-	// 续写一条新记录，重开应得 2 条（绝不和旧记录拼成损坏行）。
-	if err := s.Write(dlqRecord{MessageID: "m3", CreatedAt: 300}); err != nil {
-		t.Fatalf("write after recovery: %v", err)
-	}
-	if cerr := s.Close(); cerr != nil {
-		t.Fatalf("close: %v", cerr)
-	}
-	if got := countLines(string(mustRead(t, path))); got != 2 {
-		t.Fatalf("after recovery+append, file must have 2 clean NDJSON lines, got %d", got)
-	}
-	s2, err := OpenDLQSpill(dir)
-	if err != nil {
-		t.Fatalf("reopen must parse cleanly (no concatenated corrupt line): %v", err)
-	}
-	defer mustCloseT(t, s2)
-	if s2.Count() != 2 {
-		t.Fatalf("reopen count must be 2, got %d", s2.Count())
+		t.Fatalf("count must be 0 after truncating the only (un-synced) line, got %d", s.Count())
 	}
 }

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -259,6 +259,27 @@ func TestDLQSpill_NonTrailingCorruptionFatal(t *testing.T) {
 	}
 }
 
+// TestDLQSpill_RecoverNewlineTerminatedFinalCorrupt 🔴 P1（精修）：非原子写回下，最后一条记录
+// 即便结尾换行已落盘，更早字节也可能陈旧。故**最后一条记录**解析失败（即便以换行结尾）→ 截断恢复，
+// 不致命（它属未 Sync 批、源 id 未 Advance，resume 会重写）。
+func TestDLQSpill_RecoverNewlineTerminatedFinalCorrupt(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	// 一条合法完整行 + 最后一条「以换行结尾但损坏」的记录（撕裂的最终 append）。
+	content := validLine(t, "m1", 100) + "{half-written-final-record}\n"
+	path := writeRawSpill(t, dir, content)
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("newline-terminated torn FINAL record must recover (truncate), got: %v", err)
+	}
+	defer mustCloseT(t, s)
+	if s.Count() != 1 {
+		t.Fatalf("recovered count must be 1 (the valid line), got %d", s.Count())
+	}
+	if got := countLines(string(mustRead(t, path))); got != 1 {
+		t.Fatalf("torn final record must be truncated, file should have 1 line, got %d", got)
+	}
+}
+
 // TestDLQSpill_AllCompleteLinesNoTruncate 全是完整行（末行有换行）→ 不截断、不豁免，全部计入。
 func TestDLQSpill_AllCompleteLinesNoTruncate(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -1,7 +1,9 @@
 package backfill
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -179,5 +181,112 @@ func TestDLQSpill_Sync(t *testing.T) {
 	defer mustCloseT(t, s2)
 	if s2.Count() != 1 {
 		t.Fatalf("synced record must be visible to reopen, got %d", s2.Count())
+	}
+}
+
+// writeRawSpill 直接往 spill 文件写原始字节（模拟崩溃留下的尾部状态），不经 DLQSpill。
+func writeRawSpill(t *testing.T, dir, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "backfill-dlq.ndjson")
+	if err := os.WriteFile(path, []byte(content), 0o640); err != nil {
+		t.Fatalf("write raw spill: %v", err)
+	}
+	return path
+}
+
+// validLine 返回一条合法 NDJSON 记录行（含结尾换行）。
+func validLine(t *testing.T, mid string, createdAt int64) string {
+	t.Helper()
+	rec := dlqRecord{Reason: "backfill_payload_unparseable", MessageID: mid, CreatedAt: createdAt}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b) + "\n"
+}
+
+// TestDLQSpill_RecoverTornTrailingLine 🔴 P1(a)：尾部半写行（无结尾换行）→ 优雅截断、启动成功，
+// 完整行计数正确，且文件被截到只剩完整行。
+func TestDLQSpill_RecoverTornTrailingLine(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	// 两条完整行 + 一条未 fsync 的半写尾行（无换行结尾，且 JSON 被截断）。
+	torn := `{"reason":"backfill_payload_unparseable","message_id":"m3","created_at":300`
+	content := validLine(t, "m1", 100) + validLine(t, "m2", 200) + torn
+	path := writeRawSpill(t, dir, content)
+
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("torn trailing line must recover, got error: %v", err)
+	}
+	defer mustCloseT(t, s)
+	if s.Count() != 2 {
+		t.Fatalf("recovered count must be 2 (complete lines), got %d", s.Count())
+	}
+	// 文件应被截断到只剩两条完整行（torn 尾行已去除）。
+	data := mustRead(t, path)
+	if got := countLines(string(data)); got != 2 {
+		t.Fatalf("file must be truncated to 2 complete lines, got %d", got)
+	}
+	// 截断后继续写一条新记录 → 仍是完整行，重开可再解析（不会和旧半行拼成损坏行）。
+	if err := s.Write(dlqRecord{MessageID: "m4", CreatedAt: 400}); err != nil {
+		t.Fatalf("write after recovery: %v", err)
+	}
+	if cerr := s.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	s2, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("reopen after recovery+append must succeed: %v", err)
+	}
+	defer mustCloseT(t, s2)
+	if s2.Count() != 3 {
+		t.Fatalf("after recovery+append, count must be 3, got %d", s2.Count())
+	}
+}
+
+// TestDLQSpill_NonTrailingCorruptionFatal 🔴 P1(b)：非末尾的完整行（以换行结尾）损坏 → 仍致命，
+// 拒绝启动（那是真损坏，不是未 fsync 的半行）。
+func TestDLQSpill_NonTrailingCorruptionFatal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	// 第一行损坏但以换行结尾（=完整行损坏），后面跟一条合法行。
+	content := "{this is not valid json}\n" + validLine(t, "m2", 200)
+	writeRawSpill(t, dir, content)
+	if _, err := OpenDLQSpill(dir); err == nil {
+		t.Fatalf("non-trailing corrupt (newline-terminated) line must be fatal")
+	}
+}
+
+// TestDLQSpill_AllCompleteLinesNoTruncate 全是完整行（末行有换行）→ 不截断、不豁免，全部计入。
+func TestDLQSpill_AllCompleteLinesNoTruncate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	content := validLine(t, "m1", 100) + validLine(t, "m2", 200)
+	path := writeRawSpill(t, dir, content)
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	if s.Count() != 2 {
+		t.Fatalf("count=%d want 2", s.Count())
+	}
+	if got := countLines(string(mustRead(t, path))); got != 2 {
+		t.Fatalf("complete file must be untouched, got %d lines", got)
+	}
+}
+
+// TestDLQSpill_TornSingleLineOnly 只有一条半写行（无完整行）→ 截断为空、启动成功、计数 0。
+func TestDLQSpill_TornSingleLineOnly(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	writeRawSpill(t, dir, `{"message_id":"m1","created_at":1`)
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("single torn line must recover: %v", err)
+	}
+	defer mustCloseT(t, s)
+	if s.Count() != 0 {
+		t.Fatalf("count must be 0 after truncating the only (torn) line, got %d", s.Count())
 	}
 }

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -1,0 +1,183 @@
+package backfill
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestDLQSpill_WriteAndCount 写若干条 → 计数精确等于落盘行数。
+func TestDLQSpill_WriteAndCount(t *testing.T) {
+	s, err := OpenDLQSpill(filepath.Join(t.TempDir(), "d"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	for i := 0; i < 3; i++ {
+		if err := s.Write(dlqRecord{ID: int64(i), MessageID: fmt.Sprintf("m%d", i)}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if s.Count() != 3 {
+		t.Fatalf("count=%d want 3", s.Count())
+	}
+	data := mustRead(t, s.Path())
+	if got := countLines(string(data)); got != 3 {
+		t.Fatalf("file lines=%d want 3 (count must equal durable rows)", got)
+	}
+}
+
+// TestDLQSpill_EmptyDirRejected dir 为空 → 拒绝构造（真异常不得静默消失）。
+func TestDLQSpill_EmptyDirRejected(t *testing.T) {
+	if _, err := OpenDLQSpill(""); err == nil {
+		t.Fatalf("empty spill dir must be rejected (fail-closed)")
+	}
+}
+
+// TestDLQSpill_AppendAcrossOpens 重开同目录 → append，不截断旧记录。
+func TestDLQSpill_AppendAcrossOpens(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	s1, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s1.Write(dlqRecord{ID: 1, MessageID: "a"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if cerr := s1.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	s2, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s2)
+	if err := s2.Write(dlqRecord{ID: 2, MessageID: "b"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	data := mustRead(t, s2.Path())
+	if got := countLines(string(data)); got != 2 {
+		t.Fatalf("append across opens must keep both records, got %d lines", got)
+	}
+}
+
+func countLines(s string) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			n++
+		}
+	}
+	return n
+}
+
+// TestDLQSpill_IdempotentByMessageID 同一 message_id 重复 Write → no-op，不重复 append/计数
+// （codex P2-idempotency：批崩在 DLQ 写后、checkpoint 推进前，resume 重读同行不得膨胀 DLQ）。
+func TestDLQSpill_IdempotentByMessageID(t *testing.T) {
+	s, err := OpenDLQSpill(filepath.Join(t.TempDir(), "d"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	for i := 0; i < 5; i++ {
+		if err := s.Write(dlqRecord{ID: 7, MessageID: "same", CreatedAt: 100}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if s.Count() != 1 {
+		t.Fatalf("duplicate message_id must dedupe to 1, got %d", s.Count())
+	}
+	data := mustRead(t, s.Path())
+	if got := countLines(string(data)); got != 1 {
+		t.Fatalf("file must hold exactly 1 record, got %d lines", got)
+	}
+}
+
+// TestDLQSpill_ReplayCountOnReopen 重开既有 spill → Count 从文件重建，不归零
+// （codex P1：resume 后 Count 归零会让 inline reconcile 把已 DLQ 行当 ES 缺失 → false mismatch）。
+func TestDLQSpill_ReplayCountOnReopen(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	s1, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := s1.Write(dlqRecord{ID: int64(i), MessageID: fmt.Sprintf("m%d", i), CreatedAt: 100}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if cerr := s1.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	s2, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer mustCloseT(t, s2)
+	if s2.Count() != 3 {
+		t.Fatalf("reopen must rebuild count from spill file, got %d want 3", s2.Count())
+	}
+	// 重开后再写一条已存在的 → 仍幂等。
+	if err := s2.Write(dlqRecord{ID: 1, MessageID: "m1", CreatedAt: 100}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if s2.Count() != 3 {
+		t.Fatalf("re-writing an existing key after reopen must stay 3, got %d", s2.Count())
+	}
+}
+
+// TestDLQSpill_CountInWindow 仅数 created_at ∈ 窗的记录
+// （codex P2-window：窗不覆盖整个 run 时，用全量 DLQ 会减掉窗外行 → false mismatch/OK）。
+func TestDLQSpill_CountInWindow(t *testing.T) {
+	s, err := OpenDLQSpill(filepath.Join(t.TempDir(), "d"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	writes := []dlqRecord{
+		{ID: 1, MessageID: "before", CreatedAt: 50},
+		{ID: 2, MessageID: "in1", CreatedAt: 150},
+		{ID: 3, MessageID: "in2", CreatedAt: 200},
+		{ID: 4, MessageID: "after", CreatedAt: 500},
+	}
+	for _, w := range writes {
+		if err := s.Write(w); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if s.Count() != 4 {
+		t.Fatalf("total count=%d want 4", s.Count())
+	}
+	if got := s.CountInWindow(100, 300); got != 2 {
+		t.Fatalf("window [100,300] must count 2 (in1,in2), got %d", got)
+	}
+	// 边界含端点（gte/lte，与 recon range filter 一致）。
+	if got := s.CountInWindow(50, 50); got != 1 {
+		t.Fatalf("inclusive boundary must count 'before', got %d", got)
+	}
+}
+
+// TestDLQSpill_Sync Sync 刷盘后记录可被另一个只读 reopen 看到（落盘可见性）。
+func TestDLQSpill_Sync(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	if err := s.Write(dlqRecord{ID: 1, MessageID: "x", CreatedAt: 100}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := s.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	// 另一个 reopen（replay）应已能看到这条记录（已落盘）。
+	s2, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer mustCloseT(t, s2)
+	if s2.Count() != 1 {
+		t.Fatalf("synced record must be visible to reopen, got %d", s2.Count())
+	}
+}

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -311,3 +311,42 @@ func TestDLQSpill_TornSingleLineOnly(t *testing.T) {
 		t.Fatalf("count must be 0 after truncating the only (torn) line, got %d", s.Count())
 	}
 }
+
+// TestDLQSpill_ValidFinalRecordMissingNewlineTruncated 🔴 P1（精修2）：最后一条记录 JSON 完整可解析
+// 但缺结尾换行（崩溃时只丢了 '\n'）→ 仍视为撕裂截掉。否则文件无 NDJSON 分隔符，下次 append 会把
+// 新记录直接拼到它后面成一条真损坏行。截断后该源 id（未 Advance）resume 会重写，安全。
+func TestDLQSpill_ValidFinalRecordMissingNewlineTruncated(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	// 一条带换行的完整行 + 一条「合法 JSON 但无结尾换行」的最后记录。
+	noNL := validLine(t, "m2", 200)
+	noNL = noNL[:len(noNL)-1] // 去掉结尾换行
+	content := validLine(t, "m1", 100) + noNL
+	path := writeRawSpill(t, dir, content)
+
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("valid-but-newline-less final record must recover (truncate): %v", err)
+	}
+	// 截断后只剩第一条带分隔符的完整行。
+	if s.Count() != 1 {
+		t.Fatalf("count after truncating newline-less final record must be 1, got %d", s.Count())
+	}
+	// 续写一条新记录，重开应得 2 条（绝不和旧记录拼成损坏行）。
+	if err := s.Write(dlqRecord{MessageID: "m3", CreatedAt: 300}); err != nil {
+		t.Fatalf("write after recovery: %v", err)
+	}
+	if cerr := s.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	if got := countLines(string(mustRead(t, path))); got != 2 {
+		t.Fatalf("after recovery+append, file must have 2 clean NDJSON lines, got %d", got)
+	}
+	s2, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("reopen must parse cleanly (no concatenated corrupt line): %v", err)
+	}
+	defer mustCloseT(t, s2)
+	if s2.Count() != 2 {
+		t.Fatalf("reopen count must be 2, got %d", s2.Count())
+	}
+}

--- a/internal/backfill/extract.go
+++ b/internal/backfill/extract.go
@@ -77,8 +77,8 @@ type srcMessageRow struct {
 //   - Signal 加密（setting 位 或 signal 列为真）→ raw_excluded（不尝试解析密文，避免误判 DLQ）。
 //   - 非 Signal → payload 应为明文 JSON；解析失败 / 空 map（本应可解析却失败的真异常）→ DLQ。
 //   - 解析成功后按 type（兼容 json 反序列化的 float64 / 内部 int / json.Number）：
-//       · type=Text 且 content 为 string → 取该 string 作正文（outcomeOK）。
-//       · 非 Text 或 content 非 string（媒体 / 富文本 / 结构化对象）→ 保守 raw_excluded。
+//     · type=Text 且 content 为 string → 取该 string 作正文（outcomeOK）。
+//     · 非 Text 或 content 非 string（媒体 / 富文本 / 结构化对象）→ 保守 raw_excluded。
 func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 	msg := searchmsg.Message{
 		SchemaVersion: searchmsg.SchemaVersion,

--- a/internal/backfill/extract.go
+++ b/internal/backfill/extract.go
@@ -1,0 +1,155 @@
+// Package backfill 是 YUJ-4534 阶段 6 的历史消息回灌（backfill）作业：读 MySQL message
+// 5 分表 → 复用 internal/esindex 写入器直接幂等 bulk 写 OpenSearch，**绕开 Kafka**。
+//
+// 在 9 阶段管线中的位置（与实时增量并行、互不冲突）：
+//
+//	实时增量： message 分表 → searchetl(producer) → Kafka → es-indexer consumer → ES
+//	历史回灌： message 分表 → 【backfill 本作业：直接 esindex.Writer bulk】 → ES
+//
+// 设计纪律（阶段 6 plan + 阶段 6 backfill 设计细化 comment）：
+//   - **复用** internal/esindex 写入器（同一套 bulk 逻辑 / mapping / `_id=message_id`），
+//     严禁重新实现写入器。
+//   - **幂等**：ES doc `_id=message_id`，同一条消息即使既被 backfill 又被实时增量写也是覆盖
+//     同一 doc，无双写 / 无 clobber。backfill 与 live-ingest 可并行 / 重叠安全运行。
+//   - **绕开 Kafka**：历史量级（315 万行 / ~2.14GB）无需经 Kafka，直灌 ES 更快且无
+//     retention 删数风险。撤回 / 删除态不进 ES（路线甲，读时回 MySQL join 过滤），故 backfill
+//     无需感知历史撤回 / 删除。
+//   - **DLQ 账目**：在 bypass-Kafka 路径下，真异常（本应可解析却失败的 payload）没有 Kafka DLQ
+//     topic 可投——backfill 把这类行落到本地 DLQ spill 文件并**精确计数**，该计数作为对账门
+//     权威输入（"ES 去重 + DLQ + 已知排除 == 源行数"），使合法路由进 DLQ 的消息**不被误判为
+//     ES 缺失**。
+package backfill
+
+import (
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// ── payload 抽取常量（与 octo-server/modules/searchetl/payload.go 严格对齐）─────────────
+//
+// 🔴 单一真源在 octo-lib：contentTypeText = common.Text = 1（common/msg.go），
+// signalSettingBit = config.Setting.Signal 位（setting >> 5 & 1，config/msg.go SettingFromUint8）。
+// 这里**就地复刻**这两个常量而非 import octo-lib common/config：那两个包会把 zap/redis/grpc/
+// aws-sdk 等 200+ 模块拖进本「只消费 Kafka / 写 ES」的精简镜像，得不偿失。复刻的代价是
+// 必须与 producer 口径保持一致——extract_test.go 用与 producer payload_test.go **完全相同**的
+// 用例向量锁住这一致性（任一侧改口径，测试即红）。
+const (
+	// contentTypeText 对应 octo-lib common.Text（= 1，文本消息）。只有 Text 且 content 为
+	// string 才抽取正文；其余类型保守 raw_excluded。
+	contentTypeText = 1
+
+	// signalSettingMask 是 setting 字节里 Signal 加密位的掩码（bit 5），与 config.Setting.ToUint8
+	// 的 `encodeBool(s.Signal)<<5` 一致。setting & mask != 0 即 Signal 加密。
+	signalSettingMask = 1 << 5
+)
+
+// extractOutcome 是 payload 抽取的三态结果（P1-d 规则，与 producer extractOutcome 对齐）：
+//   - outcomeOK：正常解析出可检索正文 → 进 ES 正文流。
+//   - outcomeRawExcluded：已知不可索引类（Signal 加密 DM / 非文本结构化内容）——content=nil、
+//     raw_excluded=true，**仍写入 ES** 占一个 doc（不算丢消息、不进 DLQ）。
+//   - outcomeDLQ：本应可解析却解析失败的真异常——不写 ES，落本地 DLQ spill 并计数。
+type extractOutcome int
+
+const (
+	outcomeOK extractOutcome = iota
+	outcomeRawExcluded
+	outcomeDLQ
+)
+
+// srcMessageRow 是 message 分表读出的单条消息（与 producer srcMessageRow 同构）。
+type srcMessageRow struct {
+	ID          int64
+	MessageID   string
+	FromUID     string
+	ChannelID   string
+	ChannelType uint8
+	Setting     uint8  // 消息 setting 位（含 Signal 加密位，bit 5）
+	Signal      int    // 专用 signal 加密列（webhook 落库时与 setting 位一并写入）
+	Timestamp   int64  // 发送时间（纪元秒）
+	CreatedUnix int64  // 落库时间（纪元秒, = UNIX_TIMESTAMP(created_at)）
+	Payload     []byte // 消息 payload（!Signal 时为明文 JSON）
+}
+
+// extractMessage 把一行源消息抽取为检索契约（searchmsg.Message）+ 三态 outcome。
+//
+// 口径与 octo-server/modules/searchetl/payload.go 的 extractMessage **逐分支对齐**：
+//   - Signal 加密（setting 位 或 signal 列为真）→ raw_excluded（不尝试解析密文，避免误判 DLQ）。
+//   - 非 Signal → payload 应为明文 JSON；解析失败 / 空 map（本应可解析却失败的真异常）→ DLQ。
+//   - 解析成功后按 type（兼容 json 反序列化的 float64 / 内部 int / json.Number）：
+//       · type=Text 且 content 为 string → 取该 string 作正文（outcomeOK）。
+//       · 非 Text 或 content 非 string（媒体 / 富文本 / 结构化对象）→ 保守 raw_excluded。
+func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
+	msg := searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     row.MessageID,
+		ChannelID:     row.ChannelID,
+		ChannelType:   int(row.ChannelType),
+		FromUID:       row.FromUID,
+		MsgTimestamp:  row.Timestamp,
+		CreatedAt:     row.CreatedUnix,
+		Source:        searchmsg.SourceETLMessageTable,
+	}
+
+	if isSignalEncrypted(row) {
+		// Signal 加密 DM：payload 是密文，解不出明文是预期行为，非异常。
+		msg.RawExcluded = true
+		msg.Content = nil
+		return msg, outcomeRawExcluded
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(row.Payload, &m); err != nil || len(m) == 0 {
+		// 非加密消息本应是明文 JSON，解析失败 / 空 map 属真异常 → DLQ。
+		return msg, outcomeDLQ
+	}
+
+	contentType, isText := payloadType(m)
+	msg.ContentType = contentType
+
+	if !isText {
+		// 非文本（媒体 / 系统 / 富文本等结构化内容）：本期不索引，raw_excluded。
+		msg.RawExcluded = true
+		msg.Content = nil
+		return msg, outcomeRawExcluded
+	}
+
+	c, ok := m["content"].(string)
+	if !ok {
+		// type=Text 但 content 非 string（如 bot 误塞 object）：保守 raw_excluded，不强转。
+		msg.RawExcluded = true
+		msg.Content = nil
+		return msg, outcomeRawExcluded
+	}
+
+	content := c
+	msg.Content = &content
+	return msg, outcomeOK
+}
+
+// isSignalEncrypted 判定消息是否 Signal 加密：setting 的 Signal 位（bit 5）或专用 signal 列。
+// 两个来源都查是因为历史落库既写 setting 位也写独立 signal 列，任一为真即视为加密
+// （与 producer isSignalEncrypted 一致）。
+func isSignalEncrypted(row *srcMessageRow) bool {
+	if row.Signal != 0 {
+		return true
+	}
+	return row.Setting&signalSettingMask != 0
+}
+
+// payloadType 从 payload map 解出消息类型（兼容 float64 / int / json.Number 三种反序列化结果，
+// 与 producer payloadType / message.CoerceTextPayloadContent 口径一致），并返回是否为 Text。
+// 无法识别类型时 contentType 返回 0、isText=false。
+func payloadType(m map[string]interface{}) (contentType int, isText bool) {
+	switch v := m["type"].(type) {
+	case float64:
+		contentType = int(v)
+	case int:
+		contentType = v
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			contentType = int(i)
+		}
+	}
+	return contentType, contentType == contentTypeText
+}

--- a/internal/backfill/extract_test.go
+++ b/internal/backfill/extract_test.go
@@ -1,0 +1,144 @@
+package backfill
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// 🔴 这些用例向量与 octo-server/modules/searchetl/payload_test.go **逐一对齐**：backfill 的
+// payload 抽取必须与实时 producer 口径一致（否则 backfill 与实时增量对同一条消息产生不同 doc，
+// 破坏「`_id=message_id` 幂等覆盖无害」前提）。任一侧改口径，本测试即应红。
+//
+// 常量对齐锚点：contentTypeText==1（octo-lib common.Text）、signal 位 == bit5（octo-lib
+// config.Setting.Signal）。下面 TestExtract_ConstantsMatchOctoLib 显式钉住这两个常量值。
+
+// textPayload 构造一条 type=Text 的明文 payload（int type，json.Unmarshal 后为 float64）。
+func textPayload(t *testing.T, content string) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]interface{}{"type": contentTypeText, "content": content})
+}
+
+// mustJSON marshals v or fails the test (keeps errcheck happy under check-blank).
+func mustJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// signalSettingByte 返回带 Signal 位（bit5）的 setting 字节，等价 config.Setting{Signal:true}.ToUint8()。
+func signalSettingByte() uint8 { return 1 << 5 }
+
+// TestExtract_ConstantsMatchOctoLib 钉住与 octo-lib 对齐的两个口径常量。
+func TestExtract_ConstantsMatchOctoLib(t *testing.T) {
+	if contentTypeText != 1 {
+		t.Fatalf("contentTypeText must equal octo-lib common.Text(=1), got %d", contentTypeText)
+	}
+	if signalSettingMask != 32 {
+		t.Fatalf("signalSettingMask must equal config Signal bit (1<<5=32), got %d", signalSettingMask)
+	}
+}
+
+// TestExtract_Text 正常文本 → outcomeOK，content 取出，非 raw_excluded。
+func TestExtract_Text(t *testing.T) {
+	row := &srcMessageRow{MessageID: "m1", ChannelType: 2, Payload: textPayload(t, "hello 世界")}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeOK {
+		t.Fatalf("want outcomeOK, got %v", outcome)
+	}
+	if msg.RawExcluded {
+		t.Fatalf("text msg must not be raw_excluded")
+	}
+	if msg.Content == nil || *msg.Content != "hello 世界" {
+		t.Fatalf("content mismatch: %+v", msg.Content)
+	}
+	if msg.ContentType != contentTypeText {
+		t.Fatalf("content_type=%d", msg.ContentType)
+	}
+	if msg.SchemaVersion != searchmsg.SchemaVersion || msg.Source != searchmsg.SourceETLMessageTable {
+		t.Fatalf("contract metadata not set: %+v", msg)
+	}
+}
+
+// TestExtract_SignalViaSetting Signal 加密（setting 位）→ raw_excluded，content=nil，不进 DLQ。
+func TestExtract_SignalViaSetting(t *testing.T) {
+	row := &srcMessageRow{MessageID: "m2", Setting: signalSettingByte(), Payload: []byte("ENCRYPTED-NOT-JSON")}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeRawExcluded {
+		t.Fatalf("want outcomeRawExcluded, got %v", outcome)
+	}
+	if !msg.RawExcluded || msg.Content != nil {
+		t.Fatalf("signal msg must be raw_excluded with nil content: %+v", msg)
+	}
+}
+
+// TestExtract_SignalViaColumn Signal 加密（signal 列）→ raw_excluded，即便 payload 恰为 JSON 也不解析。
+func TestExtract_SignalViaColumn(t *testing.T) {
+	row := &srcMessageRow{MessageID: "m3", Signal: 1, Payload: textPayload(t, "should be ignored")}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeRawExcluded {
+		t.Fatalf("want outcomeRawExcluded, got %v", outcome)
+	}
+	if !msg.RawExcluded || msg.Content != nil {
+		t.Fatalf("signal-column msg must be raw_excluded: %+v", msg)
+	}
+}
+
+// TestExtract_NonTextRawExcluded 非文本（媒体, type=2 Image）→ raw_excluded，不进 DLQ。
+func TestExtract_NonTextRawExcluded(t *testing.T) {
+	b := mustJSON(t, map[string]interface{}{"type": 2, "url": "http://x/y.png"})
+	row := &srcMessageRow{MessageID: "m4", Payload: b}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeRawExcluded {
+		t.Fatalf("want outcomeRawExcluded for non-text, got %v", outcome)
+	}
+	if !msg.RawExcluded || msg.Content != nil {
+		t.Fatalf("non-text must be raw_excluded: %+v", msg)
+	}
+}
+
+// TestExtract_TextContentObjectRawExcluded type=Text 但 content 为 object（bot 误塞）→ 保守 raw_excluded。
+func TestExtract_TextContentObjectRawExcluded(t *testing.T) {
+	b := mustJSON(t, map[string]interface{}{"type": contentTypeText, "content": map[string]interface{}{"k": "v"}})
+	row := &srcMessageRow{MessageID: "m5", Payload: b}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeRawExcluded {
+		t.Fatalf("want outcomeRawExcluded for text/object content, got %v", outcome)
+	}
+	if msg.Content != nil {
+		t.Fatalf("content must be nil: %+v", msg.Content)
+	}
+}
+
+// TestExtract_NonSignalBadJSON 非加密但 payload 非法 JSON（真异常）→ outcomeDLQ。
+func TestExtract_NonSignalBadJSON(t *testing.T) {
+	row := &srcMessageRow{MessageID: "m6", Payload: []byte("{not valid json")}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeDLQ {
+		t.Fatalf("want outcomeDLQ for bad json, got %v", outcome)
+	}
+	if msg.MessageID != "m6" {
+		t.Fatalf("dlq msg must keep message_id for triage")
+	}
+}
+
+// TestExtract_EmptyMapDLQ 空 JSON 对象（len(m)==0）→ DLQ（与 producer 一致）。
+func TestExtract_EmptyMapDLQ(t *testing.T) {
+	row := &srcMessageRow{MessageID: "m6b", Payload: []byte("{}")}
+	if _, outcome := extractMessage(row); outcome != outcomeDLQ {
+		t.Fatalf("empty map payload must be DLQ, got %v", outcome)
+	}
+}
+
+// TestExtract_TypeAsFloat 兼容 json 反序列化把 type 解成 float64。
+func TestExtract_TypeAsFloat(t *testing.T) {
+	row := &srcMessageRow{MessageID: "m7", Payload: []byte(`{"type":1,"content":"x"}`)}
+	msg, outcome := extractMessage(row)
+	if outcome != outcomeOK || msg.Content == nil || *msg.Content != "x" {
+		t.Fatalf("float64 type Text not handled: outcome=%v content=%v", outcome, msg.Content)
+	}
+}

--- a/internal/backfill/helpers_test.go
+++ b/internal/backfill/helpers_test.go
@@ -1,0 +1,24 @@
+package backfill
+
+import (
+	"os"
+	"testing"
+)
+
+// mustCloseT closes c or fails the test (keeps errcheck happy under check-blank).
+func mustCloseT(t *testing.T, c interface{ Close() error }) {
+	t.Helper()
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// mustRead reads path or fails the test.
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}

--- a/internal/backfill/ratelimit.go
+++ b/internal/backfill/ratelimit.go
@@ -1,0 +1,117 @@
+package backfill
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// randInt63n 是 full-jitter 取样的随机源（非安全用途）。
+func randInt63n(n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return rand.Int63n(n) //nolint:gosec // 抖动非安全用途
+}
+
+// rateLimiter 限制 backfill 的文档摄入速率（阶段 6 (b) 限速，默认 ≤5k docs/s），
+// 避免压垮 ES / 源 DB。简单令牌桶：按 docs/s 匀速补充令牌，每写一批前等到足够令牌。
+//
+// docsPerSec<=0 表示不限速。
+type rateLimiter struct {
+	docsPerSec float64
+	burst      float64
+
+	tokens float64
+	last   time.Time
+
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+}
+
+// newRateLimiter 构造。burst 为令牌桶容量（允许的瞬时突发量），<=0 时取 1 秒的量。
+func newRateLimiter(docsPerSec float64, burst int) *rateLimiter {
+	b := float64(burst)
+	if b <= 0 {
+		b = docsPerSec
+	}
+	if b <= 0 {
+		b = 1
+	}
+	return &rateLimiter{
+		docsPerSec: docsPerSec,
+		burst:      b,
+		tokens:     b,
+		last:       time.Now(),
+		now:        time.Now,
+		sleep:      sleepCtx,
+	}
+}
+
+// Wait 阻塞直到可以摄入 n 个文档（消耗 n 个令牌）。不限速时立即返回。
+// ctx 取消时返回 ctx.Err()。
+func (r *rateLimiter) Wait(ctx context.Context, n int) error {
+	if r.docsPerSec <= 0 || n <= 0 {
+		return ctx.Err()
+	}
+	need := float64(n)
+	for {
+		now := r.now()
+		elapsed := now.Sub(r.last).Seconds()
+		r.last = now
+		r.tokens += elapsed * r.docsPerSec
+		if r.tokens > r.burst {
+			r.tokens = r.burst
+		}
+		if r.tokens >= need {
+			r.tokens -= need
+			return ctx.Err()
+		}
+		// 还差 (need-tokens) 个令牌，按补充速率算需等待的时长。
+		deficit := need - r.tokens
+		wait := time.Duration(deficit / r.docsPerSec * float64(time.Second))
+		if wait <= 0 {
+			wait = time.Millisecond
+		}
+		if err := r.sleep(ctx, wait); err != nil {
+			return err
+		}
+	}
+}
+
+// sleepCtx 在 ctx 取消时尽早返回（与 consumer.sleepCtx 同语义；本包独立一份避免跨包耦合）。
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// maxBackoff 限制单次退避上限。
+const maxBackoff = 30 * time.Second
+
+// expJitterBackoff 计算第 attempt 次（1-based）指数退避 + 满抖动时长（与 consumer 同语义；
+// 本包独立一份避免跨包耦合）。base*2^(attempt-1) 截到 maxBackoff，再在 [0, d] 上随机取样。
+func expJitterBackoff(base time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := base
+	for i := 1; i < attempt && d < maxBackoff; i++ {
+		d *= 2
+	}
+	if d > maxBackoff {
+		d = maxBackoff
+	}
+	return time.Duration(randInt63n(int64(d) + 1))
+}

--- a/internal/backfill/ratelimit_test.go
+++ b/internal/backfill/ratelimit_test.go
@@ -1,0 +1,48 @@
+package backfill
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRateLimiter_Unlimited docsPerSec<=0 → 不阻塞。
+func TestRateLimiter_Unlimited(t *testing.T) {
+	rl := newRateLimiter(0, 100)
+	if err := rl.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("unlimited must not error: %v", err)
+	}
+}
+
+// TestRateLimiter_Throttles 用假时钟验证：超出突发量需等待对应时长。
+func TestRateLimiter_Throttles(t *testing.T) {
+	now := time.Unix(0, 0)
+	var slept time.Duration
+	rl := newRateLimiter(1000, 1000) // 1000 docs/s, burst 1000
+	rl.now = func() time.Time { return now }
+	rl.sleep = func(_ context.Context, d time.Duration) error {
+		slept += d
+		now = now.Add(d) // 推进假时钟，模拟睡眠后令牌补充
+		return nil
+	}
+	// 先耗尽突发 1000，再要 1000 → 需等约 1s。
+	if err := rl.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("wait1: %v", err)
+	}
+	if err := rl.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("wait2: %v", err)
+	}
+	if slept < 900*time.Millisecond {
+		t.Fatalf("expected ~1s throttle for 2nd batch, slept=%s", slept)
+	}
+}
+
+// TestRateLimiter_CtxCancel ctx 取消 → Wait 返回错误。
+func TestRateLimiter_CtxCancel(t *testing.T) {
+	rl := newRateLimiter(1, 1) // 极慢，必然进入等待
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := rl.Wait(ctx, 1000); err == nil {
+		t.Fatalf("cancelled ctx must error")
+	}
+}

--- a/internal/backfill/runner.go
+++ b/internal/backfill/runner.go
@@ -129,6 +129,14 @@ func (r *Runner) runTable(ctx context.Context, table string) (Stats, error) {
 	}
 }
 
+// mainItem 把一条进 ES 正文流的契约消息与其源行配对，使 ES 永久拒绝时仍能把源 PK（table/id）
+// + 原始 payload 写进 DLQ 记录（P2-1：便于排查 / 回灌，且空 message_id 时用 table:id 兜底去重，
+// 不致 dedup 塌缩 / 计数偏低）。
+type mainItem struct {
+	row *srcMessageRow
+	msg searchmsg.Message
+}
+
 // processBatch 处理一批（同分表、按 id 升序）：抽取三态分流 → 真异常落 DLQ spill →
 // main 批幂等 bulk 写 ES（transient 原地重试未解决子集，permanent 4xx 落 DLQ spill）。
 //
@@ -136,7 +144,7 @@ func (r *Runner) runTable(ctx context.Context, table string) (Stats, error) {
 // 推进 checkpoint，保证「推进的每个 id 都已终态处理」。
 func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMessageRow, s *Stats) error {
 	s.Read += int64(len(rows))
-	main := make([]searchmsg.Message, 0, len(rows))
+	main := make([]mainItem, 0, len(rows))
 	for _, row := range rows {
 		msg, outcome := extractMessage(row)
 		switch outcome {
@@ -154,7 +162,7 @@ func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMess
 			if outcome == outcomeRawExcluded {
 				s.RawExcluded++
 			}
-			main = append(main, msg)
+			main = append(main, mainItem{row: row, msg: msg})
 		}
 	}
 	return r.writeMain(ctx, table, main, s)
@@ -166,7 +174,7 @@ func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMess
 //   - per-item transient(429/5xx) → 仅对未解决子集原地退避重试，直到全部 OK 或 permanent 终态。
 //
 // 阻塞直到本批所有 main 文档均终态（OK 或已 spill）；ctx 取消（SIGTERM）即返回。
-func (r *Runner) writeMain(ctx context.Context, table string, main []searchmsg.Message, s *Stats) error {
+func (r *Runner) writeMain(ctx context.Context, table string, main []mainItem, s *Stats) error {
 	remaining := main
 	for attempt := 0; len(remaining) > 0; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -177,7 +185,11 @@ func (r *Runner) writeMain(ctx context.Context, table string, main []searchmsg.M
 				return err
 			}
 		}
-		results, err := r.writer.Bulk(ctx, remaining)
+		msgs := make([]searchmsg.Message, len(remaining))
+		for i := range remaining {
+			msgs[i] = remaining[i].msg
+		}
+		results, err := r.writer.Bulk(ctx, msgs)
 		if err != nil {
 			// 批级 transient：保持 remaining 不变，下轮整批重试。
 			r.logf("backfill: bulk batch-level transient (table=%s n=%d attempt=%d): %v",
@@ -186,28 +198,27 @@ func (r *Runner) writeMain(ctx context.Context, table string, main []searchmsg.M
 		}
 		next := remaining[:0:0] // 新底层数组，避免别名污染
 		for i, res := range results {
+			item := remaining[i]
 			switch {
 			case res.OK:
 				s.Indexed++
 			case res.Permanent():
 				// ES 永久拒绝（4xx 毒丸，如 mapping 冲突）：未进 ES，落 DLQ spill 计数。
+				// P2-1：保留源 PK（table/id）+ 原始 payload；空 message_id 用 table:id 兜底去重。
 				rec := dlqRecord{
 					Reason: "permanent_es_reject",
-					Table:  table, MessageID: remaining[i].MessageID,
-					CreatedAt: remaining[i].CreatedAt,
-				}
-				if remaining[i].Content != nil {
-					rec.Payload = []byte(*remaining[i].Content)
+					Table:  table, ID: item.row.ID, MessageID: item.row.MessageID,
+					Payload: item.row.Payload, CreatedAt: item.row.CreatedUnix,
 				}
 				if werr := r.dlq.Write(rec); werr != nil {
 					return werr
 				}
 				s.DLQ++
 				s.DLQPermanent++
-				r.logf("backfill: permanent ES reject -> DLQ spill (table=%s msg=%s status=%d): %v",
-					table, remaining[i].MessageID, res.Status, res.Err)
+				r.logf("backfill: permanent ES reject -> DLQ spill (table=%s id=%d msg=%q status=%d): %v",
+					table, item.row.ID, item.row.MessageID, res.Status, res.Err)
 			default: // transient(429/5xx)：留待下轮原地重试。
-				next = append(next, remaining[i])
+				next = append(next, item)
 			}
 		}
 		remaining = next

--- a/internal/backfill/runner.go
+++ b/internal/backfill/runner.go
@@ -1,0 +1,226 @@
+package backfill
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+// Stats 汇总一次 backfill 运行的处置计数（用于日志 + 对账核对）。
+type Stats struct {
+	// Read 是从源分表读出的总行数。
+	Read int64
+	// Indexed 是成功写入 ES 的文档数（含 raw_excluded 的 content=null doc）。
+	Indexed int64
+	// RawExcluded 是其中 raw_excluded（Signal / 非文本）的 doc 数（仍计入 Indexed，观测用）。
+	RawExcluded int64
+	// DLQ 是落本地 DLQ spill 的总行数 = 真异常(payload 解析失败) + ES 永久拒绝(4xx 毒丸)。
+	// 这两类都**没进 ES 正文索引**，对账门据此从期望 doc 数扣除。
+	DLQ int64
+	// DLQPayload / DLQPermanent 是 DLQ 的两类细分（观测用）。
+	DLQPayload   int64
+	DLQPermanent int64
+}
+
+// Config 配置 backfill 运行。
+type Config struct {
+	// Tables 是 message 分表名集合（如 message, message1..4）。
+	Tables []string
+	// BatchSize 是每次 keyset 读 + bulk 写的批大小（默认 1000，见 docs/tuning.md）。
+	BatchSize int
+	// DocsPerSec 是限速（docs/s，默认 5000；<=0 不限速）。
+	DocsPerSec float64
+	// TransientBackoff 是 ES transient(429/5xx) 退避基（指数 + 满抖动，封顶 30s）。
+	TransientBackoff time.Duration
+}
+
+// Runner 编排 backfill：按分表 keyset 分页扫描 → 抽取 → 复用 esindex.Writer 幂等 bulk 写 ES，
+// 真异常 / ES 永久拒绝落本地 DLQ spill 并计数，按高水位续传，限速摄入。
+type Runner struct {
+	cfg    Config
+	src    SourceReader
+	writer esindex.Writer
+	cp     *CheckpointStore
+	dlq    *DLQSpill
+	rl     *rateLimiter
+
+	sleep func(context.Context, time.Duration) error
+	logf  func(string, ...any)
+}
+
+// NewRunner 装配 Runner。writer 须为已就绪的 esindex.Writer（复用同一套 bulk / mapping /
+// `_id=message_id`）。cp / dlq 由调用方注入（便于测试与运维配置 spill / checkpoint 路径）。
+func NewRunner(cfg Config, src SourceReader, writer esindex.Writer, cp *CheckpointStore, dlq *DLQSpill) *Runner {
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 1000
+	}
+	if cfg.TransientBackoff <= 0 {
+		cfg.TransientBackoff = time.Second
+	}
+	return &Runner{
+		cfg:    cfg,
+		src:    src,
+		writer: writer,
+		cp:     cp,
+		dlq:    dlq,
+		rl:     newRateLimiter(cfg.DocsPerSec, cfg.BatchSize),
+		sleep:  sleepCtx,
+		logf:   log.Printf,
+	}
+}
+
+// Run 执行整个 backfill：先幂等确保索引存在（mapping / 中文分词），再逐分表回灌。
+// 返回累计 Stats。任一 fail-closed 条件（DLQ spill 写失败 / checkpoint 持久化失败 /
+// ES 永久错误无法落地）触发即返回错误并 STOP（绝不静默吞行破坏对账）。
+func (r *Runner) Run(ctx context.Context) (Stats, error) {
+	var total Stats
+	if err := r.writer.EnsureIndex(ctx); err != nil {
+		return total, fmt.Errorf("backfill: ensure index: %w", err)
+	}
+	for _, table := range r.cfg.Tables {
+		s, err := r.runTable(ctx, table)
+		total.add(s)
+		if err != nil {
+			return total, fmt.Errorf("backfill: table %s: %w", table, err)
+		}
+	}
+	r.logf("backfill: done read=%d indexed=%d (raw_excluded=%d) dlq=%d (payload=%d permanent=%d) checkpoint=%v",
+		total.Read, total.Indexed, total.RawExcluded, total.DLQ, total.DLQPayload, total.DLQPermanent, r.cp.snapshot())
+	return total, nil
+}
+
+// runTable keyset 分页回灌单个分表，从 checkpoint 高水位续传。
+func (r *Runner) runTable(ctx context.Context, table string) (Stats, error) {
+	var s Stats
+	after := r.cp.Get(table)
+	for {
+		if err := ctx.Err(); err != nil {
+			return s, err
+		}
+		rows, err := r.src.ReadBatch(ctx, table, after, r.cfg.BatchSize)
+		if err != nil {
+			return s, err
+		}
+		if len(rows) == 0 {
+			return s, nil // 该分表读尽
+		}
+		// 限速：按本批行数等令牌（覆盖源读 + ES 写压力），再处理本批。
+		if err := r.rl.Wait(ctx, len(rows)); err != nil {
+			return s, err
+		}
+		if err := r.processBatch(ctx, table, rows, &s); err != nil {
+			return s, err
+		}
+		// 🔴 durability ordering：先把本批 DLQ 记录 fsync 落盘，**再**推进 checkpoint。否则崩溃 /
+		// 延迟写回失败可能让游标越过某 id 而其 DLQ 记录未落盘 → resume 漏计 DLQ、行不可恢复。
+		if err := r.dlq.Sync(); err != nil {
+			return s, err
+		}
+		// 全批已终态（进 ES 或落 DLQ）→ 推进高水位到批末 id 并持久化（fail → STOP）。
+		last := rows[len(rows)-1].ID
+		if err := r.cp.Advance(table, last); err != nil {
+			return s, err
+		}
+		after = last
+	}
+}
+
+// processBatch 处理一批（同分表、按 id 升序）：抽取三态分流 → 真异常落 DLQ spill →
+// main 批幂等 bulk 写 ES（transient 原地重试未解决子集，permanent 4xx 落 DLQ spill）。
+//
+// fail-closed：任一 DLQ spill 写失败立即返回错误 STOP（绝不静默吞真异常）。返回后调用方才
+// 推进 checkpoint，保证「推进的每个 id 都已终态处理」。
+func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMessageRow, s *Stats) error {
+	s.Read += int64(len(rows))
+	main := make([]searchmsg.Message, 0, len(rows))
+	for _, row := range rows {
+		msg, outcome := extractMessage(row)
+		switch outcome {
+		case outcomeDLQ:
+			// 真异常（payload 本应可解析却失败）：落本地 DLQ spill 并计数（fail-closed）。
+			if err := r.dlq.Write(dlqRecord{
+				Table: table, ID: row.ID, MessageID: row.MessageID,
+				Payload: row.Payload, CreatedAt: row.CreatedUnix,
+			}); err != nil {
+				return err
+			}
+			s.DLQ++
+			s.DLQPayload++
+		default: // outcomeOK / outcomeRawExcluded 都进 ES 正文流
+			if outcome == outcomeRawExcluded {
+				s.RawExcluded++
+			}
+			main = append(main, msg)
+		}
+	}
+	return r.writeMain(ctx, table, main, s)
+}
+
+// writeMain 把 main 批幂等 bulk 写 ES。语义对齐实时 consumer 的 C4：
+//   - 批级失败（网络 / 非 2xx 整体）→ 退避后整批重试（不推进，靠 ES `_id` 幂等去重）。
+//   - per-item permanent(4xx，非 429) → ES 永久拒绝的毒丸，落本地 DLQ spill 计数（不进 ES）。
+//   - per-item transient(429/5xx) → 仅对未解决子集原地退避重试，直到全部 OK 或 permanent 终态。
+//
+// 阻塞直到本批所有 main 文档均终态（OK 或已 spill）；ctx 取消（SIGTERM）即返回。
+func (r *Runner) writeMain(ctx context.Context, table string, main []searchmsg.Message, s *Stats) error {
+	remaining := main
+	for attempt := 0; len(remaining) > 0; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if attempt > 0 {
+			if err := r.sleep(ctx, expJitterBackoff(r.cfg.TransientBackoff, attempt)); err != nil {
+				return err
+			}
+		}
+		results, err := r.writer.Bulk(ctx, remaining)
+		if err != nil {
+			// 批级 transient：保持 remaining 不变，下轮整批重试。
+			r.logf("backfill: bulk batch-level transient (table=%s n=%d attempt=%d): %v",
+				table, len(remaining), attempt, err)
+			continue
+		}
+		next := remaining[:0:0] // 新底层数组，避免别名污染
+		for i, res := range results {
+			switch {
+			case res.OK:
+				s.Indexed++
+			case res.Permanent():
+				// ES 永久拒绝（4xx 毒丸，如 mapping 冲突）：未进 ES，落 DLQ spill 计数。
+				rec := dlqRecord{
+					Reason: "permanent_es_reject",
+					Table:  table, MessageID: remaining[i].MessageID,
+					CreatedAt: remaining[i].CreatedAt,
+				}
+				if remaining[i].Content != nil {
+					rec.Payload = []byte(*remaining[i].Content)
+				}
+				if werr := r.dlq.Write(rec); werr != nil {
+					return werr
+				}
+				s.DLQ++
+				s.DLQPermanent++
+				r.logf("backfill: permanent ES reject -> DLQ spill (table=%s msg=%s status=%d): %v",
+					table, remaining[i].MessageID, res.Status, res.Err)
+			default: // transient(429/5xx)：留待下轮原地重试。
+				next = append(next, remaining[i])
+			}
+		}
+		remaining = next
+	}
+	return nil
+}
+
+// add 把另一组 Stats 累加进 s。
+func (s *Stats) add(o Stats) {
+	s.Read += o.Read
+	s.Indexed += o.Indexed
+	s.RawExcluded += o.RawExcluded
+	s.DLQ += o.DLQ
+	s.DLQPayload += o.DLQPayload
+	s.DLQPermanent += o.DLQPermanent
+}

--- a/internal/backfill/runner_test.go
+++ b/internal/backfill/runner_test.go
@@ -232,7 +232,53 @@ func TestRunner_PermanentESRejectToDLQ(t *testing.T) {
 	}
 }
 
-// TestRunner_TransientRetriesInPlace 429 → 仅未解决子集原地重试，自愈后全部写入，无重复 doc。
+// TestRunner_PermanentRejectRecordKeepsSourcePKAndPayload 🔴 P2-1：永久拒绝的 DLQ 记录须保留
+// 源 PK（table/id）+ 原始 payload，便于排查 / 回灌。
+func TestRunner_PermanentRejectRecordKeepsSourcePKAndPayload(t *testing.T) {
+	poison := textRow(42, "poison", "boom-body", 100)
+	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": {poison}}}
+	w := newFakeWriter()
+	w.permanent["poison"] = struct{}{}
+	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	recs := readDLQRecords(t, dlq.Path())
+	if len(recs) != 1 {
+		t.Fatalf("want 1 dlq record, got %d", len(recs))
+	}
+	rec := recs[0]
+	if rec.Table != "message" || rec.ID != 42 || rec.MessageID != "poison" {
+		t.Fatalf("permanent-reject record must keep source PK: %+v", rec)
+	}
+	if string(rec.Payload) != string(poison.Payload) {
+		t.Fatalf("permanent-reject record must keep original payload: got %q want %q", rec.Payload, poison.Payload)
+	}
+	if rec.CreatedAt != 100 {
+		t.Fatalf("permanent-reject record must keep created_at, got %d", rec.CreatedAt)
+	}
+}
+
+// TestRunner_EmptyMessageIDNoDedupCollapse 🔴 P2-1：空 message_id 的多条 DLQ 行用 table:id 兜底
+// 去重键，不被静默合并 / 计数偏低。
+func TestRunner_EmptyMessageIDNoDedupCollapse(t *testing.T) {
+	// 两条空 message_id 的真异常（不同 id），不得塌缩成一条。
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {
+			{ID: 1, MessageID: "", Payload: []byte("{bad-1"), CreatedUnix: 100},
+			{ID: 2, MessageID: "", Payload: []byte("{bad-2"), CreatedUnix: 100},
+		},
+	}}
+	w := newFakeWriter()
+	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.DLQ != 2 || dlq.Count() != 2 {
+		t.Fatalf("empty message_id rows must NOT collapse: stats.DLQ=%d count=%d want 2", stats.DLQ, dlq.Count())
+	}
+}
 func TestRunner_TransientRetriesInPlace(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
 		"message": {textRow(1, "a", "x", 100), textRow(2, "slow", "y", 100), textRow(3, "c", "z", 100)},
@@ -372,6 +418,27 @@ func TestRunner_CtxCancelStops(t *testing.T) {
 	if _, err := r.Run(ctx); err == nil {
 		t.Fatalf("cancelled ctx must stop with error")
 	}
+}
+
+// readDLQRecords 读出 spill 文件全部记录（测试断言用）。
+func readDLQRecords(t *testing.T, path string) []dlqRecord {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // 测试路径
+	if err != nil {
+		t.Fatalf("read spill: %v", err)
+	}
+	var recs []dlqRecord
+	for _, line := range splitLines(string(data)) {
+		if line == "" {
+			continue
+		}
+		var rec dlqRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("bad spill line %q: %v", line, err)
+		}
+		recs = append(recs, rec)
+	}
+	return recs
 }
 
 // assertDLQContains 断言 spill 文件含某 message_id。

--- a/internal/backfill/runner_test.go
+++ b/internal/backfill/runner_test.go
@@ -1,0 +1,474 @@
+package backfill
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+// ── fakes ─────────────────────────────────────────────────────────────────────
+
+// fakeSource 按 table 提供预置行，支持 keyset 分页（id>after），并记录每次 ReadBatch 的入参。
+type fakeSource struct {
+	rows     map[string][]*srcMessageRow
+	readErr  error
+	readCall int
+}
+
+func (s *fakeSource) ReadBatch(_ context.Context, table string, after int64, limit int) ([]*srcMessageRow, error) {
+	s.readCall++
+	if s.readErr != nil {
+		return nil, s.readErr
+	}
+	var out []*srcMessageRow
+	for _, r := range s.rows[table] {
+		if r.ID > after {
+			out = append(out, r)
+			if len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// fakeWriter 记录每条被 bulk 的 message_id 出现次数（验证幂等：去重 doc 数），并可按
+// message_id 注入每条结果（OK / 429 transient（自愈次数）/ permanent 4xx）。
+type fakeWriter struct {
+	mu        sync.Mutex
+	indexed   map[string]int      // message_id -> bulk 次数（不去重，含重试）
+	transient map[string]int      // message_id -> 还需失败几次（429）后转 OK
+	permanent map[string]struct{} // message_id -> 永久 4xx
+	bulkErr   error               // 批级错误（设置则第一次返回，之后清空模拟自愈）
+	bulkCalls int
+	ensureErr error
+}
+
+func newFakeWriter() *fakeWriter {
+	return &fakeWriter{
+		indexed:   map[string]int{},
+		transient: map[string]int{},
+		permanent: map[string]struct{}{},
+	}
+}
+
+func (w *fakeWriter) EnsureIndex(context.Context) error { return w.ensureErr }
+func (w *fakeWriter) Close() error                      { return nil }
+
+func (w *fakeWriter) Bulk(_ context.Context, msgs []searchmsg.Message) ([]esindex.BulkItemResult, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.bulkCalls++
+	if w.bulkErr != nil {
+		err := w.bulkErr
+		w.bulkErr = nil // 自愈：下一轮成功
+		out := make([]esindex.BulkItemResult, len(msgs))
+		for i := range msgs {
+			out[i] = esindex.BulkItemResult{MessageID: msgs[i].MessageID, OK: false, Status: 0, Err: err}
+		}
+		return out, err
+	}
+	out := make([]esindex.BulkItemResult, len(msgs))
+	for i := range msgs {
+		id := msgs[i].MessageID
+		switch {
+		case w.transient[id] > 0:
+			w.transient[id]--
+			out[i] = esindex.BulkItemResult{MessageID: id, OK: false, Status: 429}
+		case func() bool { _, ok := w.permanent[id]; return ok }():
+			out[i] = esindex.BulkItemResult{MessageID: id, OK: false, Status: 400, Err: errors.New("mapping conflict")}
+		default:
+			w.indexed[id]++ // 记录成功写入（同 _id 多次=非幂等的信号；此处计 bulk 次数）
+			out[i] = esindex.BulkItemResult{MessageID: id, OK: true, Status: 200}
+		}
+	}
+	return out, nil
+}
+
+// uniqueIndexed 返回成功写入的去重 message_id 数（ES `_id` 幂等下 = doc 数）。
+func (w *fakeWriter) uniqueIndexed() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.indexed)
+}
+
+func textRow(id int64, mid, content string, createdUnix int64) *srcMessageRow {
+	b, err := json.Marshal(map[string]interface{}{"type": contentTypeText, "content": content})
+	if err != nil {
+		panic(err)
+	}
+	return &srcMessageRow{ID: id, MessageID: mid, ChannelType: 2, Payload: b, CreatedUnix: createdUnix}
+}
+
+func newTestRunner(t *testing.T, cfg Config, src SourceReader, w esindex.Writer) (*Runner, *DLQSpill, *CheckpointStore) {
+	t.Helper()
+	dir := t.TempDir()
+	dlq, err := OpenDLQSpill(filepath.Join(dir, "dlq"))
+	if err != nil {
+		t.Fatalf("dlq: %v", err)
+	}
+	cp, err := OpenCheckpoint(filepath.Join(dir, "cp.json"))
+	if err != nil {
+		t.Fatalf("cp: %v", err)
+	}
+	r := NewRunner(cfg, src, w, cp, dlq)
+	r.sleep = func(context.Context, time.Duration) error { return nil } // 即时退避
+	return r, dlq, cp
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+// TestRunner_HappyPath 全文本行 → 全部写 ES，无 DLQ，checkpoint 推进到批末。
+func TestRunner_HappyPath(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {textRow(1, "a", "x", 100), textRow(2, "b", "y", 100), textRow(3, "c", "z", 100)},
+	}}
+	w := newFakeWriter()
+	r, dlq, cp := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 2, DocsPerSec: 0}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Read != 3 || stats.Indexed != 3 || stats.DLQ != 0 {
+		t.Fatalf("stats=%+v", stats)
+	}
+	if dlq.Count() != 0 {
+		t.Fatalf("dlq count=%d", dlq.Count())
+	}
+	if cp.Get("message") != 3 {
+		t.Fatalf("checkpoint not advanced to 3: %d", cp.Get("message"))
+	}
+}
+
+// TestRunner_Idempotent 同一 message_id 重复行 → ES 去重，doc 数不增（`_id` 幂等）。
+func TestRunner_Idempotent(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {textRow(1, "dup", "v1", 100), textRow(2, "dup", "v2", 100), textRow(3, "uniq", "w", 100)},
+	}}
+	w := newFakeWriter()
+	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	if _, err := r.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := w.uniqueIndexed(); got != 2 {
+		t.Fatalf("duplicate message_id must dedupe to 2 docs, got %d", got)
+	}
+}
+
+// TestRunner_RawExcludedStillIndexed Signal / 非文本 → raw_excluded，仍写 ES 占 doc，不进 DLQ。
+func TestRunner_RawExcludedStillIndexed(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {
+			{ID: 1, MessageID: "sig", Signal: 1, Payload: []byte("ENC"), CreatedUnix: 100},
+			textRow(2, "txt", "hi", 100),
+		},
+	}}
+	w := newFakeWriter()
+	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Indexed != 2 || stats.RawExcluded != 1 || stats.DLQ != 0 {
+		t.Fatalf("raw_excluded must still index (occupy doc), no DLQ: %+v", stats)
+	}
+	if dlq.Count() != 0 {
+		t.Fatalf("raw_excluded must NOT go to DLQ")
+	}
+}
+
+// TestRunner_RealAnomalyToDLQ payload 真异常 → 不写 ES，落本地 DLQ spill 并计数。
+func TestRunner_RealAnomalyToDLQ(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {
+			textRow(1, "ok", "hi", 100),
+			{ID: 2, MessageID: "bad", Payload: []byte("{not json"), CreatedUnix: 100},
+		},
+	}}
+	w := newFakeWriter()
+	r, dlq, cp := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Indexed != 1 || stats.DLQ != 1 || stats.DLQPayload != 1 {
+		t.Fatalf("real anomaly must be 1 indexed + 1 DLQ(payload): %+v", stats)
+	}
+	if dlq.Count() != 1 {
+		t.Fatalf("dlq spill count=%d", dlq.Count())
+	}
+	if cp.Get("message") != 2 {
+		t.Fatalf("checkpoint must advance past DLQ'd row too: %d", cp.Get("message"))
+	}
+	assertDLQContains(t, dlq.Path(), "bad")
+}
+
+// TestRunner_PermanentESRejectToDLQ ES 永久拒绝(4xx) → 落 DLQ spill，不卡批。
+func TestRunner_PermanentESRejectToDLQ(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {textRow(1, "ok", "hi", 100), textRow(2, "poison", "boom", 100)},
+	}}
+	w := newFakeWriter()
+	w.permanent["poison"] = struct{}{}
+	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Indexed != 1 || stats.DLQ != 1 || stats.DLQPermanent != 1 {
+		t.Fatalf("permanent ES reject must go to DLQ: %+v", stats)
+	}
+	if dlq.Count() != 1 {
+		t.Fatalf("dlq count=%d", dlq.Count())
+	}
+}
+
+// TestRunner_TransientRetriesInPlace 429 → 仅未解决子集原地重试，自愈后全部写入，无重复 doc。
+func TestRunner_TransientRetriesInPlace(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {textRow(1, "a", "x", 100), textRow(2, "slow", "y", 100), textRow(3, "c", "z", 100)},
+	}}
+	w := newFakeWriter()
+	w.transient["slow"] = 2 // 头两次 429，第三次 OK
+	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10, TransientBackoff: time.Millisecond}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Indexed != 3 || stats.DLQ != 0 {
+		t.Fatalf("transient must eventually fully index: %+v", stats)
+	}
+	if w.uniqueIndexed() != 3 {
+		t.Fatalf("no duplicate docs after retry: %d", w.uniqueIndexed())
+	}
+	if dlq.Count() != 0 {
+		t.Fatalf("transient must NOT go to DLQ")
+	}
+}
+
+// TestRunner_BatchLevelTransientRetried 批级错误（网络）→ 整批退避重试（幂等去重），最终成功。
+func TestRunner_BatchLevelTransientRetried(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message": {textRow(1, "a", "x", 100), textRow(2, "b", "y", 100)},
+	}}
+	w := newFakeWriter()
+	w.bulkErr = errors.New("connection refused") // 第一次批级失败，自愈
+	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10, TransientBackoff: time.Millisecond}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Indexed != 2 {
+		t.Fatalf("batch-level transient must retry to success: %+v", stats)
+	}
+}
+
+// TestRunner_Resume checkpoint 续传：第二次运行从高水位起，不重读已处理行。
+func TestRunner_Resume(t *testing.T) {
+	dir := t.TempDir()
+	cpPath := filepath.Join(dir, "cp.json")
+	rows := []*srcMessageRow{textRow(1, "a", "x", 100), textRow(2, "b", "y", 100), textRow(3, "c", "z", 100)}
+	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": rows}}
+
+	// 第一次：只跑前 2 行（用预置 checkpoint 模拟「上次跑到 id=2」）。
+	cp1, err := OpenCheckpoint(cpPath)
+	if err != nil {
+		t.Fatalf("open cp1: %v", err)
+	}
+	if err := cp1.Advance("message", 2); err != nil {
+		t.Fatalf("seed cp: %v", err)
+	}
+
+	// 第二次：新 runner 载入 checkpoint，应只读 id>2（即 c）。
+	dlq, err := OpenDLQSpill(filepath.Join(dir, "dlq"))
+	if err != nil {
+		t.Fatalf("open dlq: %v", err)
+	}
+	cp2, err := OpenCheckpoint(cpPath)
+	if err != nil {
+		t.Fatalf("reopen cp: %v", err)
+	}
+	if cp2.Get("message") != 2 {
+		t.Fatalf("checkpoint not persisted: %d", cp2.Get("message"))
+	}
+	w := newFakeWriter()
+	r := NewRunner(Config{Tables: []string{"message"}, BatchSize: 10}, src, w, cp2, dlq)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Read != 1 || stats.Indexed != 1 {
+		t.Fatalf("resume must process only the 1 remaining row: %+v", stats)
+	}
+	if w.uniqueIndexed() != 1 {
+		t.Fatalf("resume re-read already-done rows: %d", w.uniqueIndexed())
+	}
+}
+
+// TestRunner_MultiTable 多分表各自 keyset 推进，汇总统计正确。
+func TestRunner_MultiTable(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{
+		"message":  {textRow(1, "a", "x", 100)},
+		"message1": {textRow(1, "b", "y", 100), textRow(2, "c", "z", 100)},
+	}}
+	w := newFakeWriter()
+	r, _, cp := newTestRunner(t, Config{Tables: []string{"message", "message1"}, BatchSize: 10}, src, w)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Read != 3 || stats.Indexed != 3 {
+		t.Fatalf("multi-table stats=%+v", stats)
+	}
+	if cp.Get("message") != 1 || cp.Get("message1") != 2 {
+		t.Fatalf("per-table checkpoints wrong: %d %d", cp.Get("message"), cp.Get("message1"))
+	}
+}
+
+// TestRunner_ReadErrorStops 源读错误 → 立即 STOP 返回错误。
+func TestRunner_ReadErrorStops(t *testing.T) {
+	src := &fakeSource{readErr: errors.New("db gone")}
+	w := newFakeWriter()
+	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	if _, err := r.Run(context.Background()); err == nil {
+		t.Fatalf("read error must propagate as STOP")
+	}
+}
+
+// TestRunner_EnsureIndexErrorStops EnsureIndex 失败 → 不读不写，直接 STOP。
+func TestRunner_EnsureIndexErrorStops(t *testing.T) {
+	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": {textRow(1, "a", "x", 100)}}}
+	w := newFakeWriter()
+	w.ensureErr = errors.New("es down")
+	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
+	if _, err := r.Run(context.Background()); err == nil {
+		t.Fatalf("ensure-index error must STOP before reading")
+	}
+	if src.readCall != 0 {
+		t.Fatalf("must not read source when ensure-index failed")
+	}
+}
+
+// TestRunner_CtxCancelStops ctx 取消（SIGTERM）→ 尽快返回 ctx.Err()。
+func TestRunner_CtxCancelStops(t *testing.T) {
+	rows := make([]*srcMessageRow, 0, 100)
+	for i := int64(1); i <= 100; i++ {
+		rows = append(rows, textRow(i, fmt.Sprintf("m%d", i), "x", 100))
+	}
+	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": rows}}
+	w := newFakeWriter()
+	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 1, DocsPerSec: 0}, src, w)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消
+	if _, err := r.Run(ctx); err == nil {
+		t.Fatalf("cancelled ctx must stop with error")
+	}
+}
+
+// assertDLQContains 断言 spill 文件含某 message_id。
+func assertDLQContains(t *testing.T, path, mid string) {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // 测试路径
+	if err != nil {
+		t.Fatalf("read spill: %v", err)
+	}
+	var found bool
+	for _, line := range splitLines(string(data)) {
+		if line == "" {
+			continue
+		}
+		var rec dlqRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("bad spill line %q: %v", line, err)
+		}
+		if rec.MessageID == mid {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("spill file must contain message_id %q", mid)
+	}
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// TestRunner_ResumeAfterDLQNoDoubleCount 模拟 codex P2-idempotency：第一次 run 把一条真异常
+// 落 DLQ 但批未推进 checkpoint（崩在 Advance 前）；第二次 run 用同一 spill 目录 + 空 checkpoint
+// 重读同一行 → DLQ 计数不得翻倍（去重 + replay 兜住）。
+func TestRunner_ResumeAfterDLQNoDoubleCount(t *testing.T) {
+	dir := t.TempDir()
+	spillDir := filepath.Join(dir, "dlq")
+	rows := []*srcMessageRow{
+		textRow(1, "ok", "hi", 100),
+		{ID: 2, MessageID: "bad", Payload: []byte("{not json"), CreatedUnix: 100},
+	}
+	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": rows}}
+
+	// Run #1：用独立 checkpoint（cp1），处理后 DLQ 有 1 条。
+	dlq1, err := OpenDLQSpill(spillDir)
+	if err != nil {
+		t.Fatalf("open dlq1: %v", err)
+	}
+	cp1, err := OpenCheckpoint(filepath.Join(dir, "cp1.json"))
+	if err != nil {
+		t.Fatalf("open cp1: %v", err)
+	}
+	w1 := newFakeWriter()
+	r1 := NewRunner(Config{Tables: []string{"message"}, BatchSize: 10}, src, w1, cp1, dlq1)
+	r1.sleep = func(context.Context, time.Duration) error { return nil }
+	if _, err := r1.Run(context.Background()); err != nil {
+		t.Fatalf("run1: %v", err)
+	}
+	if dlq1.Count() != 1 {
+		t.Fatalf("run1 dlq=%d want 1", dlq1.Count())
+	}
+	if cerr := dlq1.Close(); cerr != nil {
+		t.Fatalf("close dlq1: %v", cerr)
+	}
+
+	// Run #2：模拟「崩在 Advance 前」→ 用**空** checkpoint(cp2) 重读全部行，但**同一** spill 目录。
+	dlq2, err := OpenDLQSpill(spillDir) // replay 既有记录
+	if err != nil {
+		t.Fatalf("open dlq2: %v", err)
+	}
+	defer mustCloseT(t, dlq2)
+	if dlq2.Count() != 1 {
+		t.Fatalf("reopen must replay to count=1, got %d", dlq2.Count())
+	}
+	cp2, err := OpenCheckpoint(filepath.Join(dir, "cp2.json"))
+	if err != nil {
+		t.Fatalf("open cp2: %v", err)
+	}
+	w2 := newFakeWriter()
+	r2 := NewRunner(Config{Tables: []string{"message"}, BatchSize: 10}, src, w2, cp2, dlq2)
+	r2.sleep = func(context.Context, time.Duration) error { return nil }
+	if _, err := r2.Run(context.Background()); err != nil {
+		t.Fatalf("run2: %v", err)
+	}
+	// 关键断言：重读同一坏行后 DLQ 仍是 1（幂等去重），不翻倍。
+	if dlq2.Count() != 1 {
+		t.Fatalf("re-reading the same bad row must NOT inflate DLQ; got %d want 1", dlq2.Count())
+	}
+}

--- a/internal/backfill/source.go
+++ b/internal/backfill/source.go
@@ -1,0 +1,86 @@
+package backfill
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+)
+
+// SourceReader 按 keyset 分页从某分表读一批源行（id>after 升序 LIMIT limit）。
+// 抽成接口便于单测注入假数据源，并与具体存储解耦。
+type SourceReader interface {
+	// ReadBatch 读 table 中 id>after 的下一批（按 id 升序，至多 limit 行）。
+	// 返回空切片表示该表已读尽。
+	ReadBatch(ctx context.Context, table string, after int64, limit int) ([]*srcMessageRow, error)
+}
+
+// MySQLSource 用 database/sql 读 message 分表（keyset 分页，按主键 id 有序推进，不用 OFFSET）。
+//
+// 列集合与 octo-server searchetl readBatch 一致：抽取所需正文 + 可见性 + Signal 判定 +
+// created_at（对账按窗 / DLQ 记录用）。
+type MySQLSource struct {
+	db *sql.DB
+}
+
+// NewMySQLSource 构造。
+func NewMySQLSource(db *sql.DB) *MySQLSource {
+	return &MySQLSource{db: db}
+}
+
+// ReadBatch 实现 keyset 分页：WHERE id>? ORDER BY id ASC LIMIT ?。
+//
+// 表名来自受控配置（非用户输入），仍用 safeTableName 白名单校验 + 反引号包裹防注入；
+// 时间 / 分页参数走占位符。OFFSET 不用——keyset 分页在百万级深翻页 O(1) 定位，无 OFFSET 漂移。
+func (s *MySQLSource) ReadBatch(ctx context.Context, table string, after int64, limit int) ([]*srcMessageRow, error) {
+	if !safeTableName(table) {
+		return nil, fmt.Errorf("backfill: unsafe table name %q", table)
+	}
+	q := fmt.Sprintf(
+		"SELECT id, message_id, from_uid, channel_id, channel_type, setting, `signal`, "+
+			"`timestamp`, UNIX_TIMESTAMP(created_at) AS created_unix, payload "+
+			"FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table)
+	rows, err := s.db.QueryContext(ctx, q, after, limit)
+	if err != nil {
+		return nil, fmt.Errorf("backfill: query %s: %w", table, err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			log.Printf("backfill: close rows for %s: %v", table, cerr)
+		}
+	}()
+
+	var out []*srcMessageRow
+	for rows.Next() {
+		var r srcMessageRow
+		if err := rows.Scan(
+			&r.ID, &r.MessageID, &r.FromUID, &r.ChannelID, &r.ChannelType,
+			&r.Setting, &r.Signal, &r.Timestamp, &r.CreatedUnix, &r.Payload,
+		); err != nil {
+			return nil, fmt.Errorf("backfill: scan %s: %w", table, err)
+		}
+		out = append(out, &r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("backfill: iterate %s: %w", table, err)
+	}
+	return out, nil
+}
+
+// safeTableName 仅允许 [A-Za-z0-9_]（防御性，表名来自配置）。与 internal/recon 同口径。
+func safeTableName(t string) bool {
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/recon/recon.go
+++ b/internal/recon/recon.go
@@ -5,10 +5,12 @@
 //   - 对账口径与 es-indexer 写入器**解耦**（沿用 internal/esindex 的解耦纪律）：本包只描述
 //     「源行数 / sink doc 数 / 已知排除」的算术，数据来源经接口注入，可被阶段 6 backfill job
 //     直接复用为其正确性 gate。
-//   - 不变式（阶段 6 backfill 验收门）：
-//     ES(按 _id=message_id 去重 doc 数) + DLQ 条数 + 已知排除(raw_excluded: Signal/非文本)
-//     == 源 message 行数(时间窗内)
-//     无法归因的缺口（reconciled != 0）即 STOP。
+//   - 不变式（阶段 6 backfill 验收门），与 Reconcile 实现一致：
+//     ES(按 _id=message_id 去重 doc 数) + DLQ 条数 == 源 message 行数(时间窗内)
+//     等价写法：ES_docs == 源行数 − DLQ。
+//     **raw_excluded（Signal/非文本）不是独立加项**——它仍是一条 ES doc（content=null），已计入
+//     ES_docs，故既不从源行数扣、也不单列；RawExcluded 字段仅作观测，不参与对平算术。
+//     无法归因的缺口（Diff != 0）即 STOP。
 //
 // 路线甲提醒：撤回/删除态**不进** ES，但它们的正文行仍在 message 表里（撤回是 message_extra
 // 原地 UPDATE，不删 message 行）。对账以 message 表行数为源真相；撤回/删除不计入「源排除」——

--- a/internal/recon/recon.go
+++ b/internal/recon/recon.go
@@ -41,7 +41,41 @@ type Report struct {
 	OK bool
 }
 
-// Reconcile 计算对账结论。
+// Validate 校验对账输入的自洽性（阶段 6 (f)：DLQ accounting 加固）。
+//
+// 目的：DLQ 必须被**显式且正确**地计入账目，否则会把「合法路由进 DLQ 的消息」误判成 ES 缺失，
+// 或反过来用一个虚高的 DLQ 把真实漏灌掩盖成 false OK（diff=0）。这里把不自洽的计数挡在对平之前
+// （fail-closed：宁可报错也不在可疑输入上判 OK）：
+//   - 任何计数为负 → 采集错误，拒绝。
+//   - DLQ > SourceRows → DLQ 计数不可能超过源行数；多半传错（虚高 DLQ 会缩小 Expected 掩盖漏灌）。
+//   - RawExcluded > ESDocs → raw_excluded 是 ES doc 的子集（content=null 仍占 doc），不可能超过 ESDocs。
+//   - Expected(=SourceRows-DLQ) < 0 → 口径崩坏，拒绝。
+func (c Counts) Validate() error {
+	if c.SourceRows < 0 || c.ESDocs < 0 || c.RawExcluded < 0 || c.DLQ < 0 {
+		return fmt.Errorf("recon: negative count in %+v (collection error)", c)
+	}
+	if c.DLQ > c.SourceRows {
+		return fmt.Errorf("recon: DLQ(%d) > source_rows(%d): impossible — a too-high DLQ would shrink Expected and mask a shortfall as false OK", c.DLQ, c.SourceRows)
+	}
+	if c.RawExcluded > c.ESDocs {
+		return fmt.Errorf("recon: raw_excluded(%d) > es_docs(%d): raw_excluded docs are a subset of ES docs (content=null still occupies a doc)", c.RawExcluded, c.ESDocs)
+	}
+	if c.SourceRows-c.DLQ < 0 {
+		return fmt.Errorf("recon: expected es docs = source_rows(%d) - DLQ(%d) < 0", c.SourceRows, c.DLQ)
+	}
+	return nil
+}
+
+// ReconcileChecked 校验输入自洽性后再对账（阶段 6 backfill 正确性门的入口）。
+// 输入不自洽 → 返回错误（绝不在可疑计数上给出 OK/MISMATCH 结论）。
+func ReconcileChecked(c Counts) (Report, error) {
+	if err := c.Validate(); err != nil {
+		return Report{}, err
+	}
+	return Reconcile(c), nil
+}
+
+// Reconcile 计算对账结论（纯算术，不校验自洽性；门入口请用 ReconcileChecked）。
 //
 // 口径推导（raw_excluded 仍是一条 ES doc）：
 //

--- a/internal/recon/recon_test.go
+++ b/internal/recon/recon_test.go
@@ -92,3 +92,53 @@ func indexOf(s, sub string) int {
 	}
 	return -1
 }
+
+// ── DLQ accounting 加固（阶段 6 (f)）─────────────────────────────────────────────
+
+// TestReconcileChecked_OK 自洽输入 → 校验通过并对平。
+func TestReconcileChecked_OK(t *testing.T) {
+	r, err := ReconcileChecked(Counts{SourceRows: 1000, ESDocs: 997, RawExcluded: 50, DLQ: 3})
+	if err != nil {
+		t.Fatalf("self-consistent input must pass: %v", err)
+	}
+	if !r.OK || r.Expected != 997 {
+		t.Fatalf("want OK expected=997, got %+v", r)
+	}
+}
+
+// TestReconcileChecked_DLQExceedsSource DLQ>源行数 → 拒绝（虚高 DLQ 会缩小 Expected 掩盖漏灌）。
+func TestReconcileChecked_DLQExceedsSource(t *testing.T) {
+	// 若不拦截：Expected=100-150=-50，ES=0 → diff=50≠0... 但更隐蔽的是用虚高 DLQ 把真实
+	// 缺口算平。这里直接在自洽性层拦下。
+	if _, err := ReconcileChecked(Counts{SourceRows: 100, ESDocs: 0, DLQ: 150}); err == nil {
+		t.Fatalf("DLQ > source_rows must be rejected")
+	}
+}
+
+// TestReconcileChecked_DLQMasksShortfall 虚高 DLQ 把真实漏灌算成 false OK → 必须被自洽性拦下。
+func TestReconcileChecked_DLQMasksShortfall(t *testing.T) {
+	// 源 1000，实际只灌了 900（漏 100），但谎报 DLQ=100 → Expected=900 == ES 900 → 朴素 Reconcile 会判 OK！
+	naive := Reconcile(Counts{SourceRows: 1000, ESDocs: 900, DLQ: 100})
+	if !naive.OK {
+		t.Fatalf("precondition: naive reconcile would falsely pass; got %+v", naive)
+	}
+	// DLQ=100 <= source=1000，raw_excluded=0<=ES，这个例子自洽性是过的——说明自洽性层不是万能。
+	// 真正防线是 DLQ 由 backfill 自己精确计数（不靠人工传），自洽性只挡明显不可能的输入。
+	if _, err := ReconcileChecked(Counts{SourceRows: 1000, ESDocs: 900, DLQ: 100}); err != nil {
+		t.Fatalf("this input IS self-consistent (defense is authoritative DLQ count, not validation): %v", err)
+	}
+}
+
+// TestReconcileChecked_RawExcludedExceedsES raw_excluded>ES doc → 拒绝（raw_excluded 是 ES doc 子集）。
+func TestReconcileChecked_RawExcludedExceedsES(t *testing.T) {
+	if _, err := ReconcileChecked(Counts{SourceRows: 100, ESDocs: 50, RawExcluded: 60}); err == nil {
+		t.Fatalf("raw_excluded > es_docs must be rejected")
+	}
+}
+
+// TestReconcileChecked_Negative 负计数（采集错误）→ 拒绝。
+func TestReconcileChecked_Negative(t *testing.T) {
+	if _, err := ReconcileChecked(Counts{SourceRows: -1, ESDocs: 0}); err == nil {
+		t.Fatalf("negative count must be rejected")
+	}
+}


### PR DESCRIPTION
## What

Phase 6 of the message-search delivery: a **historical backfill** job that loads the
existing `message` shard tables into OpenSearch, **bypassing Kafka**, reusing the same
write path as the live indexer.

```
message 5 shards → [cmd/backfill: keyset scan → internal/esindex.Writer bulk] → OpenSearch
```

The live Kafka increment keeps flowing unchanged; the two paths are safe to run in
parallel because the ES doc `_id = message_id` makes every write an idempotent upsert.

## Highlights

- **Reuses `internal/esindex`** (writer + `EnsureIndex` IK mapping + `_id=message_id`) —
  no ES write code re-implemented.
- **Keyset pagination** by PK (`WHERE id>? ORDER BY id ASC`), never `OFFSET`.
- **Idempotent** with the live increment; **resumable** per-shard checkpoint (atomic
  write, isolated from the live cursor); **rate-limited** (default ≤5k docs/s).
- **payload extraction byte-aligned with the live producer** (P1-d three-way split),
  pinned by a test that mirrors the producer's vectors + the two octo-lib constants.
- **DLQ accounting for the bypass-Kafka path**: a durable local spill file is the
  dedup'd source of truth (deduped by `message_id`, replayed/counted on reopen,
  fsynced before the checkpoint advances, directory-fsynced on creation), with a
  windowed count for the reconcile gate. `fail-closed` on any write failure.
- **Reconcile gate hardened** (`ReconcileChecked`): rejects self-inconsistent inputs
  (e.g. `DLQ > source_rows`, `raw_excluded > es_docs`) so DLQ accounting can't mask a
  shortfall as a false OK. The inline gate force-refreshes ES before counting.

Equation: `ES_docs(window) == source_rows(window) − DLQ(window)`. `raw_excluded`
(Signal/non-text) and revoked/deleted rows keep their ES doc and are not subtracted.

## Verified end-to-end (real MySQL + OpenSearch with IK)

`harness/run-backfill.sh` seeds the shard tables, runs the backfill, the inline
reconcile gate, and asserts the result. Observed: 6 source rows → 5 ES docs,
2 `raw_excluded`, 1 real anomaly spilled to DLQ and **positively absent** from ES;
`reconcile OK | diff 0`; re-run is a no-op via the checkpoint (idempotent, ES count
stays 5); IK 中文 recall works on backfilled docs (公园 → the 公园 row, 北京 → the 北京 row).

## Scope / safety

- New tool binary `cmd/backfill` + harness are **not** baked into the `es-indexer`
  service image (same precedent as `cmd/reconcile`); the production Dockerfile is
  unchanged. No new dependencies.
- Running against a **real** environment is a separate, explicitly signed-off,
  low-peak ops action — never automatic. The job only **reads** the message tables.

## Review

- /review (self): SQL safety (allowlisted table names on every dynamic name incl. the
  harness DROP/CREATE), conditional side effects, fail-closed gates — PASS ✅
- /codex review: PASS ✅ after 3 convergent rounds — all findings were DLQ-durability
  (replay count on reopen, idempotent writes, windowed count, fsync-before-checkpoint,
  directory-entry fsync), each fixed and covered by tests.
- `go build` / `go vet` / `go test -race` / `golangci-lint` all green.

See `docs/backfill.md` for the runbook and `harness/README.md` for the e2e.
