### PR TITLE
feat(esindex): converge OS doc contract to reader shape + recon sampling

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -33,7 +33,14 @@ name: Check Sprint
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # Include "edited" so the check re-runs when the PR description is updated
+    # (e.g. a developer adds "Closes #<issue>" after opening) — the reusable
+    # workflow resolves Sprint from the linked issue, so a body edit must
+    # re-trigger it. "ready_for_review"/"converted_to_draft" keep the draft-skip
+    # safe (without them a green "skipped" result cached on the draft SHA would
+    # persist after promotion and bypass the Sprint gate). Matches the usage
+    # documented in reusable-check-sprint.yml.
+    types: [opened, synchronize, reopened, edited, ready_for_review, converted_to_draft]
     branches: [main]
 
 permissions: {}

--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,19 @@ test: ## 跑全部单测
 ##   RECON_ES_INDEX    目标索引/别名（默认 octo-message；切换后对 wukongim-messages-read）
 ##   RECON_TABLES      message 分表（默认 message,message1,message2,message3,message4）
 ## 可选：RECON_SAMPLE（抽样数，默认 200）、RECON_FROM/RECON_TO（窗，纪元秒）、
-##       RECON_DLQ（窗内已知 DLQ 数）、RECON_PUSH_URL/RECON_PUSH_TOKEN（回填 octo-server gauge）。
+##       RECON_DLQ（窗内已知 DLQ 数）、RECON_DLQ_SPILL_DIR（backfill 落下的 DLQ spill 目录；
+##       其 message_id 从字段级抽样门排除，避免合法 DLQ 行被误判 sample_missing）、
+##       RECON_PUSH_URL/RECON_PUSH_TOKEN（回填 octo-server gauge）。
 RECON_FROM ?= 0
 RECON_TO   ?= 0
 RECON_DLQ  ?= 0
+RECON_DLQ_SPILL_DIR ?=
 
 run-recon: ## 跑对账（人类可读摘要 + 退出码 gate）
-	$(GO) run ./cmd/reconcile -from $(RECON_FROM) -to $(RECON_TO) -dlq $(RECON_DLQ)
+	$(GO) run ./cmd/reconcile -from $(RECON_FROM) -to $(RECON_TO) -dlq $(RECON_DLQ) -dlq-spill-dir '$(RECON_DLQ_SPILL_DIR)'
 
 run-recon-json: ## 跑对账（结构化 JSON 报告，供机检 / 入库）
-	$(GO) run ./cmd/reconcile -from $(RECON_FROM) -to $(RECON_TO) -dlq $(RECON_DLQ) -json
+	$(GO) run ./cmd/reconcile -from $(RECON_FROM) -to $(RECON_TO) -dlq $(RECON_DLQ) -dlq-spill-dir '$(RECON_DLQ_SPILL_DIR)' -json
 
 ## ── 前向迁移（步骤 6 三步）─────────────────────────────────────────────────────
 ## 写新契约索引(v1.9) → 存量 reindex → alias 原子切换。详见 docs/forward-migration-v1.9.md。

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# octo-search-indexer — build / test / recon entrypoints (YUJ-4534 / YUJ-4682)
+.DEFAULT_GOAL := help
+
+GO ?= go
+
+.PHONY: help build test vet run-recon run-recon-json migrate-forward
+
+help: ## 列出可用目标
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+build: ## 编译全部二进制
+	$(GO) build ./...
+
+vet: ## go vet
+	$(GO) vet ./...
+
+test: ## 跑全部单测
+	$(GO) test ./... | tail -40
+
+## ── 对账作业（步骤 5）─────────────────────────────────────────────────────────
+## ES doc-count vs MySQL 行数 + 抽样字段比对，检出多 doc/少 doc/字段 drift。
+## 对平退出 0；不对平退出 2（CI / cron gate 失败信号）。
+## 指标/阈值钉死在 internal/recon（doc_drift!=0 / sample_mismatch!=0 / sample_missing!=0 即不健康）。
+##
+## 必需配置（env 或 flag）：
+##   RECON_MYSQL_DSN   MySQL DSN，如 'user:pass@tcp(host:3306)/im_prod'
+##   RECON_ES          OpenSearch 地址（默认 http://localhost:9200）
+##   RECON_ES_INDEX    目标索引/别名（默认 octo-message；切换后对 wukongim-messages-read）
+##   RECON_TABLES      message 分表（默认 message,message1,message2,message3,message4）
+## 可选：RECON_SAMPLE（抽样数，默认 200）、RECON_FROM/RECON_TO（窗，纪元秒）、
+##       RECON_DLQ（窗内已知 DLQ 数）、RECON_PUSH_URL/RECON_PUSH_TOKEN（回填 octo-server gauge）。
+RECON_FROM ?= 0
+RECON_TO   ?= 0
+RECON_DLQ  ?= 0
+
+run-recon: ## 跑对账（人类可读摘要 + 退出码 gate）
+	$(GO) run ./cmd/reconcile -from $(RECON_FROM) -to $(RECON_TO) -dlq $(RECON_DLQ)
+
+run-recon-json: ## 跑对账（结构化 JSON 报告，供机检 / 入库）
+	$(GO) run ./cmd/reconcile -from $(RECON_FROM) -to $(RECON_TO) -dlq $(RECON_DLQ) -json
+
+## ── 前向迁移（步骤 6 三步）─────────────────────────────────────────────────────
+## 写新契约索引(v1.9) → 存量 reindex → alias 原子切换。详见 docs/forward-migration-v1.9.md。
+migrate-forward: ## 执行前向迁移（写新索引 + reindex + alias 切，禁半新半旧同 alias）
+	./scripts/forward-migrate.sh

--- a/README.md
+++ b/README.md
@@ -103,14 +103,22 @@ the field-level reconciliation gate after a backfill:**
 # inline after the backfill run (uses the job's own exact DLQ count as authority):
 go run ./cmd/backfill ... -reconcile -from <epoch> -to <epoch>   # count gate + field-level sample gate
 
-# or standalone, any time:
-make run-recon RECON_FROM=<epoch> RECON_TO=<epoch> RECON_DLQ=<dlq-count>
+# or standalone, any time (pass the backfill DLQ spill dir so legit DLQ rows are
+# excluded from the sample gate exactly like the inline path — otherwise a sampled
+# DLQ row false-fails as sample_missing and the gate exits non-zero):
+make run-recon RECON_FROM=<epoch> RECON_TO=<epoch> RECON_DLQ=<dlq-count> \
+  RECON_DLQ_SPILL_DIR=<the backfill -spill-dir>
 ```
 
 The sample gate cross-checks `messageId` (full precision), `channelId`,
 `channelType`, `spaceId`, and **`visibles`** between MySQL and the ES doc, so a
 silently dropped ACL (`visibles`) field surfaces as `sample_mismatch>0` and the
-gate exits non-zero. `make run-recon` is **mandatory** before switching the read
+gate exits non-zero. Rows the backfill deliberately routed to the DLQ (bad
+payload / non-numeric id / permanent ES reject — already counted in `-dlq`) are
+*expected* to have no ES doc; both reconcile paths exclude them from the sample
+gate (inline reads its in-memory spill, standalone reads the same spill dir via
+`-dlq-spill-dir` / `RECON_DLQ_SPILL_DIR`) so they never false-fail as
+`sample_missing`. `make run-recon` is **mandatory** before switching the read
 alias to a freshly backfilled index (see `docs/forward-migration-v1.9.md`).
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ independent binary/image distinct from `octo-server`.
 > + 中文 analyzer bootstrap. `/metrics` and lag/backlog instrumentation land in
 > phase 7.
 
+## Backfill & reconciliation (must-run gate)
+
+The phase-6 backfill job (`cmd/backfill`) loads existing `message` shards into
+OpenSearch, bypassing Kafka, and is the **only** path that fills the reader's
+safety fields (`spaceId`/`visibles`/`messageSeq`) from the raw MySQL payload.
+
+A count match alone does not prove correctness — it proves only that the row
+*counts* tie, not that each doc's authz/correctness fields are right. **Always run
+the field-level reconciliation gate after a backfill:**
+
+```sh
+# inline after the backfill run (uses the job's own exact DLQ count as authority):
+go run ./cmd/backfill ... -reconcile -from <epoch> -to <epoch>   # count gate + field-level sample gate
+
+# or standalone, any time:
+make run-recon RECON_FROM=<epoch> RECON_TO=<epoch> RECON_DLQ=<dlq-count>
+```
+
+The sample gate cross-checks `messageId` (full precision), `channelId`,
+`channelType`, `spaceId`, and **`visibles`** between MySQL and the ES doc, so a
+silently dropped ACL (`visibles`) field surfaces as `sample_mismatch>0` and the
+gate exits non-zero. `make run-recon` is **mandatory** before switching the read
+alias to a freshly backfilled index (see `docs/forward-migration-v1.9.md`).
+
 ## Build
 
 ```sh

--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -11,6 +11,8 @@
 //   - 限速 ≤5k docs/s（默认）；checkpoint 续传（已灌 message_id 高水位，与实时游标物理隔离）。
 //   - 真异常 / ES 永久拒绝落本地 DLQ spill 并精确计数，作为对账门权威输入。
 //   - 配置全走 flag / env。运行结束后建议跑 cmd/reconcile（或 -reconcile 内联对账门）核验。
+//     -reconcile 内联门含 count 对账 **+ 字段级抽样比对**（-recon-sample，默认 200）：
+//     count 只证条数、抽样证 reader 契约关键字段（spaceId/visibles/messageSeq 等）内容一致。
 //
 // 🔴 隔离纪律：本作业对真实环境执行需 Yu / 运维显式 sign-off 后低峰触发，绝不自动跑生产。
 //
@@ -68,6 +70,8 @@ func run() error {
 		doRecon    = flag.Bool("reconcile", false, "after backfill, run the reconcile gate (requires -from/-to)")
 		fromUnix   = flag.Int64("from", 0, "reconcile window start (epoch seconds, inclusive)")
 		toUnix     = flag.Int64("to", 0, "reconcile window end (epoch seconds, inclusive; 0 = now)")
+		sampleN    = flag.Int("recon-sample", envInt("BACKFILL_RECON_SAMPLE", 200), "reconcile field-level sample size (0 disables field sampling, count gate only)")
+		maxDet     = flag.Int("recon-sample-max-details", envInt("BACKFILL_RECON_SAMPLE_MAX_DETAILS", 50), "cap on sample-mismatch detail entries in the report")
 	)
 	flag.Parse()
 
@@ -145,7 +149,7 @@ func run() error {
 	}
 
 	if *doRecon {
-		return reconcile(ctx, db, splitCSV(*esAddrs), *esUser, *esPass, *esIndex, tables, *fromUnix, *toUnix, dlq)
+		return reconcile(ctx, db, splitCSV(*esAddrs), *esUser, *esPass, *esIndex, tables, *fromUnix, *toUnix, *sampleN, *maxDet, dlq)
 	}
 	log.Printf("backfill complete. Run cmd/reconcile (or re-run with -reconcile -from/-to) to gate correctness. Total DLQ count: %d", dlq.Count())
 	return nil
@@ -155,8 +159,14 @@ func run() error {
 // 🔴 用**按窗** DLQ 计数（CountInWindow）：reconcile 窗可能不覆盖本次 run 处理的全部行
 // （如分批跑、或只校验某个时间段），用全量 dlqCount 会把窗外的 DLQ 行也减掉 → false
 // mismatch/false OK（codex review P2-window）。
+//
+// 🔴 字段级抽样门（YUJ-4701 落地 Jerry-Xin non-blocking）：count 门只证「条数」一致，不证
+// 「内容」一致。复用 recon.CompareSamples 逐字段核对 reader 契约关键字段（messageId/channelId/
+// channelType/spaceId/visibles/messageSeq），检出「条数对得上但字段错位」的静默 drift——backfill
+// 正是富化 spaceId/visibles/messageSeq 的唯一路径，这些字段错位最该在 backfill 后立即拦住。
+// sampleN<=0 时退回纯 count 门（与 cmd/reconcile -sample 0 同口径）。
 // 对平退出码 0；不对平返回错误（main 退出码 1）作为 STOP 信号。
-func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, index string, tables []string, fromUnix, toUnix int64, dlq *backfill.DLQSpill) error {
+func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, index string, tables []string, fromUnix, toUnix int64, sampleN, maxDet int, dlq *backfill.DLQSpill) error {
 	to := toUnix
 	if to == 0 {
 		to = time.Now().Unix()
@@ -200,9 +210,30 @@ func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, in
 	if err != nil {
 		return fmt.Errorf("reconcile inputs not self-consistent: %w", err)
 	}
-	log.Printf("reconcile gate: %s", report.String())
-	if !report.OK {
-		return fmt.Errorf("reconcile MISMATCH (diff=%d): backfill correctness gate FAILED — STOP, do not proceed", report.Diff)
+
+	full := recon.FullReport{Count: report, RanAtUnixSeconds: time.Now().Unix()}
+	full.Window.FromUnix = fromUnix
+	full.Window.ToUnix = to
+
+	// 字段级抽样门（count 门不证内容一致）。
+	if sampleN > 0 {
+		sampleReader := recon.NewMySQLSampleReader(db, tables)
+		docFetcher := recon.NewOSDocFetcher(osClient, index)
+		// 排除本批已落 DLQ spill 的真异常 / 永久拒绝行：它们本就不该在 ES 正文索引里
+		// （count 门已用同一 DLQ 计数抵消），抽样命中时不能再算成 missing（口径冲突 → false MISMATCH）。
+		excluded := dlq.MessageIDsInWindow(fromUnix, to)
+		sample, serr := recon.CompareSamplesExcluding(ctx, sampleReader, docFetcher, fromUnix, to, sampleN, maxDet, excluded)
+		if serr != nil {
+			return fmt.Errorf("sample compare: %w", serr)
+		}
+		full.Sample = sample
+	}
+
+	log.Printf("reconcile gate: %s", full.String())
+	if !full.Healthy() {
+		return fmt.Errorf("reconcile MISMATCH (count diff=%d, sample mismatch=%d missing=%d): "+
+			"backfill correctness gate FAILED — STOP, do not proceed",
+			report.Diff, full.Sample.Mismatch, full.Sample.Missing)
 	}
 	return nil
 }

--- a/cmd/reconcile/main.go
+++ b/cmd/reconcile/main.go
@@ -5,10 +5,15 @@
 //
 //	reconcile -from 1709078400 -to 1718323200 \
 //	  -mysql-dsn 'user:pass@tcp(host:3306)/im_prod' -tables message,message1,message2,message3,message4 \
-//	  -es http://localhost:9200 -es-index octo-message [-dlq N]
+//	  -es http://localhost:9200 -es-index octo-message [-dlq N] [-dlq-spill-dir DIR]
 //
 // 与 indexer 写入器解耦（沿用 internal/esindex 解耦纪律）：本命令只读 MySQL + 查 ES，不依赖
 // consumer。阶段 6 backfill job 可直接 import internal/recon 复用对账算术。
+//
+// DLQ 行处理：count 对账用 -dlq 抵消窗内已知 DLQ 数；字段级抽样门用 -dlq-spill-dir 读 backfill
+// 落下的 DLQ spill 文件，把这些行（本就不该有 ES doc）从抽样比对排除——与 inline backfill 对账门
+// （cmd/backfill 用 in-memory DLQSpill.MessageIDsInWindow）口径一致，避免抽样命中合法 DLQ 行时
+// 误报 sample_missing → 误 exit 2 阻塞 alias 切换。
 package main
 
 import (
@@ -25,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/backfill"
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/recon"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/opensearch-project/opensearch-go/v3"
@@ -50,6 +56,7 @@ func run() error {
 		esUser   = flag.String("es-user", os.Getenv("RECON_ES_USER"), "OpenSearch username")
 		esPass   = flag.String("es-pass", os.Getenv("RECON_ES_PASS"), "OpenSearch password")
 		dlq      = flag.Int64("dlq", 0, "known DLQ count in window (rows that never reached ES body index)")
+		dlqDir   = flag.String("dlq-spill-dir", os.Getenv("RECON_DLQ_SPILL_DIR"), "optional backfill DLQ spill dir (or RECON_DLQ_SPILL_DIR); its message_ids are excluded from the field-level sample gate so legit DLQ rows don't false-fail as sample_missing")
 		sampleN  = flag.Int("sample", envInt("RECON_SAMPLE", 200), "field-level sample size (0 disables sampling)")
 		maxDet   = flag.Int("sample-max-details", envInt("RECON_SAMPLE_MAX_DETAILS", 50), "cap on mismatch detail entries in the report")
 		jsonOut  = flag.Bool("json", false, "emit the structured FullReport as JSON")
@@ -132,7 +139,15 @@ func run() error {
 	if *sampleN > 0 {
 		sampleReader := recon.NewMySQLSampleReader(db, splitCSV(*tablesS))
 		docFetcher := recon.NewOSDocFetcher(osClient, *esIndex)
-		sample, serr := recon.CompareSamples(ctx, sampleReader, docFetcher, *fromUnix, to, *sampleN, *maxDet)
+		// 排除 backfill 已落 DLQ spill 的真异常 / 永久拒绝行：它们本就不该在 ES 正文索引里
+		// （count 门已用同一 DLQ 计数抵消），抽样命中时不能再算成 missing（口径冲突 → false MISMATCH）。
+		// 与 inline backfill 对账门（cmd/backfill）行为一致：那条路用 in-memory DLQSpill.MessageIDsInWindow，
+		// 这条 standalone 路无 live spill，故从 backfill job 留下的 spill 文件只读复原同一份排除集。
+		excluded, lerr := backfill.LoadDLQMessageIDsInWindow(*dlqDir, *fromUnix, to)
+		if lerr != nil {
+			return fmt.Errorf("load DLQ spill exclusion set: %w", lerr)
+		}
+		sample, serr := recon.CompareSamplesExcluding(ctx, sampleReader, docFetcher, *fromUnix, to, *sampleN, *maxDet, excluded)
 		if serr != nil {
 			return serr
 		}

--- a/cmd/reconcile/main.go
+++ b/cmd/reconcile/main.go
@@ -182,7 +182,11 @@ func pushReport(ctx context.Context, url, token string, payload recon.PushPayloa
 	if err != nil {
 		return err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Printf("reconcile: close push response body: %v", cerr)
+		}
+	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("push returned status %d", resp.StatusCode)
 	}

--- a/cmd/reconcile/main.go
+++ b/cmd/reconcile/main.go
@@ -12,12 +12,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,6 +50,11 @@ func run() error {
 		esUser   = flag.String("es-user", os.Getenv("RECON_ES_USER"), "OpenSearch username")
 		esPass   = flag.String("es-pass", os.Getenv("RECON_ES_PASS"), "OpenSearch password")
 		dlq      = flag.Int64("dlq", 0, "known DLQ count in window (rows that never reached ES body index)")
+		sampleN  = flag.Int("sample", envInt("RECON_SAMPLE", 200), "field-level sample size (0 disables sampling)")
+		maxDet   = flag.Int("sample-max-details", envInt("RECON_SAMPLE_MAX_DETAILS", 50), "cap on mismatch detail entries in the report")
+		jsonOut  = flag.Bool("json", false, "emit the structured FullReport as JSON")
+		pushURL  = flag.String("push-url", os.Getenv("RECON_PUSH_URL"), "optional octo-server ingestion URL to POST the search_recon gauge payload")
+		pushTok  = flag.String("push-token", os.Getenv("RECON_PUSH_TOKEN"), "optional bearer token for -push-url")
 		timeout  = flag.Duration("timeout", 60*time.Second, "overall timeout")
 	)
 	flag.Parse()
@@ -114,12 +123,79 @@ func run() error {
 		// 输入不自洽（DLQ accounting 加固，阶段 6 (f)）：拒绝在可疑计数上判 OK。
 		return err
 	}
-	fmt.Println(report.String())
-	if !report.OK {
-		// 不对平：退出码 2，作为 backfill/CI gate 的失败信号。
+
+	full := recon.FullReport{Count: report, RanAtUnixSeconds: time.Now().Unix()}
+	full.Window.FromUnix = *fromUnix
+	full.Window.ToUnix = to
+
+	// 抽样字段比对（步骤 5 核心：count 对账不证内容一致）。
+	if *sampleN > 0 {
+		sampleReader := recon.NewMySQLSampleReader(db, splitCSV(*tablesS))
+		docFetcher := recon.NewOSDocFetcher(osClient, *esIndex)
+		sample, serr := recon.CompareSamples(ctx, sampleReader, docFetcher, *fromUnix, to, *sampleN, *maxDet)
+		if serr != nil {
+			return serr
+		}
+		full.Sample = sample
+	}
+
+	// 回填 octo-server 只读 search_recon_* gauge（可选）。push 失败不改变对账结论，但要显式告警。
+	if *pushURL != "" {
+		if perr := pushReport(ctx, *pushURL, *pushTok, full.PushPayload()); perr != nil {
+			log.Printf("warn: push recon payload to %s failed: %v", *pushURL, perr)
+		}
+	}
+
+	if *jsonOut {
+		b, jerr := json.MarshalIndent(full, "", "  ")
+		if jerr != nil {
+			return fmt.Errorf("marshal report: %w", jerr)
+		}
+		fmt.Println(string(b))
+	} else {
+		fmt.Println(full.String())
+	}
+
+	if !full.Healthy() {
+		// 不对平（count 或抽样 drift）：退出码 2，作为 backfill/CI/cron gate 的失败信号。
 		os.Exit(2)
 	}
 	return nil
+}
+
+// pushReport POST 结构化 gauge 载荷到 octo-server 只读 ingestion 端（载荷逐字段对齐
+// recon_metrics.go::ReconReport）。仅在 -push-url 配置时调用。
+func pushReport(ctx context.Context, url, token string, payload recon.PushPayload) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal push payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("push returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func envInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
 }
 
 func envOr(k, def string) string {

--- a/cmd/reconcile/main_test.go
+++ b/cmd/reconcile/main_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/backfill"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/recon"
+)
+
+// fakeSampleSrc / fakeESFetch 模拟 standalone reconcile 的两个抽样依赖（MySQL 源 + ES doc）。
+type fakeSampleSrc struct{ rows []recon.SampleRow }
+
+func (f *fakeSampleSrc) SampleRows(_ context.Context, _, _ int64, limit int) ([]recon.SampleRow, error) {
+	if limit < len(f.rows) {
+		return f.rows[:limit], nil
+	}
+	return f.rows, nil
+}
+
+type fakeESFetch struct{ docs map[string]recon.ESDocFields }
+
+func (f *fakeESFetch) FetchDocs(_ context.Context, ids []string) (map[string]recon.ESDocFields, error) {
+	out := map[string]recon.ESDocFields{}
+	for _, id := range ids {
+		if d, ok := f.docs[id]; ok {
+			out[id] = d
+		}
+	}
+	return out, nil
+}
+
+// writeSpillWithDLQRow 落一行 DLQ spill 记录（NDJSON + 已 fsync 的 offset sidecar），返回 spill dir。
+// 直接按 backfill spill 的磁盘格式写，模拟 backfill job 跑完后留在盘上、供 standalone reconcile 只读
+// 加载的文件（DLQSpill 的内部写入器不导出，故测试按已固定的盘上契约构造）。
+func writeSpillWithDLQRow(t *testing.T, messageID string, createdAt int64) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "spill")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir spill: %v", err)
+	}
+	line := fmt.Sprintf("{\"reason\":\"backfill_payload_unparseable\",\"message_id\":%q,\"created_at\":%d}\n", messageID, createdAt)
+	if err := os.WriteFile(filepath.Join(dir, "backfill-dlq.ndjson"), []byte(line), 0o640); err != nil {
+		t.Fatalf("write spill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "backfill-dlq.synced"), []byte(fmt.Sprintf("%d", len(line))), 0o640); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	return dir
+}
+
+// TestStandaloneReconcile_DLQRowNotMissing 🔴 R3 核心回归：standalone reconcile 的字段级抽样门
+// 抽到一个合法 DLQ 行（已在 backfill spill / 排除集内）时，必须不计 sample_missing、不触发 exit 2。
+// 复刻 cmd/reconcile run() 的抽样链：LoadDLQMessageIDsInWindow(spillDir) → CompareSamplesExcluding。
+func TestStandaloneReconcile_DLQRowNotMissing(t *testing.T) {
+	spillDir := writeSpillWithDLQRow(t, "99", 150) // 合法 DLQ 行：坏 payload，故意不进 ES
+
+	src := &fakeSampleSrc{rows: []recon.SampleRow{
+		{MessageID: "10", ChannelID: "g1", ChannelType: 2}, // 正常：ES 有 doc
+		{MessageID: "99", ChannelID: "gx", ChannelType: 2}, // DLQ：ES 无 doc，应被排除
+	}}
+	es := &fakeESFetch{docs: map[string]recon.ESDocFields{
+		"10": {MessageID: 10, ChannelID: "g1", ChannelType: 2},
+	}}
+
+	excluded, err := backfill.LoadDLQMessageIDsInWindow(spillDir, 0, 1000)
+	if err != nil {
+		t.Fatalf("load exclusion: %v", err)
+	}
+	res, err := recon.CompareSamplesExcluding(context.Background(), src, es, 0, 1000, 100, 50, excluded)
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if res.Missing != 0 {
+		t.Fatalf("legit DLQ row must NOT be sample_missing (would false exit 2): %+v", res)
+	}
+	if res.Sampled != 1 || res.Mismatch != 0 {
+		t.Fatalf("only the non-DLQ row should be compared cleanly: %+v", res)
+	}
+}
+
+// TestStandaloneReconcile_NoSpillDirStillFailsOnRealMissing 没传 spill dir（空排除集）时，
+// 真正漏灌的行仍按 sample_missing 计——确保排除逻辑不会掩盖真实缺失（fail-closed 不被削弱）。
+func TestStandaloneReconcile_NoSpillDirStillFailsOnRealMissing(t *testing.T) {
+	src := &fakeSampleSrc{rows: []recon.SampleRow{
+		{MessageID: "10", ChannelID: "g1", ChannelType: 2}, // 真漏灌：ES 无 doc
+	}}
+	es := &fakeESFetch{docs: map[string]recon.ESDocFields{}}
+
+	excluded, err := backfill.LoadDLQMessageIDsInWindow("", 0, 1000)
+	if err != nil {
+		t.Fatalf("load exclusion: %v", err)
+	}
+	res, err := recon.CompareSamplesExcluding(context.Background(), src, es, 0, 1000, 100, 50, excluded)
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if res.Missing != 1 {
+		t.Fatalf("real missing row must still be flagged (gate must stay fail-closed): %+v", res)
+	}
+}

--- a/docs/forward-migration-v1.9.md
+++ b/docs/forward-migration-v1.9.md
@@ -63,6 +63,11 @@ octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查
      重叠安全；重灌覆盖 reindex 的空字段。生产推荐：直接 backfill 重灌新索引，跳过 reindex 的空壳。
 3. **alias 原子切换** read alias → 新索引：`STEP=3`。**前置门**：先 `make run-recon RECON_ES_INDEX=<新索引>`
    抽样对账通过（doc_drift==0 且 sample_mismatch==0 且 sample_missing==0）再切。
+   - ⚠️ 若该新索引是 backfill 重灌出来的（步骤 2 推荐路径），跑对账时必须带上 backfill 的 DLQ spill 目录：
+     `make run-recon RECON_ES_INDEX=<新索引> RECON_DLQ=<窗内 DLQ 数> RECON_DLQ_SPILL_DIR=<backfill -spill-dir>`。
+     这些合法 DLQ 行（坏 payload / 永久 ES 拒绝，故意不进 ES、已被 `-dlq` 计入）本就无 ES doc，spill 目录
+     让 standalone 抽样门把它们排除（与 inline backfill 对账门口径一致），否则抽样命中 DLQ 行会误报
+     sample_missing → 退出码 2 → 误阻塞 alias 切换。
    切换在单个 `_aliases` 事务内 `remove(index="*", must_exist=false)` + `add(新索引)`：从**任意**当前
    挂着的索引摘掉 alias 再挂新索引（幂等 + 保证 alias 任何时刻单指向，杜绝半新半旧同 alias）。
 
@@ -77,6 +82,8 @@ octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查
 - **count 对账**：ES doc-count vs MySQL 行数（扣 DLQ；raw_excluded 仍占 doc 不扣）。`doc_drift = ESDocs − MySQL行数`。
 - **抽样字段比对**：取 N 条样本，按 message_id 拉 ES doc，逐字段核对
   `messageId/channelId/channelType/spaceId/visibles/messageSeq`，检出「条数对得上但字段错位」的静默 drift。
+  传 `-dlq-spill-dir`（`RECON_DLQ_SPILL_DIR`）时，backfill 落下的 DLQ 行（已记账、本就不该有 ES doc）被排除，
+  不计 sample_missing——与 inline backfill 对账门（`recon.CompareSamplesExcluding`）口径一致。
 - **阈值（机检，钉死在 internal/recon）**：`doc_drift!=0` 或 `sample_mismatch!=0` 或 `sample_missing!=0` → 不健康，退出码 2。
 - **回填 octo-server**：`-push-url` POST `PushPayload`（逐字段对齐 `recon_metrics.go::ReconReport`）到只读
   ingestion 端 → `search_recon_doc_drift` / `search_recon_sample_mismatch` / `search_recon_last_run_timestamp_seconds` gauge。

--- a/docs/forward-migration-v1.9.md
+++ b/docs/forward-migration-v1.9.md
@@ -44,6 +44,11 @@ octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查
 （+SpaceID/+Visibles/+MessageSeq，SchemaVersion 1→2）+ octo-server `modules/searchetl` producer 富化，
 随阶段 9 开 Kafka.On 一并上线。本期 Kafka.On=OFF（plan §6），无实时流量，存量由 backfill 填全即可。
 
+> 🔒 **实时写入安全闸（防 V3b fail-OPEN）**：`consumer.Service.Run` 在 Kafka 契约
+> `searchmsg.SchemaVersion < SafetyFieldsSchemaVersion(=2)` 时**拒启动**实时写入——否则会灌出
+> 空 `visibles` 的 doc，让 reader 的群系统消息白名单 gate fail-OPEN（普通成员搜出群管才可见消息）。
+> octo-lib bump 到带安全字段的契约 + producer 富化后，重 pin 自动解封。存量始终由 backfill 富化。
+
 ## 前向迁移三步（钉死，禁半新半旧 doc 同 alias 服务）
 
 脚本：`scripts/forward-migrate.sh`（`make migrate-forward`）。

--- a/docs/forward-migration-v1.9.md
+++ b/docs/forward-migration-v1.9.md
@@ -1,0 +1,79 @@
+# 索引契约收敛 + 前向迁移 (v1.8 → v1.9)
+
+> YUJ-4534 阶段 8 · 分叉 B（两索引摄入链收敛）· 由 octo-search-indexer 侧实施。
+> 权威 plan：YUJ-4662 PLAN-FULL v1 + YUJ-4534「Yu 裁决」(2026-06-16)。
+
+## 为什么要收敛
+
+octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查 OpenSearch，读的是
+**reader 契约** `source.go::Doc`（camelCase 嵌套）。但本仓 indexer 历史上写的是另一套
+**flat snake_case** doc（`message_id/content/...`）到索引 `octo-message`。两套字段名/形态不一致
+——若 reader 读不到 indexer 写的字段，阶段 1-7 建的整条摄入链白做。
+
+本次把 indexer 写成 **reader 能读的 doc 契约**（reader 不动）。逐字段对齐见下。
+
+## 契约对齐表（v1.9，逐字段对照 reader `Doc`）
+
+| reader Doc 字段 | 类型 | indexer 写入来源 | 备注 |
+|---|---|---|---|
+| `messageId` | long | message_id（VARCHAR(20) 解析为 int64） | **全精度**，snowflake id 不被 float64 截断；= ES `_id` |
+| `messageSeq` | long | message.message_seq 列（backfill）| reader channel_offset「清空会话」gate |
+| `from` | keyword | from_uid | sender 过滤 / 鉴权 |
+| `channelId` | keyword | channel_id | 频道鉴权过滤 |
+| `channelType` | integer | channel_type | 频道类型分流 |
+| `spaceId` | keyword | payload.space_id（backfill）| **p2p space 召回过滤**，缺则 reader fail-closed（V1b 红） |
+| `visibles` | keyword[] | payload.visibles（backfill）| **群系统消息白名单 gate**，缺则 reader fail-OPEN（V3b 红，安全项） |
+| `timestamp` | date(epoch_second) | message.timestamp | sort 字段（+ messageId） |
+| `payload.type` | integer | content_type | reader `_search_all` 分流 |
+| `payload.text.content` | text(IK) | content（仅文本） | ik_max_word 建索引 / ik_smart 查询 |
+| `createdAt` | long | UNIX_TIMESTAMP(created_at) | 对账窗口字段 |
+| `rawExcluded` | boolean | raw_excluded | Signal/非文本占位 doc 标记 |
+| `source` | keyword | source | 来源（ETL/CDC） |
+
+- **排序**：reader cursor sort = `timestamp` + `messageId`（dsl.go::applySort）。两字段都已就位。
+- **alias**：reader 读 `wukongim-messages-read`（pattern `wukongim-messages-*`）。新 mapping 内嵌该 alias。
+
+## 实时 consumer 路径 vs backfill 路径（关键差异）
+
+| 路径 | 数据来源 | 能否填 spaceId/visibles/messageSeq |
+|---|---|---|
+| backfill（`internal/backfill`） | **原始 MySQL payload + message_seq 列** | ✅ 能自源填全（V1b/V3b 解红） |
+| 实时 consumer（`internal/consumer`） | Kafka 契约 `searchmsg.Message` | ❌ 契约不带这三字段 → 写空（reader 安全方向：fail-closed/无 gate/保守隐藏） |
+
+**实时路径填全这三字段 = 阶段 9 上线前置（跨仓 sibling）**：需扩 `octo-lib/contract/searchmsg.Message`
+（+SpaceID/+Visibles/+MessageSeq，SchemaVersion 1→2）+ octo-server `modules/searchetl` producer 富化，
+随阶段 9 开 Kafka.On 一并上线。本期 Kafka.On=OFF（plan §6），无实时流量，存量由 backfill 填全即可。
+
+## 前向迁移三步（钉死，禁半新半旧 doc 同 alias 服务）
+
+脚本：`scripts/forward-migrate.sh`（`make migrate-forward`）。
+
+1. **写新契约索引**（mapping v1.9）：`STEP=1`。建索引时剥离 aliases 段，alias 第③步单独原子挂，
+   保证 reindex 完成前 read alias 不指向半空新索引。
+2. **存量 reindex** 旧索引 → 新契约索引：`STEP=2`。painless 把 flat snake_case 映射成 camelCase 嵌套。
+   - ⚠️ reindex 只能搬旧索引**已有**字段；spaceId/visibles/messageSeq 旧链没写 → 新 doc 这三字段空。
+   - **存量富化**：要让存量 doc 带 spaceId/visibles/messageSeq，跑 backfill 重灌（`cmd/backfill`，
+     读原始 MySQL payload）到新索引（`BACKFILL_ES_INDEX=<新索引>`）。backfill 与 reindex 幂等同 _id，
+     重叠安全；重灌覆盖 reindex 的空字段。生产推荐：直接 backfill 重灌新索引，跳过 reindex 的空壳。
+3. **alias 原子切换** read alias → 新索引：`STEP=3`。**前置门**：先 `make run-recon RECON_ES_INDEX=<新索引>`
+   抽样对账通过（doc_drift==0 且 sample_mismatch==0 且 sample_missing==0）再切。
+
+### 回滚
+- read alias 秒切回旧索引（脚本末尾 ROLLBACK 段）。
+- 旧索引保留 ≥7 天再删。
+- 切 alias 前的任意步骤失败：旧索引仍在 alias 上服务，零影响。
+
+## 对账门（步骤 5）
+
+`cmd/reconcile`（`make run-recon` / `make run-recon-json`）：
+- **count 对账**：ES doc-count vs MySQL 行数（扣 DLQ；raw_excluded 仍占 doc 不扣）。`doc_drift = ESDocs − MySQL行数`。
+- **抽样字段比对**：取 N 条样本，按 message_id 拉 ES doc，逐字段核对
+  `messageId/channelId/channelType/spaceId/visibles/messageSeq`，检出「条数对得上但字段错位」的静默 drift。
+- **阈值（机检，钉死在 internal/recon）**：`doc_drift!=0` 或 `sample_mismatch!=0` 或 `sample_missing!=0` → 不健康，退出码 2。
+- **回填 octo-server**：`-push-url` POST `PushPayload`（逐字段对齐 `recon_metrics.go::ReconReport`）到只读
+  ingestion 端 → `search_recon_doc_drift` / `search_recon_sample_mismatch` / `search_recon_last_run_timestamp_seconds` gauge。
+
+## 上线纪律
+
+本票只到「写新契约 + reindex/backfill + alias 切」的**代码与本地/预发验证**层面。
+真实生产开 Kafka.On + 灰度放量归阶段 9，不在本票上线生产。

--- a/docs/forward-migration-v1.9.md
+++ b/docs/forward-migration-v1.9.md
@@ -31,7 +31,8 @@ octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查
 | `source` | keyword | source | 来源（ETL/CDC） |
 
 - **排序**：reader cursor sort = `timestamp` + `messageId`（dsl.go::applySort）。两字段都已就位。
-- **alias**：reader 读 `wukongim-messages-read`（pattern `wukongim-messages-*`）。新 mapping 内嵌该 alias。
+- **alias**：reader 读 `wukongim-messages-read`（pattern `wukongim-messages-*`）。**mapping 不再内嵌该 alias**
+  （v1.9 R2：裸 PUT 默认安全，建索引 ≠ 上线）——alias 只在迁移步骤③ reindex + 抽样对账通过后单独原子挂。
 
 ## 实时 consumer 路径 vs backfill 路径（关键差异）
 
@@ -53,8 +54,8 @@ octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查
 
 脚本：`scripts/forward-migrate.sh`（`make migrate-forward`）。
 
-1. **写新契约索引**（mapping v1.9）：`STEP=1`。建索引时剥离 aliases 段，alias 第③步单独原子挂，
-   保证 reindex 完成前 read alias 不指向半空新索引。
+1. **写新契约索引**（mapping v1.9）：`STEP=1`。mapping 已不含 aliases 段（裸 PUT 默认安全），
+   脚本仍兜底剥离；alias 第③步单独原子挂，保证 reindex 完成前 read alias 不指向半空新索引。
 2. **存量 reindex** 旧索引 → 新契约索引：`STEP=2`。painless 把 flat snake_case 映射成 camelCase 嵌套。
    - ⚠️ reindex 只能搬旧索引**已有**字段；spaceId/visibles/messageSeq 旧链没写 → 新 doc 这三字段空。
    - **存量富化**：要让存量 doc 带 spaceId/visibles/messageSeq，跑 backfill 重灌（`cmd/backfill`，
@@ -62,6 +63,8 @@ octo-server 的读路径（`modules/messages_search`，PR#361/#374/#385）直查
      重叠安全；重灌覆盖 reindex 的空字段。生产推荐：直接 backfill 重灌新索引，跳过 reindex 的空壳。
 3. **alias 原子切换** read alias → 新索引：`STEP=3`。**前置门**：先 `make run-recon RECON_ES_INDEX=<新索引>`
    抽样对账通过（doc_drift==0 且 sample_mismatch==0 且 sample_missing==0）再切。
+   切换在单个 `_aliases` 事务内 `remove(index="*", must_exist=false)` + `add(新索引)`：从**任意**当前
+   挂着的索引摘掉 alias 再挂新索引（幂等 + 保证 alias 任何时刻单指向，杜绝半新半旧同 alias）。
 
 ### 回滚
 - read alias 秒切回旧索引（脚本末尾 ROLLBACK 段）。

--- a/harness/README.md
+++ b/harness/README.md
@@ -12,6 +12,25 @@ seed → Kafka octo.message.v1 → es-indexer consumer → OpenSearch (analysis-
 > `messageSeq`，alias `wukongim-messages-read`）。harness 的 message_id 因此用**数值** snowflake 串
 > （reader 读 `messageId` 为 long；非数值串会被判毒丸进 DLQ）。详见 `docs/forward-migration-v1.9.md`。
 
+> 🔒 **v1.9 实时写入安全门（YUJ-4698 / Jerry-Xin Critical）— 决定该用哪条 e2e 路径。**
+> 实时 consumer（`internal/consumer.Service.Run`）在 Kafka 契约（octo-lib `searchmsg.SchemaVersion`）
+> **未携带** reader 安全字段（`spaceId`/`visibles`/`messageSeq`，即 `SchemaVersion < 2`）时**拒启动**
+> （fail-CLOSED）：放行会让 reader 对空 `visibles` fail-OPEN（普通成员搜出群管才可见消息）。这是
+> 生产安全设计，**harness 不可绕过、也不应削弱**。
+>
+> 后果：当前契约 `SchemaVersion=1` 下，**`./harness/run.sh all`（Kafka→consumer→OpenSearch
+> 实时链）跑不通**——indexer 在消费前就退出。`run.sh` 会先跑 `./harness/contractgate`（复用
+> consumer 同一判定 `esindex.LiveContractCarriesSafetyFields()`，永不与生产门冲突）探测门状态：
+> - **门关（现状，SchemaVersion=1）**：`run.sh all` 不再尝试拉栈/seed，而是打印指引并 exit 0，
+>   把 v1.9 e2e 引到下面的 **backfill harness**——这是当前唯一能端到端验证 v1.9 reader 契约的路径
+>   （只有 backfill 能从 MySQL payload 自源填全 `spaceId`/`visibles`/`messageSeq`）。
+> - **门开（octo-lib 升 `SchemaVersion>=2` + 阶段 9 producer 富化后）**：门自动解封，`run.sh all`
+>   重新驱动实时链，**无需改 harness**。
+>
+> 单独看门状态：`./harness/run.sh gate`（门开 exit 0 / 门关 exit≥1，并打印当前 SchemaVersion）。
+> （仅在契约已升到 `>=2` 后才有意义的逃生口：`FORCE_LIVE=1 ./harness/run.sh all` 跳过预检直跑实时链；
+> indexer 仍自带同一安全门自检，所以这个开关无法绕过生产安全门。）
+
 > 🔒 **Isolation.** This is a local-only stack (`docker compose`). It is NEVER
 > wired into a shared test environment, and the indexer's `Kafka.On` / real
 > deployment wiring stays off until a separate, explicitly signed-off step.
@@ -24,22 +43,34 @@ seed → Kafka octo.message.v1 → es-indexer consumer → OpenSearch (analysis-
 | --- | --- |
 | `docker-compose.yml` | Kafka (KRaft, 1 broker) + OpenSearch (1 node) |
 | `opensearch-ik.Dockerfile` | OpenSearch image with the `analysis-ik` plugin installed (version-matched) |
-| `run.sh` | orchestrator: `up` (build+start+create topics) / `down` / `seed` / `verify` / `all` |
+| `run.sh` | orchestrator: `up` / `down` / `gate` (print live-ingestion gate state) / `seed` / `verify` / `all` |
+| `contractgate/` | harness-only probe: reports whether the compiled contract carries the reader safety fields (live gate open/closed); reuses the consumer's own predicate so it can't disagree with production |
 | `seed/` | producer of a controlled message suite (normal / 中文 / raw_excluded / duplicate _id / unknown schema / bad JSON) and a `-mode bulk -n N` throughput load |
 | `verify/` | asserts the invariants against OpenSearch |
 
 ## Run it
 
+> ⚠️ At the current contract (`SchemaVersion=1`) the **live** path below is gated
+> off (see the v1.9 safety-gate note above). `./harness/run.sh all` will detect
+> this, print guidance, and route you to `./harness/run-backfill.sh` — the
+> backfill harness is the v1.9 end-to-end verification path today. The live steps
+> below become runnable again once the contract is bumped to `SchemaVersion>=2`.
+
 ```sh
+# inspect the live-ingestion safety gate first (exit 0 = open, e2e live path available)
+./harness/run.sh gate
+
 # full cycle: up → indexer → seed suite → verify invariants → down
+# (auto-skips with guidance while the live gate is closed)
 ./harness/run.sh
 
-# or step by step, leaving the stack up:
+# or step by step, leaving the stack up (only meaningful once the gate is OPEN):
 KEEP_UP=1 ./harness/run.sh up
 ES_INDEXER_ENABLED=true KAFKA_BROKERS=localhost:19092 \
   ES_ADDRESSES=http://localhost:19200 ES_INDEX=octo-message \
   KAFKA_DLQ_TOPIC=octo.message.v1.dlq INDEXER_DLQ_SPILL_DIR=/tmp/spill \
   go run ./cmd/es-indexer &        # start the indexer against the harness
+                                   # (exits immediately while the contract is SchemaVersion<2)
 
 # Fence the DLQ check to THIS run: capture the DLQ end offset BEFORE seeding.
 FENCE=$(docker exec octo-harness-kafka /opt/kafka/bin/kafka-get-offsets.sh \
@@ -88,6 +119,12 @@ a real broker + real OpenSearch.
   testing only — production uses authenticated endpoints (`ES_USERNAME`/`ES_PASSWORD`).
 
 ## Phase-6 backfill harness (`run-backfill.sh` + `backfill/`)
+
+> 🔒 **This is the v1.9 end-to-end verification path while the live-ingestion gate
+> is closed (current `SchemaVersion=1`).** Only backfill can populate the reader
+> safety fields (`spaceId`/`visibles`/`messageSeq`) — it reads them straight from
+> the MySQL payload — so it is the one path that exercises the full v1.9 reader
+> contract end to end against real infra today.
 
 A second, self-contained e2e that exercises the historical backfill job (`cmd/backfill`)
 against a real MySQL + OpenSearch(IK), bypassing Kafka:

--- a/harness/README.md
+++ b/harness/README.md
@@ -7,6 +7,11 @@ seed → Kafka octo.message.v1 → es-indexer consumer → OpenSearch (analysis-
                                       └→ octo.message.v1.dlq (poison pills)
 ```
 
+> **v1.9 契约收敛（YUJ-4534 阶段 8）**：索引 doc 已收敛到 octo-server reader 形态
+> （camelCase 嵌套，`messageId`(long) / `payload.text.content`(IK) / `spaceId` / `visibles` /
+> `messageSeq`，alias `wukongim-messages-read`）。harness 的 message_id 因此用**数值** snowflake 串
+> （reader 读 `messageId` 为 long；非数值串会被判毒丸进 DLQ）。详见 `docs/forward-migration-v1.9.md`。
+
 > 🔒 **Isolation.** This is a local-only stack (`docker compose`). It is NEVER
 > wired into a shared test environment, and the indexer's `Kafka.On` / real
 > deployment wiring stays off until a separate, explicitly signed-off step.

--- a/harness/backfill/main.go
+++ b/harness/backfill/main.go
@@ -92,6 +92,7 @@ func seed(ctx context.Context, dsn string, tables []string, base int64) error {
 	rows := []struct {
 		table       string
 		mid         string
+		messageSeq  int64
 		fromUID     string
 		channelID   string
 		channelType uint8
@@ -99,18 +100,20 @@ func seed(ctx context.Context, dsn string, tables []string, base int64) error {
 		signal      int
 		payload     string
 	}{
-		{t0, "h-en", "u1", "g1", 2, 0, 0, `{"type":1,"content":"hello world pipeline"}`},
-		{t0, "h-zh1", "u1", "g1", 2, 0, 0, `{"type":1,"content":"今天天气很好我们去公园散步吧"}`},
-		{t1, "h-zh2", "u2", "g1", 2, 0, 0, `{"type":1,"content":"搜索引擎中文分词测试北京欢迎你"}`},
-		{t1, "h-signal", "u3", "u3@u4", 1, 0, 1, `ENCRYPTED-NOT-JSON`},
-		{t0, "h-image", "u1", "g1", 2, 0, 0, `{"type":2,"url":"http://x/y.png"}`},
-		{t1, "h-bad", "u2", "g1", 2, 0, 0, `{not valid json`},
+		// 含 space_id（p2p）→ 验证 backfill 富化 reader 必读的 spaceId（V1b）。
+		{t0, "3000000000000000001", 11, "u1", "g1", 2, 0, 0, `{"type":1,"content":"hello world pipeline","space_id":"space-A"}`},
+		{t0, "3000000000000000002", 12, "u1", "g1", 2, 0, 0, `{"type":1,"content":"今天天气很好我们去公园散步吧"}`},
+		// 含 visibles（群系统消息白名单）→ 验证 backfill 富化 reader 必读的 visibles（V3b）。
+		{t1, "3000000000000000003", 13, "u2", "g1", 2, 0, 0, `{"type":1,"content":"搜索引擎中文分词测试北京欢迎你","visibles":["admin1"]}`},
+		{t1, "3000000000000000004", 14, "u3", "u3@u4", 1, 0, 1, `ENCRYPTED-NOT-JSON`},
+		{t0, "3000000000000000005", 15, "u1", "g1", 2, 0, 0, `{"type":2,"url":"http://x/y.png"}`},
+		{t1, "3000000000000000006", 16, "u2", "g1", 2, 0, 0, `{not valid json`},
 	}
 	for i, r := range rows {
 		if _, err := db.ExecContext(ctx, fmt.Sprintf(
-			"INSERT INTO `%s` (message_id, from_uid, channel_id, channel_type, setting, `signal`, `timestamp`, created_at, payload) "+
-				"VALUES (?,?,?,?,?,?,?,FROM_UNIXTIME(?),?)", r.table),
-			r.mid, r.fromUID, r.channelID, r.channelType, r.setting, r.signal, base, base+int64(i), r.payload,
+			"INSERT INTO `%s` (message_id, message_seq, from_uid, channel_id, channel_type, setting, `signal`, `timestamp`, created_at, payload) "+
+				"VALUES (?,?,?,?,?,?,?,?,FROM_UNIXTIME(?),?)", r.table),
+			r.mid, r.messageSeq, r.fromUID, r.channelID, r.channelType, r.setting, r.signal, base, base+int64(i), r.payload,
 		); err != nil {
 			return fmt.Errorf("insert %s: %w", r.mid, err)
 		}
@@ -134,6 +137,7 @@ func createTable(ctx context.Context, db *sql.DB, table string) error {
 		"CREATE TABLE `%s` ("+
 			"id BIGINT AUTO_INCREMENT PRIMARY KEY, "+
 			"message_id VARCHAR(20) NOT NULL, "+
+			"message_seq BIGINT NOT NULL DEFAULT 0, "+
 			"from_uid VARCHAR(40) NOT NULL DEFAULT '', "+
 			"channel_id VARCHAR(100) NOT NULL DEFAULT '', "+
 			"channel_type TINYINT UNSIGNED NOT NULL DEFAULT 0, "+
@@ -181,15 +185,15 @@ func verify(ctx context.Context, esURL, index string, base int64) error {
 		log.Printf("PASS: raw_excluded=%d (Signal + non-text, still occupy ES docs)", rawEx)
 	}
 	// Positively assert the bad-JSON row is NOT in ES (it went to DLQ spill).
-	badPresent, err := count(ctx, client, index, idsQuery("h-bad"))
+	badPresent, err := count(ctx, client, index, idsQuery("3000000000000000006"))
 	if err != nil {
 		return err
 	}
 	if badPresent != 0 {
-		log.Printf("FAIL: real-anomaly row h-bad must NOT be in ES, found %d", badPresent)
+		log.Printf("FAIL: real-anomaly row 3000000000000000006 must NOT be in ES, found %d", badPresent)
 		fail = true
 	} else {
-		log.Printf("PASS: real-anomaly row h-bad absent from ES (routed to DLQ spill)")
+		log.Printf("PASS: real-anomaly row 3000000000000000006 absent from ES (routed to DLQ spill)")
 	}
 	if fail {
 		return fmt.Errorf("backfill e2e verification FAILED")
@@ -224,7 +228,7 @@ func rangeQuery(from, to int64) map[string]any {
 func rawExcludedQuery(from, to int64) map[string]any {
 	return map[string]any{"query": map[string]any{"bool": map[string]any{"filter": []any{
 		rangeFilter(from, to),
-		map[string]any{"term": map[string]any{"raw_excluded": true}},
+		map[string]any{"term": map[string]any{"rawExcluded": true}},
 	}}}}
 }
 
@@ -233,7 +237,7 @@ func idsQuery(id string) map[string]any {
 }
 
 func rangeFilter(from, to int64) map[string]any {
-	return map[string]any{"range": map[string]any{"created_at": map[string]any{"gte": from, "lte": to}}}
+	return map[string]any{"range": map[string]any{"createdAt": map[string]any{"gte": from, "lte": to}}}
 }
 
 func mustClose(db *sql.DB) {

--- a/harness/contractgate/main.go
+++ b/harness/contractgate/main.go
@@ -1,0 +1,36 @@
+// Command contractgate is a harness-only probe that reports whether the Kafka
+// contract compiled into this build (octo-lib searchmsg.SchemaVersion) carries
+// the reader safety fields (spaceId/visibles/messageSeq) — i.e. whether the live
+// consumer's safety gate (internal/consumer.Service.Run) will permit live
+// ingestion or refuse to start.
+//
+// It exists so the local Kafka e2e harness (run.sh) can decide, BEFORE bringing
+// up a stack and seeding, whether the live consumer path can run at all under the
+// current contract. It imports the SAME predicate the production consumer uses
+// (esindex.LiveContractCarriesSafetyFields), so it can never report a state that
+// disagrees with production — and it reads nothing, writes nothing, and is not
+// part of any production binary or deploy path.
+//
+//	exit 0  → "unlocked": contract carries safety fields; live ingestion permitted.
+//	exit 10 → "gated":    contract lacks safety fields; live consumer refuses to
+//	                       start (fail-closed). Use the backfill harness for v1.9 e2e.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+func main() {
+	if esindex.LiveContractCarriesSafetyFields() {
+		fmt.Printf("unlocked schema_version=%d safety_min=%d\n",
+			searchmsg.SchemaVersion, esindex.SafetyFieldsSchemaVersion)
+		os.Exit(0)
+	}
+	fmt.Printf("gated schema_version=%d safety_min=%d\n",
+		searchmsg.SchemaVersion, esindex.SafetyFieldsSchemaVersion)
+	os.Exit(10)
+}

--- a/harness/run.sh
+++ b/harness/run.sh
@@ -7,11 +7,32 @@
 # controlled message suite, and asserts the C2/C4 + idempotency + IK-tokenization
 # invariants. Throwaway local stack ONLY — never wired into a shared environment.
 #
+# 🔒 v1.9 LIVE-INGESTION SAFETY GATE (YUJ-4698 / Jerry-Xin Critical):
+#   The live consumer (internal/consumer.Service.Run) refuses to start while the
+#   Kafka contract (octo-lib searchmsg.SchemaVersion) does not carry the reader
+#   safety fields spaceId/visibles/messageSeq (i.e. SchemaVersion < 2). Writing
+#   live docs without those fields would fail-OPEN the reader's visibles gate, so
+#   the gate is fail-CLOSED by design and is NOT bypassable from this harness.
+#
+#   Consequence: at the current contract (SchemaVersion=1) `run.sh all` cannot
+#   drive a Kafka->consumer->OpenSearch e2e — the indexer exits before consuming.
+#   This script detects that up front (./harness/contractgate) and tells you to
+#   use ./harness/run-backfill.sh, which IS the v1.9 e2e path: only backfill can
+#   populate the safety fields (read straight from MySQL payload), so it exercises
+#   the full v1.9 reader contract end to end. When octo-lib bumps SchemaVersion>=2
+#   (phase 9 producer enrichment), the gate auto-unlocks and `run.sh all` drives
+#   the live path again — no harness change needed.
+#
 # Usage:
 #   ./harness/run.sh            # full run: up -> indexer -> seed -> verify -> down
+#                               #   (auto-skips with guidance while the live gate is closed)
 #   ./harness/run.sh up         # just bring the stack up
 #   ./harness/run.sh down       # tear the stack down (+volumes)
+#   ./harness/run.sh gate       # print the live-ingestion gate state and exit
 #   KEEP_UP=1 ./harness/run.sh  # leave the stack running after verify
+#   FORCE_LIVE=1 ./harness/run.sh  # (advanced) run live path even if gate reports closed;
+#                               #   the indexer still enforces its own gate, so this only
+#                               #   makes sense once the contract is bumped to SchemaVersion>=2
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,6 +44,65 @@ ES_URL="${ES_URL:-http://localhost:19200}"
 ES_INDEX="${ES_INDEX:-octo-message}"
 
 compose() { docker compose "$@"; }
+
+# live_gate_open reports whether the live-ingestion safety gate is currently OPEN
+# (contract carries spaceId/visibles/messageSeq, SchemaVersion>=2). It delegates to
+# ./harness/contractgate, which imports the SAME predicate the production consumer
+# uses (esindex.LiveContractCarriesSafetyFields) so it can never disagree with the
+# indexer's own startup check.
+#
+# contractgate exit codes: 0 = gate OPEN, 10 = gate CLOSED (gated by design). Any
+# OTHER non-zero (compile error, broken import, missing Go toolchain) is a broken
+# probe, NOT a closed gate — we must fail loudly rather than treat a broken harness
+# as a passing skip (would mask real breakage).
+#
+# NB: we `go build` the probe to a temp binary and run THAT, rather than `go run`:
+# `go run` collapses any non-zero program exit to 1, which would make the gated
+# exit 10 indistinguishable from a compile error. Building first preserves the
+# probe's real exit code (and a build failure is itself surfaced as a probe error).
+#
+# Returns: 0 = open, 10 = closed-by-design, other = probe error (caller must abort).
+live_gate_open() {
+  local bin="/tmp/octo-contractgate.bin"
+  if ! ( cd "$ROOT" && go build -o "$bin" ./harness/contractgate ) >/tmp/octo-contractgate.out 2>&1; then
+    return 3 # build failed → broken probe
+  fi
+  "$bin" >/tmp/octo-contractgate.out 2>&1
+}
+
+gate() {
+  echo "[harness] checking live-ingestion safety gate (octo-lib contract)..."
+  local rc=0
+  live_gate_open || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "[harness] gate=OPEN — $(cat /tmp/octo-contractgate.out)"
+    echo "[harness] live Kafka->consumer->OpenSearch e2e is available."
+    return 0
+  fi
+  if [[ $rc -ne 10 ]]; then
+    echo "[harness] FATAL: contract gate probe failed (exit $rc) — this is a broken probe," >&2
+    echo "[harness] not a closed gate. Refusing to skip silently. Probe output:" >&2
+    sed 's/^/[harness]   /' /tmp/octo-contractgate.out >&2
+    return 2
+  fi
+  echo "[harness] gate=CLOSED — $(cat /tmp/octo-contractgate.out)"
+  cat >&2 <<'GATE'
+[harness] The live consumer refuses to start at this contract version: the Kafka
+[harness] contract does not yet carry the reader safety fields (spaceId/visibles/
+[harness] messageSeq), so live ingestion would fail-OPEN the reader's visibles gate.
+[harness] This is the v1.9 fail-CLOSED safety gate (by design), not a harness bug.
+[harness]
+[harness] v1.9 end-to-end verification path → use the backfill harness instead:
+[harness]     ./harness/run-backfill.sh
+[harness] It populates spaceId/visibles/messageSeq from MySQL payload and asserts the
+[harness] full v1.9 reader contract (camelCase nested doc, IK 中文 recall, reconcile gate)
+[harness] end to end against real OpenSearch.
+[harness]
+[harness] When octo-lib bumps SchemaVersion>=2 (phase 9 producer enrichment), this gate
+[harness] auto-unlocks and `./harness/run.sh all` drives the live path again.
+GATE
+  return 1
+}
 
 up() {
   echo "[harness] building + starting Kafka + OpenSearch(IK)..."
@@ -138,9 +218,31 @@ verify() {
 case "${1:-all}" in
   up) up ;;
   down) down ;;
+  gate) gate ;;
   seed) seed ;;
   verify) verify ;;
   all)
+    # 🔒 v1.9 gate pre-flight: the live consumer will refuse to start while the
+    # contract lacks safety fields, so seed/verify can never pass. Detect that
+    # up front and point at the backfill harness instead of bringing up a stack
+    # that the indexer would immediately bail out of. FORCE_LIVE=1 overrides for
+    # when the contract has been bumped (the indexer still self-enforces the gate).
+    #
+    # Distinguish closed-by-design (gate rc=1, skip cleanly) from a BROKEN probe
+    # (gate rc>=2, e.g. compile error): a broken probe must abort, not masquerade
+    # as a passing skip.
+    if [[ "${FORCE_LIVE:-0}" != "1" ]]; then
+      grc=0
+      gate || grc=$?
+      if [[ $grc -ge 2 ]]; then
+        echo "[harness] aborting: contract gate probe is broken (see error above)." >&2
+        exit "$grc"
+      fi
+      if [[ $grc -ne 0 ]]; then
+        echo "[harness] skipping live e2e (gate closed). See guidance above." >&2
+        exit 0
+      fi
+    fi
     up
     run_indexer
     trap 'stop_indexer' EXIT
@@ -150,5 +252,5 @@ case "${1:-all}" in
     if [[ "${KEEP_UP:-0}" != "1" ]]; then down; fi
     echo "[harness] e2e run complete."
     ;;
-  *) echo "usage: $0 {all|up|down|seed|verify}"; exit 1 ;;
+  *) echo "usage: $0 {all|up|down|gate|seed|verify}"; exit 1 ;;
 esac

--- a/harness/seed/main.go
+++ b/harness/seed/main.go
@@ -75,15 +75,15 @@ func suite(base int64) []kafka.Message {
 		})
 	}
 	// 正常英文 + 中文（验证 IK 分词召回）。
-	out = append(out, text("m-en-1", "hello world search pipeline"))
-	out = append(out, text("m-zh-1", "今天天气很好我们去公园散步吧"))
-	out = append(out, text("m-zh-2", "搜索引擎中文分词测试：北京欢迎你"))
+	out = append(out, text("1000000000000000001", "hello world search pipeline"))
+	out = append(out, text("1000000000000000002", "今天天气很好我们去公园散步吧"))
+	out = append(out, text("1000000000000000003", "搜索引擎中文分词测试：北京欢迎你"))
 	// 重复 message_id（幂等：写两次，ES 只应有一条 doc）。
-	out = append(out, text("m-dup", "first copy"))
-	out = append(out, text("m-dup", "second copy overwrites same _id"))
+	out = append(out, text("1000000000000000004", "first copy"))
+	out = append(out, text("1000000000000000004", "second copy overwrites same _id"))
 	// raw_excluded（Signal 加密 / 非文本）：content=null，仍写入 ES 占一个 doc。
 	out = append(out, contractMsg(searchmsg.Message{
-		SchemaVersion: searchmsg.SchemaVersion, MessageID: "m-signal", ChannelID: "u1@u2", ChannelType: 1,
+		SchemaVersion: searchmsg.SchemaVersion, MessageID: "1000000000000000005", ChannelID: "u1@u2", ChannelType: 1,
 		FromUID: "u1", Content: nil, RawExcluded: true, MsgTimestamp: base, CreatedAt: base,
 		Source: searchmsg.SourceETLMessageTable,
 	}))
@@ -102,7 +102,7 @@ func bulk(n int, base int64) []kafka.Message {
 		c := fmt.Sprintf("消息正文 message body number %d 测试中文分词与吞吐", i)
 		out = append(out, contractMsg(searchmsg.Message{
 			SchemaVersion: searchmsg.SchemaVersion,
-			MessageID:     fmt.Sprintf("bulk-%08d", i),
+			MessageID:     fmt.Sprintf("%d", int64(2000000000000000000)+int64(i)),
 			ChannelID:     "g_bulk", ChannelType: 2, FromUID: "u_bulk",
 			Content: &c, ContentType: 1, MsgTimestamp: base, CreatedAt: base + int64(i%3600),
 			Source: searchmsg.SourceETLMessageTable,

--- a/harness/verify/main.go
+++ b/harness/verify/main.go
@@ -85,18 +85,18 @@ func main() {
 	check("consumer-group-drained", drainErr)
 
 	// Positives: these poll until present, confirming healthy indexing.
-	// Invariant: idempotency — duplicate message_id => exactly one doc.
-	check("idempotent-dup", v.expectDocExists(ctx, "m-dup"))
-	check("idempotent-count", v.expectCount(ctx, term("message_id", "m-dup"), 1))
+	// Invariant: idempotency — duplicate message_id => exactly one doc (_id = normalized messageId).
+	check("idempotent-dup", v.expectDocExists(ctx, "1000000000000000004"))
+	check("idempotent-count", v.expectCount(ctx, term("messageId", "1000000000000000004"), 1))
 
 	// Invariant: raw_excluded doc IS indexed (content null), occupies a doc.
-	check("raw-excluded-indexed", v.expectDocExists(ctx, "m-signal"))
+	check("raw-excluded-indexed", v.expectDocExists(ctx, "1000000000000000005"))
 
-	// Invariant: IK tokenization — Chinese query term recalls the doc.
-	check("ik-recall-公园", v.expectMatchAtLeast(ctx, "content", "公园", 1))
-	check("ik-recall-北京", v.expectMatchAtLeast(ctx, "content", "北京", 1))
+	// Invariant: IK tokenization — Chinese query term recalls the doc (reader nested field).
+	check("ik-recall-公园", v.expectMatchAtLeast(ctx, "payload.text.content", "公园", 1))
+	check("ik-recall-北京", v.expectMatchAtLeast(ctx, "payload.text.content", "北京", 1))
 	// English still works.
-	check("en-recall-pipeline", v.expectMatchAtLeast(ctx, "content", "pipeline", 1))
+	check("en-recall-pipeline", v.expectMatchAtLeast(ctx, "payload.text.content", "pipeline", 1))
 
 	// 🔴 C4 schema gate — verify BOTH directions:
 	//  (1) positive: the DLQ topic actually CONTAINS the poison-pill keys (routing happened);
@@ -104,8 +104,8 @@ func main() {
 	// The negative assertions only stand once the group is proven drained.
 	check("dlq-contains-poison", kv.expectDLQKeys(ctx, *dlqTopic, []string{"m-badschema", "m-badjson"}, fence, 60*time.Second))
 	if drainErr == nil {
-		check("badschema-not-indexed", v.expectCount(ctx, term("message_id", "m-badschema"), 0))
-		check("badjson-not-indexed", v.expectCount(ctx, term("message_id", "m-badjson"), 0))
+		check("badschema-not-indexed", v.expectCount(ctx, term("_id", "m-badschema"), 0))
+		check("badjson-not-indexed", v.expectCount(ctx, term("_id", "m-badjson"), 0))
 	} else {
 		failures = append(failures, "badschema/badjson: skipped — consumer drain not proven")
 		log.Printf("FAIL badschema/badjson: skipped — consumer drain not proven (%v)", drainErr)

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -169,10 +169,23 @@ func recoverAndLoad(path string, syncedLen int64) (map[string]dlqMeta, error) {
 	}
 	// [0, syncedLen) 是既 fsync、又与 checkpoint 一致的干净前缀：必由完整记录构成、以换行结尾。
 	// 任何偏差（非换行结尾 / 解析失败）都是该持久区内的真损坏，致命。
-	if data[len(data)-1] != '\n' {
+	return parseSyncedSpillPrefix(data)
+}
+
+// parseSyncedSpillPrefix 解析 spill 的「已 fsync 同步前缀」（调用方保证传入的 prefix 恰好是
+// [0, syncedLen) 字节）并重建去重集。该前缀必由完整记录构成、以换行结尾——任何偏差（非换行
+// 结尾 / 记录解析失败）都是该持久区内的真损坏，致命（fail-closed）。空前缀 = 无任何持久记录。
+// 抽离为共享函数：让 OpenDLQSpill 的崩溃恢复路径与 standalone reconcile 的只读加载路径
+// (LoadDLQMessageIDsInWindow) 用**同一**解析/校验逻辑，杜绝两条路径口径漂移。
+func parseSyncedSpillPrefix(prefix []byte) (map[string]dlqMeta, error) {
+	seen := map[string]dlqMeta{}
+	if len(prefix) == 0 {
+		return seen, nil
+	}
+	if prefix[len(prefix)-1] != '\n' {
 		return nil, fmt.Errorf("backfill: synced spill prefix does not end at a record boundary (real corruption)")
 	}
-	for _, line := range bytes.Split(data[:len(data)-1], []byte{'\n'}) {
+	for _, line := range bytes.Split(prefix[:len(prefix)-1], []byte{'\n'}) {
 		if len(bytes.TrimSpace(line)) == 0 {
 			continue
 		}
@@ -280,7 +293,66 @@ func (s *DLQSpill) MessageIDsInWindow(fromUnix, toUnix int64) map[string]bool {
 	return out
 }
 
-// Sync 把已 append 的 DLQ 记录刷盘（fsync），再原子推进 offset sidecar 到当前文件长度。
+// LoadDLQMessageIDsInWindow 只读地从 backfill 落下的 DLQ spill 文件加载 created_at ∈
+// [fromUnix, toUnix] 的去重 DLQ 记录的**真实**（非空）message_id 集合。这是 standalone
+// reconcile（cmd/reconcile）的 MessageIDsInWindow 对应物：standalone 路径不跑 backfill、没有
+// in-memory *DLQSpill，故直接从 backfill job 留下的 spill 文件复原同一份排除集，让 standalone
+// 与 inline 两条字段级抽样门对 DLQ 行的处理**口径一致**——合法 DLQ 行（坏 payload / 永久 ES
+// 拒绝，已记账为 DLQ）被抽样命中时不再误判为 sample_missing → 不再 false exit 2 阻塞 alias 切换。
+//
+// 语义与 (*DLQSpill).MessageIDsInWindow 严格一致：以 dedupKey 去重、只吐**非空** message_id、
+// 按 created_at 窗过滤。durability 口径与 OpenDLQSpill 崩溃恢复**完全一致**（fail-closed）：
+//   - dir=="" → 返回空集（无排除：行为退化回旧的 CompareSamples）。
+//   - spill 文件不存在 → 空集、不报错：standalone recon 可能跑在压根没 backfill spill 的环境
+//     （如 reindex-only 链路），「无 spill」等价「无 DLQ 行」。
+//   - **只信任 offset sidecar 记录的已 fsync 同步前缀** `[0, syncedLen)`，且复用 inline 路径同一个
+//     解析器（parseSyncedSpillPrefix）：前缀必以记录边界（换行）结尾、每条完整记录可解析，否则致命。
+//   - sidecar 缺失 / 为空（syncedLen==0）→ **视作无任何持久 DLQ 记录**，返回空集（与 OpenDLQSpill
+//     把 offset 0 当「无持久记录」一致）。绝不退化去信任未 fsync 的裸 .ndjson 后缀——那会让 standalone
+//     在崩溃 / 部分拷贝 / 损坏 sidecar 场景下信任不持久数据、对这些 id 跳过 sample_missing，与 inline 门
+//     口径漂移。「无可信前缀」时回退到「不排除」是安全侧：最坏只是把合法 DLQ 行算成 missing（门转红、
+//     人工复核），绝不会把真漏灌悄悄放过。
+//   - 文件比 syncedLen 还短 → 持久层不一致，致命（不可静默放过）。
+func LoadDLQMessageIDsInWindow(dir string, fromUnix, toUnix int64) (map[string]bool, error) {
+	out := make(map[string]bool)
+	if dir == "" {
+		return out, nil
+	}
+	syncedLen, err := readSyncedOffset(filepath.Join(dir, "backfill-dlq.synced"))
+	if err != nil {
+		return nil, err
+	}
+	if syncedLen == 0 {
+		// 无 sidecar / 空 sidecar：无任何已 fsync 的持久前缀可信任 → 不排除（fail-closed 安全侧）。
+		return out, nil
+	}
+
+	path := filepath.Join(dir, "backfill-dlq.ndjson")
+	data, err := os.ReadFile(path) //nolint:gosec // path 来自运维配置，非用户输入
+	if err != nil {
+		if os.IsNotExist(err) {
+			// sidecar 说有 syncedLen 字节，但 spill 文件不存在：持久状态丢失，致命（与 recoverAndLoad 一致）。
+			return nil, fmt.Errorf("backfill: dlq spill offset sidecar says %d bytes but spill file is missing (durability state lost; manual inspection required)", syncedLen)
+		}
+		return nil, fmt.Errorf("backfill: read dlq spill for reconcile exclusion: %w", err)
+	}
+	if syncedLen > int64(len(data)) {
+		// 文件比已记录的同步长度还短：持久层不一致（被外部截断/损坏），不可静默放过。
+		return nil, fmt.Errorf("backfill: dlq spill (%d bytes) shorter than synced offset (%d) — durability state lost; manual inspection required", len(data), syncedLen)
+	}
+
+	// 只解析已 fsync 的同步前缀，复用 inline 崩溃恢复的同一解析/校验逻辑（杜绝口径漂移）。
+	seen, err := parseSyncedSpillPrefix(data[:syncedLen])
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range seen {
+		if m.messageID != "" && m.createdAt >= fromUnix && m.createdAt <= toUnix {
+			out[m.messageID] = true
+		}
+	}
+	return out, nil
+}// Sync 把已 append 的 DLQ 记录刷盘（fsync），再原子推进 offset sidecar 到当前文件长度。
 // **必须在推进 checkpoint 前调用**：否则主机崩溃 / 延迟写回失败可能让 checkpoint 跳过某些 id，
 // 而它们的 DLQ 记录尚未落盘 → resume 后 DLQ 漏计、该行不经手动回退 checkpoint 不可恢复
 // （durability ordering：先让 DLQ 落盘 + offset 记账，再推进游标）。

--- a/internal/backfill/dlq.go
+++ b/internal/backfill/dlq.go
@@ -48,10 +48,18 @@ type DLQSpill struct {
 
 	mu         sync.Mutex
 	f          *os.File
-	seen       map[string]int64 // dedup key (message_id) -> created_at（按窗计数用）
-	pendingLen int64            // 当前文件总字节数（含尚未 fsync 的 append）
-	syncedLen  int64            // 已 fsync 且已记入 offset sidecar 的持久长度（字节）
+	seen       map[string]dlqMeta // dedup key (message_id, 空则 table:id) -> 记账元数据
+	pendingLen int64              // 当前文件总字节数（含尚未 fsync 的 append）
+	syncedLen  int64              // 已 fsync 且已记入 offset sidecar 的持久长度（字节）
 	nowUnix    func() int64
+}
+
+// dlqMeta 是单条去重 DLQ 记录的记账元数据。createdAt 供按窗对账；messageID 是源行的**真实**
+// message_id（可能为空——空 message_id 行的去重键退化为 table:id，但其真实 message_id 仍记为空），
+// 供抽样门排除集用：只有非空 message_id 才能与 ES doc / 抽样行对齐，故 MessageIDsInWindow 只吐非空值。
+type dlqMeta struct {
+	createdAt int64
+	messageID string
 }
 
 // OpenDLQSpill 打开（或创建）spill 文件，并从既有内容重建去重集 + 计数（resume 安全）。
@@ -127,8 +135,8 @@ func readSyncedOffset(offsetPath string) (int64, error) {
 
 // recoverAndLoad 把 spill 截断到 syncedLen（丢弃未 fsync 的脏后缀），再严格解析 [0, syncedLen)
 // 干净前缀，重建去重集 + 计数。
-func recoverAndLoad(path string, syncedLen int64) (map[string]int64, error) {
-	seen := map[string]int64{}
+func recoverAndLoad(path string, syncedLen int64) (map[string]dlqMeta, error) {
+	seen := map[string]dlqMeta{}
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -172,7 +180,7 @@ func recoverAndLoad(path string, syncedLen int64) (map[string]int64, error) {
 		if err := json.Unmarshal(line, &rec); err != nil {
 			return nil, fmt.Errorf("backfill: corrupt record in synced spill prefix during replay (real corruption): %w", err)
 		}
-		seen[dedupKey(rec)] = rec.CreatedAt
+		seen[dedupKey(rec)] = dlqMeta{createdAt: rec.CreatedAt, messageID: rec.MessageID}
 	}
 	return seen, nil
 }
@@ -222,7 +230,7 @@ func (s *DLQSpill) Write(rec dlqRecord) error {
 		return fmt.Errorf("backfill: write dlq spill (id=%d msg=%s): %w", rec.ID, rec.MessageID, err)
 	}
 	s.pendingLen += int64(len(line))
-	s.seen[key] = rec.CreatedAt
+	s.seen[key] = dlqMeta{createdAt: rec.CreatedAt, messageID: rec.MessageID}
 	return nil
 }
 
@@ -247,12 +255,29 @@ func (s *DLQSpill) CountInWindow(fromUnix, toUnix int64) int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var n int64
-	for _, createdAt := range s.seen {
-		if createdAt >= fromUnix && createdAt <= toUnix {
+	for _, m := range s.seen {
+		if m.createdAt >= fromUnix && m.createdAt <= toUnix {
 			n++
 		}
 	}
 	return n
+}
+
+// MessageIDsInWindow 返回 created_at ∈ [fromUnix, toUnix] 的去重 DLQ 记录的**真实** message_id 集合。
+// 用于字段级抽样对账门（recon.CompareSamplesExcluding）：这些行**本应不在** ES 正文索引里
+// （真异常 / 永久拒绝，已记账为 DLQ），故抽样命中它们时「ES 无 doc」是预期，不算 missing。
+// 注意：空 message_id（源行 message_id 缺失/为空）不进集合——这类行去重键退化为 table:id，无法与
+// ES doc / 抽样行（抽样器按 message_id 取行）对齐，不会被抽到，吐出 table:id 反而会污染排除集。
+func (s *DLQSpill) MessageIDsInWindow(fromUnix, toUnix int64) map[string]bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]bool)
+	for _, m := range s.seen {
+		if m.messageID != "" && m.createdAt >= fromUnix && m.createdAt <= toUnix {
+			out[m.messageID] = true
+		}
+	}
+	return out
 }
 
 // Sync 把已 append 的 DLQ 记录刷盘（fsync），再原子推进 offset sidecar 到当前文件长度。

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -160,6 +160,61 @@ func TestDLQSpill_CountInWindow(t *testing.T) {
 	}
 }
 
+// TestDLQSpill_MessageIDsInWindow 返回窗内 DLQ 行的 message_id 集合（抽样门排除集），
+// 与 CountInWindow 同窗口口径；空 message_id 不入集合。
+func TestDLQSpill_MessageIDsInWindow(t *testing.T) {
+	s, err := OpenDLQSpill(filepath.Join(t.TempDir(), "d"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	writes := []dlqRecord{
+		{ID: 1, MessageID: "before", CreatedAt: 50},
+		{ID: 2, MessageID: "in1", CreatedAt: 150},
+		{ID: 3, MessageID: "in2", CreatedAt: 200},
+		{ID: 4, MessageID: "after", CreatedAt: 500},
+	}
+	for _, w := range writes {
+		if err := s.Write(w); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	got := s.MessageIDsInWindow(100, 300)
+	if len(got) != 2 || !got["in1"] || !got["in2"] {
+		t.Fatalf("window [100,300] must yield {in1,in2}, got %v", got)
+	}
+	if got["before"] || got["after"] {
+		t.Fatalf("out-of-window ids must be excluded: %v", got)
+	}
+}
+
+// TestDLQSpill_MessageIDsInWindow_SkipsEmptyID 空 message_id 行（去重键退化为 table:id）
+// 不得把 table:id 当成 message_id 吐进排除集——否则会污染抽样门排除集（codex P2）。
+func TestDLQSpill_MessageIDsInWindow_SkipsEmptyID(t *testing.T) {
+	s, err := OpenDLQSpill(filepath.Join(t.TempDir(), "d"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer mustCloseT(t, s)
+	if err := s.Write(dlqRecord{Table: "message", ID: 123, MessageID: "", CreatedAt: 150}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := s.Write(dlqRecord{Table: "message", ID: 124, MessageID: "real1", CreatedAt: 160}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// 两行都在窗内、都计数；但排除集只含真实非空 message_id。
+	if got := s.CountInWindow(100, 300); got != 2 {
+		t.Fatalf("CountInWindow must count both rows, got %d", got)
+	}
+	got := s.MessageIDsInWindow(100, 300)
+	if len(got) != 1 || !got["real1"] {
+		t.Fatalf("exclusion set must contain only real non-empty message_id {real1}, got %v", got)
+	}
+	if got["message:123"] {
+		t.Fatalf("table:id fallback key must NOT leak into exclusion set: %v", got)
+	}
+}
+
 // TestDLQSpill_Sync Sync 刷盘后记录可被另一个只读 reopen 看到（落盘可见性）。
 func TestDLQSpill_Sync(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "d")

--- a/internal/backfill/dlq_test.go
+++ b/internal/backfill/dlq_test.go
@@ -396,3 +396,165 @@ func TestDLQSpill_TornSingleLineOnly(t *testing.T) {
 		t.Fatalf("count must be 0 after truncating the only (un-synced) line, got %d", s.Count())
 	}
 }
+
+// TestLoadDLQMessageIDsInWindow_RoundTrip 写 spill（经 in-memory DLQSpill，含 sidecar）后，
+// 只读 loader 复原的 message_id 集合必须与 in-memory MessageIDsInWindow 完全一致——保证 standalone
+// reconcile 与 inline backfill 两条字段级抽样门对 DLQ 行口径一致。
+func TestLoadDLQMessageIDsInWindow_RoundTrip(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	s, err := OpenDLQSpill(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for _, rec := range []dlqRecord{
+		{ID: 1, MessageID: "m1", CreatedAt: 100},
+		{ID: 2, MessageID: "m2", CreatedAt: 200},
+		{ID: 3, MessageID: "m3", CreatedAt: 999}, // 窗外
+		{Table: "message", ID: 4, MessageID: "", CreatedAt: 150}, // 空 message_id：不入集
+	} {
+		if err := s.Write(rec); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	want := s.MessageIDsInWindow(50, 300)
+	if cerr := s.Close(); cerr != nil { // Close 推进 sidecar，落同步前缀
+		t.Fatalf("close: %v", cerr)
+	}
+
+	got, err := LoadDLQMessageIDsInWindow(dir, 50, 300)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !sameStringBoolSet(got, want) {
+		t.Fatalf("loader set %v != in-memory set %v (standalone/inline must agree)", got, want)
+	}
+	if got["m3"] {
+		t.Fatalf("out-of-window id must be excluded from set")
+	}
+	if _, ok := got["message:4"]; ok || got[""] {
+		t.Fatalf("empty message_id row must not enter exclusion set")
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_EmptyDir dir=="" → 空集、无错（退化回旧 CompareSamples 行为）。
+func TestLoadDLQMessageIDsInWindow_EmptyDir(t *testing.T) {
+	got, err := LoadDLQMessageIDsInWindow("", 0, 1000)
+	if err != nil {
+		t.Fatalf("empty dir must not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty dir must yield empty set, got %v", got)
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_MissingFile spill 文件不存在 → 空集、无错（无 backfill 的环境）。
+func TestLoadDLQMessageIDsInWindow_MissingFile(t *testing.T) {
+	got, err := LoadDLQMessageIDsInWindow(filepath.Join(t.TempDir(), "nope"), 0, 1000)
+	if err != nil {
+		t.Fatalf("missing spill file must not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("missing file must yield empty set, got %v", got)
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_SyncedPrefixOnly 有 sidecar 时只解析已 fsync 的同步前缀，
+// 崩溃留下的未 fsync 脏后缀（撕裂行）被丢弃，不污染排除集、不报错。
+func TestLoadDLQMessageIDsInWindow_SyncedPrefixOnly(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	clean := validLine(t, "m1", 100) + validLine(t, "m2", 200)
+	dirty := `{"message_id":"m3","created_at":30` // 未 fsync 撕裂半行
+	writeRawSpill(t, dir, clean+dirty)
+	writeSyncedSidecar(t, dir, int64(len(clean)))
+
+	got, err := LoadDLQMessageIDsInWindow(dir, 0, 1000)
+	if err != nil {
+		t.Fatalf("synced-prefix load must not error on dirty suffix: %v", err)
+	}
+	if !got["m1"] || !got["m2"] || len(got) != 2 {
+		t.Fatalf("only synced-prefix ids expected, got %v", got)
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_NoSidecarYieldsEmpty 无 sidecar（如崩溃 / 部分拷贝 / 损坏 sidecar，
+// syncedLen==0）→ 无任何可信任的已 fsync 前缀，返回空排除集（与 OpenDLQSpill 把 offset 0 当「无持久
+// 记录」一致）。绝不退化去信任未 fsync 的裸 .ndjson：那会让 standalone 信任不持久数据、对这些 id 跳过
+// sample_missing，与 inline 门口径漂移。回退到「不排除」是安全侧（最坏把合法 DLQ 行算成 missing → 门
+// 转红人工复核，绝不悄悄放过真漏灌）。
+func TestLoadDLQMessageIDsInWindow_NoSidecarYieldsEmpty(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	// 即便整文件都是完整记录，无 sidecar 也不信任（不持久）。
+	content := validLine(t, "m1", 100) + validLine(t, "m2", 200)
+	writeRawSpill(t, dir, content)
+
+	got, err := LoadDLQMessageIDsInWindow(dir, 0, 1000)
+	if err != nil {
+		t.Fatalf("no-sidecar load must not error (degrades to no-exclusion): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("no synced sidecar must yield empty exclusion set (untrusted, fail-closed safe side), got %v", got)
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_SidecarSaysBytesButFileMissingFatal sidecar 记录了非零同步长度，
+// 但 spill 文件不存在：持久状态丢失，致命（与 recoverAndLoad 一致，不可静默放过）。
+func TestLoadDLQMessageIDsInWindow_SidecarSaysBytesButFileMissingFatal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeSyncedSidecar(t, dir, 42) // 谎称有 42 字节同步前缀，但没有 .ndjson 文件
+	if _, err := LoadDLQMessageIDsInWindow(dir, 0, 1000); err == nil {
+		t.Fatalf("sidecar bytes with missing spill file must be fatal")
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_SyncedPrefixNotRecordBoundaryFatal 同步前缀不以记录边界（换行）
+// 结尾 → 真损坏，致命（fail-closed；与 inline parseSyncedSpillPrefix 同一校验）。
+func TestLoadDLQMessageIDsInWindow_SyncedPrefixNotRecordBoundaryFatal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	clean := validLine(t, "m1", 100)
+	partial := `{"message_id":"m2"` // 半行，无换行
+	writeRawSpill(t, dir, clean+partial)
+	// sidecar 谎称同步前缀覆盖到半行中间（非换行边界）。
+	writeSyncedSidecar(t, dir, int64(len(clean)+len(partial)))
+	if _, err := LoadDLQMessageIDsInWindow(dir, 0, 1000); err == nil {
+		t.Fatalf("synced prefix not ending on a record boundary must be fatal")
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_CorruptSyncedRecordFatal 同步前缀内一条完整记录解析失败是真损坏
+// → 报错（fail-closed：鉴权关键门绝不在可疑 DLQ 数据上静默放过）。
+func TestLoadDLQMessageIDsInWindow_CorruptSyncedRecordFatal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	bad := "{not-json}\n"
+	writeRawSpill(t, dir, bad)
+	writeSyncedSidecar(t, dir, int64(len(bad)))
+	if _, err := LoadDLQMessageIDsInWindow(dir, 0, 1000); err == nil {
+		t.Fatalf("corrupt record in synced prefix must be fatal")
+	}
+}
+
+// TestLoadDLQMessageIDsInWindow_ShorterThanSyncedFatal 文件比 sidecar 记录的同步长度还短：
+// 持久层不一致 → 报错（不可静默放过）。
+func TestLoadDLQMessageIDsInWindow_ShorterThanSyncedFatal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "d")
+	line := validLine(t, "m1", 100)
+	writeRawSpill(t, dir, line)
+	writeSyncedSidecar(t, dir, int64(len(line))+50)
+	if _, err := LoadDLQMessageIDsInWindow(dir, 0, 1000); err == nil {
+		t.Fatalf("file shorter than synced offset must be fatal")
+	}
+}
+
+func sameStringBoolSet(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/backfill/doc_enrich.go
+++ b/internal/backfill/doc_enrich.go
@@ -1,7 +1,9 @@
 package backfill
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 )
@@ -37,7 +39,18 @@ func docFromRow(row *srcMessageRow) (esindex.Doc, extractOutcome, error) {
 	}
 	// 加密消息 payload 是密文，不解析（与 extract 一致），spaceId/visibles 留空（reader fail-closed）。
 	if !isSignalEncrypted(row) {
-		spaceID, visibles := extractVisibility(row.Payload)
+		spaceID, visibles, verr := extractVisibility(row.Payload)
+		if verr != nil {
+			// 🔴 fail-CLOSED：可见性是 access-control ACL。一旦它无法可信解析（payload 非 JSON 对象、
+			// visibles 非数组等结构性损坏），**绝不**写空 visibles —— 否则 reader(doc.go:21) 把空
+			// visibles 当 fail-OPEN（群系统消息「仅管理员可见」白名单门被移除，普通成员能搜到管理员
+			// 可见消息）。这类行一律落 DLQ（永久跳过写入），把 ACL 解析失败显式暴露给对账门而非静默塌掉。
+			//
+			// 注意：space_id 的 JSON 类型（数字/对象/上游漂移）**不**触发此路径——extractVisibility 把
+			// space_id 解成容忍类型，非字符串 space_id 退化为空 spaceId（reader p2p fail-closed，安全方向），
+			// 绝不因一个字段类型怪异连累合法的 visibles 一并清空（V3b fail-OPEN 的根因）。
+			return esindex.Doc{}, outcomeDLQ, verr
+		}
 		doc.SpaceID = spaceID
 		doc.Visibles = visibles
 	}
@@ -45,28 +58,53 @@ func docFromRow(row *srcMessageRow) (esindex.Doc, extractOutcome, error) {
 }
 
 // extractVisibility 从原始 payload 字节解析 reader 鉴权所需的可见性字段：
-//   - space_id（string）：p2p space 召回过滤的真源。
+//   - space_id：p2p space 召回过滤的真源。**容忍类型**：仅当 JSON 字符串时取值，其余 JSON 类型
+//     （数字/对象/上游漂移）退化为空 spaceId（reader p2p fail-closed，安全方向）——绝不让 space_id
+//     的怪异类型炸掉整条 payload 的解析、连累合法 visibles 被清空（V3b fail-OPEN 根因）。
 //   - visibles（[]string，仅保留字符串元素，与 octo-server visiblesAllows 口径一致）：
 //     群系统消息白名单。空/缺失 → 空切片（reader：无 gate）。
 //
-// 解析失败（payload 非 JSON 对象，如加密/损坏）→ 返回空，保守不附加可见性约束
-// （与 reader/server visiblesAllows 对损坏 payload「不约束」一致，且 space 留空走 fail-closed）。
-func extractVisibility(payload []byte) (spaceID string, visibles []string) {
-	var v struct {
-		SpaceID  string            `json:"space_id"`
-		Visibles []json.RawMessage `json:"visibles"`
+// 🔴 fail-CLOSED 返回值契约：
+//   - payload 是合法 JSON 对象（即使含怪异字段类型）→ 返回解析出的 spaceID/visibles，err=nil。
+//   - payload **不是** JSON 对象（顶层非 `{...}`，如损坏/截断/数组/标量）→ 返回 err≠nil。
+//     调用方据此 fail-closed（落 DLQ），绝不把无法可信解析的行写成空 visibles（fail-OPEN）。
+//
+// 为何不再用 strict struct unmarshal：strict struct 里 `SpaceID string` 一旦遇非字符串 space_id
+// 会令**整个 struct** Unmarshal 失败 → 旧实现返回 "",nil → 合法 visibles 被静默清空 → reader
+// fail-OPEN。这正是本 PR 要堵的 V3b，却从 active backfill 路径重新引入。改用「先验顶层是对象，
+// 再字段级容忍解析」彻底切断「单字段类型 → 全可见性塌掉」的耦合。
+func extractVisibility(payload []byte) (spaceID string, visibles []string, err error) {
+	// 先把 payload 解成顶层对象（容忍每个字段的 JSON 类型）。顶层不是对象（损坏/截断/数组/标量）
+	// 才是真正「可见性不可信」→ fail-closed。space_id/visibles 字段本身的类型不在此判死。
+	var top map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	if derr := dec.Decode(&top); derr != nil {
+		return "", nil, fmt.Errorf("backfill: visibility payload not a JSON object (fail-closed): %w", derr)
 	}
-	if err := json.Unmarshal(payload, &v); err != nil {
-		return "", nil
-	}
-	spaceID = v.SpaceID
-	if len(v.Visibles) == 0 {
-		return spaceID, nil
-	}
-	out := make([]string, 0, len(v.Visibles))
-	for _, raw := range v.Visibles {
+
+	// space_id：容忍类型——仅 JSON 字符串取值，其余类型留空（不报错、不连累 visibles）。
+	if raw, ok := top["space_id"]; ok {
 		var s string
-		if err := json.Unmarshal(raw, &s); err != nil {
+		if uerr := json.Unmarshal(raw, &s); uerr == nil {
+			spaceID = s
+		}
+		// 非字符串 space_id（数字/对象/null）→ spaceID 留空（reader p2p fail-closed，安全方向）。
+	}
+
+	// visibles：必须是 JSON 数组（或缺失/null）。是别的类型（对象/标量/字符串）说明白名单结构损坏
+	// → fail-closed（绝不当作「无 gate」放空，那是 fail-OPEN）。
+	rawVis, ok := top["visibles"]
+	if !ok || string(rawVis) == "null" {
+		return spaceID, nil, nil
+	}
+	var elems []json.RawMessage
+	if uerr := json.Unmarshal(rawVis, &elems); uerr != nil {
+		return "", nil, fmt.Errorf("backfill: visibles is not a JSON array (fail-closed, refuse to drop ACL): %w", uerr)
+	}
+	out := make([]string, 0, len(elems))
+	for _, raw := range elems {
+		var s string
+		if uerr := json.Unmarshal(raw, &s); uerr != nil {
 			// 与 server visiblesAllows 一致：非字符串元素跳过，不当作约束。
 			continue
 		}
@@ -75,7 +113,7 @@ func extractVisibility(payload []byte) (spaceID string, visibles []string) {
 		}
 	}
 	if len(out) == 0 {
-		return spaceID, nil
+		return spaceID, nil, nil
 	}
-	return spaceID, out
+	return spaceID, out, nil
 }

--- a/internal/backfill/doc_enrich.go
+++ b/internal/backfill/doc_enrich.go
@@ -1,0 +1,81 @@
+package backfill
+
+import (
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+// docFromRow 把一行源消息抽取为 reader 可读的 esindex.Doc（backfill 富化路径）。
+//
+// 这是分叉 B 在 backfill 侧的核心：backfill 读**原始 MySQL payload**，因此能自源填全
+// reader 必读但 Kafka 契约缺失的三字段：
+//   - spaceId：从 payload.space_id 抽（octo-server 发送时由 enrichPayloadWithSpaceID 写入，
+//     p2p/group/topic 均经服务端权威注入）。reader 对 p2p 缺 spaceId 走 fail-closed。
+//   - visibles：从 payload.visibles 抽（群系统消息「仅管理员可见」白名单）。reader 缺则 fail-OPEN。
+//   - messageSeq：从 message 表 message_seq 列（reader channel_offset「清空会话」gate）。
+//
+// 正文 outcome（OK/RawExcluded/DLQ）完全复用 extractMessage 的口径（与实时 producer 一致），
+// 故 backfill 与实时增量对同一条消息产生**同形态 doc**（同 _id 幂等覆盖无害）。
+func docFromRow(row *srcMessageRow) (esindex.Doc, extractOutcome, error) {
+	msg, outcome := extractMessage(row)
+	if outcome == outcomeDLQ {
+		return esindex.Doc{}, outcome, nil
+	}
+
+	// 复用 esindex 的契约→Doc 转换（messageId 全精度 long / payload 嵌套 / 字段名对齐 reader）。
+	doc, err := esindex.DocFromMessage(msg)
+	if err != nil {
+		// message_id 非数值：reader 读 long messageId 无法对齐 → 当真异常落 DLQ（不静默落 0）。
+		return esindex.Doc{}, outcomeDLQ, err
+	}
+
+	// 富化 reader 必读的安全/正确性字段（仅 backfill 可做：见上）。
+	doc.MessageSeq = uint64(row.MessageSeq)
+	if row.MessageSeq < 0 {
+		doc.MessageSeq = 0
+	}
+	// 加密消息 payload 是密文，不解析（与 extract 一致），spaceId/visibles 留空（reader fail-closed）。
+	if !isSignalEncrypted(row) {
+		spaceID, visibles := extractVisibility(row.Payload)
+		doc.SpaceID = spaceID
+		doc.Visibles = visibles
+	}
+	return doc, outcome, nil
+}
+
+// extractVisibility 从原始 payload 字节解析 reader 鉴权所需的可见性字段：
+//   - space_id（string）：p2p space 召回过滤的真源。
+//   - visibles（[]string，仅保留字符串元素，与 octo-server visiblesAllows 口径一致）：
+//     群系统消息白名单。空/缺失 → 空切片（reader：无 gate）。
+//
+// 解析失败（payload 非 JSON 对象，如加密/损坏）→ 返回空，保守不附加可见性约束
+// （与 reader/server visiblesAllows 对损坏 payload「不约束」一致，且 space 留空走 fail-closed）。
+func extractVisibility(payload []byte) (spaceID string, visibles []string) {
+	var v struct {
+		SpaceID  string            `json:"space_id"`
+		Visibles []json.RawMessage `json:"visibles"`
+	}
+	if err := json.Unmarshal(payload, &v); err != nil {
+		return "", nil
+	}
+	spaceID = v.SpaceID
+	if len(v.Visibles) == 0 {
+		return spaceID, nil
+	}
+	out := make([]string, 0, len(v.Visibles))
+	for _, raw := range v.Visibles {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			// 与 server visiblesAllows 一致：非字符串元素跳过，不当作约束。
+			continue
+		}
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return spaceID, nil
+	}
+	return spaceID, out
+}

--- a/internal/backfill/doc_enrich_test.go
+++ b/internal/backfill/doc_enrich_test.go
@@ -1,0 +1,108 @@
+package backfill
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// payloadWith 构造一条带 space_id/visibles 的文本 payload（明文 JSON，模拟 enrichPayloadWithSpaceID 产物）。
+func payloadWith(t *testing.T, content, spaceID string, visibles []string) []byte {
+	t.Helper()
+	m := map[string]interface{}{"type": contentTypeText, "content": content}
+	if spaceID != "" {
+		m["space_id"] = spaceID
+	}
+	if visibles != nil {
+		m["visibles"] = visibles
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestDocFromRow_EnrichesSpaceIDVisiblesSeq 🔴 V1(b)+V3b 解红的根：backfill 从原始 MySQL
+// payload 自源填 reader 必读的 spaceId/visibles + message_seq 列。
+func TestDocFromRow_EnrichesSpaceIDVisiblesSeq(t *testing.T) {
+	row := &srcMessageRow{
+		ID: 1, MessageID: "1001", MessageSeq: 77, ChannelType: 1, // p2p
+		Payload: payloadWith(t, "hello", "space-A", []string{"admin1", "admin2"}),
+	}
+	doc, outcome, err := docFromRow(row)
+	if err != nil {
+		t.Fatalf("docFromRow: %v", err)
+	}
+	if outcome != outcomeOK {
+		t.Fatalf("want outcomeOK, got %v", outcome)
+	}
+	if doc.SpaceID != "space-A" {
+		t.Fatalf("spaceId not enriched (V1b would stay red): %q", doc.SpaceID)
+	}
+	if len(doc.Visibles) != 2 || doc.Visibles[0] != "admin1" || doc.Visibles[1] != "admin2" {
+		t.Fatalf("visibles not enriched (V3b would fail-OPEN): %+v", doc.Visibles)
+	}
+	if doc.MessageSeq != 77 {
+		t.Fatalf("messageSeq not carried (reader channel_offset gate): %d", doc.MessageSeq)
+	}
+	if doc.MessageID != 1001 {
+		t.Fatalf("messageId mismatch: %d", doc.MessageID)
+	}
+}
+
+// TestDocFromRow_NoVisibilityFields payload 无 space_id/visibles → 字段留空（reader p2p fail-closed / 无 gate）。
+func TestDocFromRow_NoVisibilityFields(t *testing.T) {
+	row := &srcMessageRow{ID: 2, MessageID: "1002", ChannelType: 2, Payload: payloadWith(t, "hi", "", nil)}
+	doc, outcome, err := docFromRow(row)
+	if err != nil || outcome != outcomeOK {
+		t.Fatalf("docFromRow: outcome=%v err=%v", outcome, err)
+	}
+	if doc.SpaceID != "" || len(doc.Visibles) != 0 {
+		t.Fatalf("absent visibility fields must stay empty: spaceId=%q visibles=%+v", doc.SpaceID, doc.Visibles)
+	}
+}
+
+// TestDocFromRow_SignalEncryptedNoVisibility 加密消息不解析 payload → spaceId/visibles 留空（fail-closed）。
+func TestDocFromRow_SignalEncryptedNoVisibility(t *testing.T) {
+	row := &srcMessageRow{ID: 3, MessageID: "1003", Signal: 1, ChannelType: 1, Payload: []byte("CIPHERTEXT")}
+	doc, outcome, err := docFromRow(row)
+	if err != nil {
+		t.Fatalf("docFromRow: %v", err)
+	}
+	if outcome != outcomeRawExcluded {
+		t.Fatalf("signal msg must be raw_excluded, got %v", outcome)
+	}
+	if doc.SpaceID != "" || len(doc.Visibles) != 0 {
+		t.Fatalf("encrypted msg must not leak visibility fields: %+v", doc)
+	}
+}
+
+// TestDocFromRow_NonNumericMessageIDToDLQ message_id 非数值 → outcomeDLQ + err（不静默落 0）。
+func TestDocFromRow_NonNumericMessageIDToDLQ(t *testing.T) {
+	row := &srcMessageRow{ID: 4, MessageID: "abc", ChannelType: 2, Payload: payloadWith(t, "hi", "", nil)}
+	_, outcome, err := docFromRow(row)
+	if outcome != outcomeDLQ || err == nil {
+		t.Fatalf("non-numeric message_id must be DLQ with error: outcome=%v err=%v", outcome, err)
+	}
+}
+
+// TestDocFromRow_BadJSONToDLQ payload 真异常 → outcomeDLQ（与 extract 口径一致）。
+func TestDocFromRow_BadJSONToDLQ(t *testing.T) {
+	row := &srcMessageRow{ID: 5, MessageID: "1005", ChannelType: 2, Payload: []byte("{not json")}
+	_, outcome, err := docFromRow(row)
+	if outcome != outcomeDLQ {
+		t.Fatalf("bad json must be DLQ, got %v (err=%v)", outcome, err)
+	}
+}
+
+// TestExtractVisibility_DropsNonStringElements visibles 非字符串元素跳过（与 server visiblesAllows 口径一致）。
+func TestExtractVisibility_DropsNonStringElements(t *testing.T) {
+	raw := []byte(`{"space_id":"s1","visibles":["u1",123,"u2",{"x":1}]}`)
+	sid, vis := extractVisibility(raw)
+	if sid != "s1" {
+		t.Fatalf("space_id mismatch: %q", sid)
+	}
+	if len(vis) != 2 || vis[0] != "u1" || vis[1] != "u2" {
+		t.Fatalf("non-string visibles elements must be dropped: %+v", vis)
+	}
+}

--- a/internal/backfill/doc_enrich_test.go
+++ b/internal/backfill/doc_enrich_test.go
@@ -98,11 +98,131 @@ func TestDocFromRow_BadJSONToDLQ(t *testing.T) {
 // TestExtractVisibility_DropsNonStringElements visibles 非字符串元素跳过（与 server visiblesAllows 口径一致）。
 func TestExtractVisibility_DropsNonStringElements(t *testing.T) {
 	raw := []byte(`{"space_id":"s1","visibles":["u1",123,"u2",{"x":1}]}`)
-	sid, vis := extractVisibility(raw)
+	sid, vis, err := extractVisibility(raw)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if sid != "s1" {
 		t.Fatalf("space_id mismatch: %q", sid)
 	}
 	if len(vis) != 2 || vis[0] != "u1" || vis[1] != "u2" {
 		t.Fatalf("non-string visibles elements must be dropped: %+v", vis)
+	}
+}
+
+// TestExtractVisibility_NonStringSpaceIDKeepsVisibles 🔴 V3b fail-OPEN 根因回归门：
+// 某行 payload 的 space_id 是**非字符串** JSON 类型（数字/对象/上游漂移），而 visibles 数据**合法**。
+// 旧实现用 strict struct（SpaceID string）→ 整条 Unmarshal 失败 → 返回 "",nil → 合法 visibles 被
+// 静默清空 → reader fail-OPEN（普通成员搜出群管才可见消息）。修后：space_id 怪异类型退化为空
+// spaceId（reader p2p fail-closed，安全方向），但 visibles **必须**完整保留——绝不产出空 visibles。
+func TestExtractVisibility_NonStringSpaceIDKeepsVisibles(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"space_id is number", `{"space_id":123,"visibles":["admin1","admin2"]}`},
+		{"space_id is object", `{"space_id":{"nested":1},"visibles":["admin1","admin2"]}`},
+		{"space_id is bool", `{"space_id":true,"visibles":["admin1","admin2"]}`},
+		{"space_id is null", `{"space_id":null,"visibles":["admin1","admin2"]}`},
+		{"space_id is array", `{"space_id":["x"],"visibles":["admin1","admin2"]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sid, vis, err := extractVisibility([]byte(tc.payload))
+			if err != nil {
+				t.Fatalf("a weird space_id type must NOT fail visibility parse: %v", err)
+			}
+			if sid != "" {
+				t.Fatalf("non-string space_id must degrade to empty spaceId (p2p fail-closed), got %q", sid)
+			}
+			if len(vis) != 2 || vis[0] != "admin1" || vis[1] != "admin2" {
+				t.Fatalf("legitimate visibles must NOT be cleared by a weird space_id (V3b fail-OPEN): %+v", vis)
+			}
+		})
+	}
+}
+
+// TestExtractVisibility_StringSpaceIDStillParsed 字符串 space_id 仍正常取值（容忍类型未破坏正常路径）。
+func TestExtractVisibility_StringSpaceIDStillParsed(t *testing.T) {
+	sid, vis, err := extractVisibility([]byte(`{"space_id":"space-A","visibles":["u1"]}`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sid != "space-A" {
+		t.Fatalf("string space_id must parse: %q", sid)
+	}
+	if len(vis) != 1 || vis[0] != "u1" {
+		t.Fatalf("visibles: %+v", vis)
+	}
+}
+
+// TestExtractVisibility_StructurallyBrokenFailClosed payload 顶层非对象 / visibles 非数组 → err（fail-closed）。
+// 调用方据此落 DLQ，绝不写空 visibles。
+func TestExtractVisibility_StructurallyBrokenFailClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"not json", `{not json`},
+		{"top-level array", `["a","b"]`},
+		{"top-level scalar", `42`},
+		{"visibles is object", `{"space_id":"s1","visibles":{"u1":true}}`},
+		{"visibles is string", `{"space_id":"s1","visibles":"u1,u2"}`},
+		{"visibles is number", `{"space_id":"s1","visibles":7}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := extractVisibility([]byte(tc.payload))
+			if err == nil {
+				t.Fatalf("structurally broken visibility must fail-closed (err), not silently empty: %q", tc.payload)
+			}
+		})
+	}
+}
+
+// TestExtractVisibility_AbsentVisiblesNoError 缺 visibles / visibles=null → 空切片 + 无错（reader 无 gate，合法）。
+func TestExtractVisibility_AbsentVisiblesNoError(t *testing.T) {
+	for _, p := range []string{`{"space_id":"s1"}`, `{"space_id":"s1","visibles":null}`, `{}`} {
+		sid, vis, err := extractVisibility([]byte(p))
+		if err != nil {
+			t.Fatalf("absent visibles is legitimate (no gate), must not fail-closed: %q err=%v", p, err)
+		}
+		if len(vis) != 0 {
+			t.Fatalf("absent visibles must be empty: %+v", vis)
+		}
+		_ = sid
+	}
+}
+
+// TestDocFromRow_NonStringSpaceIDKeepsVisibles 🔴 端到端 V3b：backfill doc 富化路径下，
+// 非字符串 space_id 的合法行**绝不**产出空 visibles —— 要么保留 visibles，要么 fail-closed。
+// 本用例锁定「保留 visibles」（visibles 合法时不该 fail-closed 把好行也丢了）。
+func TestDocFromRow_NonStringSpaceIDKeepsVisibles(t *testing.T) {
+	// 手工拼一条 space_id 为数字、visibles 合法的明文 payload。
+	raw := []byte(`{"type":1,"content":"hi","space_id":12345,"visibles":["admin1","admin2"]}`)
+	row := &srcMessageRow{ID: 9, MessageID: "2001", ChannelType: 2, Payload: raw}
+	doc, outcome, err := docFromRow(row)
+	if err != nil {
+		t.Fatalf("legitimate visibles row must not error: %v", err)
+	}
+	if outcome != outcomeOK {
+		t.Fatalf("want outcomeOK (visibles legit), got %v", outcome)
+	}
+	if len(doc.Visibles) != 2 || doc.Visibles[0] != "admin1" || doc.Visibles[1] != "admin2" {
+		t.Fatalf("V3b fail-OPEN: weird space_id cleared legitimate visibles: %+v", doc.Visibles)
+	}
+	if doc.SpaceID != "" {
+		t.Fatalf("non-string space_id must degrade to empty (p2p fail-closed): %q", doc.SpaceID)
+	}
+}
+
+// TestDocFromRow_BrokenVisibilityFailClosed visibles 结构损坏（非数组）→ 该行 fail-closed 落 DLQ，
+// 绝不写空 visibles（fail-OPEN）。
+func TestDocFromRow_BrokenVisibilityFailClosed(t *testing.T) {
+	raw := []byte(`{"type":1,"content":"hi","space_id":"s1","visibles":"u1,u2"}`)
+	row := &srcMessageRow{ID: 10, MessageID: "2002", ChannelType: 2, Payload: raw}
+	_, outcome, err := docFromRow(row)
+	if outcome != outcomeDLQ || err == nil {
+		t.Fatalf("broken visibles must fail-closed to DLQ (never empty visibles): outcome=%v err=%v", outcome, err)
 	}
 }

--- a/internal/backfill/extract.go
+++ b/internal/backfill/extract.go
@@ -61,6 +61,7 @@ const (
 type srcMessageRow struct {
 	ID          int64
 	MessageID   string
+	MessageSeq  int64 // 消息序列号（严格递增）— reader channel_offset「清空会话」gate 用
 	FromUID     string
 	ChannelID   string
 	ChannelType uint8

--- a/internal/backfill/runner.go
+++ b/internal/backfill/runner.go
@@ -148,8 +148,8 @@ func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMess
 		// docFromRow 复用 extractMessage 的三态口径，并富化 reader 必读的
 		// spaceId/visibles/messageSeq（仅 backfill 可从原始 MySQL payload 自源填）。
 		doc, outcome, err := docFromRow(row)
-		switch {
-		case outcome == outcomeDLQ:
+		switch outcome {
+		case outcomeDLQ:
 			// 真异常（payload 解析失败 / message_id 非数值）：落本地 DLQ spill 并计数（fail-closed）。
 			reason := "payload_parse"
 			if err != nil {

--- a/internal/backfill/runner.go
+++ b/internal/backfill/runner.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 )
 
@@ -134,7 +133,7 @@ func (r *Runner) runTable(ctx context.Context, table string) (Stats, error) {
 // 不致 dedup 塌缩 / 计数偏低）。
 type mainItem struct {
 	row *srcMessageRow
-	msg searchmsg.Message
+	doc esindex.Doc
 }
 
 // processBatch 处理一批（同分表、按 id 升序）：抽取三态分流 → 真异常落 DLQ spill →
@@ -146,15 +145,22 @@ func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMess
 	s.Read += int64(len(rows))
 	main := make([]mainItem, 0, len(rows))
 	for _, row := range rows {
-		msg, outcome := extractMessage(row)
-		switch outcome {
-		case outcomeDLQ:
-			// 真异常（payload 本应可解析却失败）：落本地 DLQ spill 并计数（fail-closed）。
-			if err := r.dlq.Write(dlqRecord{
-				Table: table, ID: row.ID, MessageID: row.MessageID,
+		// docFromRow 复用 extractMessage 的三态口径，并富化 reader 必读的
+		// spaceId/visibles/messageSeq（仅 backfill 可从原始 MySQL payload 自源填）。
+		doc, outcome, err := docFromRow(row)
+		switch {
+		case outcome == outcomeDLQ:
+			// 真异常（payload 解析失败 / message_id 非数值）：落本地 DLQ spill 并计数（fail-closed）。
+			reason := "payload_parse"
+			if err != nil {
+				reason = "doc_convert"
+			}
+			if werr := r.dlq.Write(dlqRecord{
+				Reason: reason,
+				Table:  table, ID: row.ID, MessageID: row.MessageID,
 				Payload: row.Payload, CreatedAt: row.CreatedUnix,
-			}); err != nil {
-				return err
+			}); werr != nil {
+				return werr
 			}
 			s.DLQ++
 			s.DLQPayload++
@@ -162,7 +168,7 @@ func (r *Runner) processBatch(ctx context.Context, table string, rows []*srcMess
 			if outcome == outcomeRawExcluded {
 				s.RawExcluded++
 			}
-			main = append(main, mainItem{row: row, msg: msg})
+			main = append(main, mainItem{row: row, doc: doc})
 		}
 	}
 	return r.writeMain(ctx, table, main, s)
@@ -185,11 +191,11 @@ func (r *Runner) writeMain(ctx context.Context, table string, main []mainItem, s
 				return err
 			}
 		}
-		msgs := make([]searchmsg.Message, len(remaining))
+		docs := make([]esindex.Doc, len(remaining))
 		for i := range remaining {
-			msgs[i] = remaining[i].msg
+			docs[i] = remaining[i].doc
 		}
-		results, err := r.writer.Bulk(ctx, msgs)
+		results, err := r.writer.BulkDocs(ctx, docs)
 		if err != nil {
 			// 批级 transient：保持 remaining 不变，下轮整批重试。
 			r.logf("backfill: bulk batch-level transient (table=%s n=%d attempt=%d): %v",

--- a/internal/backfill/runner_test.go
+++ b/internal/backfill/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -64,22 +65,28 @@ func newFakeWriter() *fakeWriter {
 func (w *fakeWriter) EnsureIndex(context.Context) error { return w.ensureErr }
 func (w *fakeWriter) Close() error                      { return nil }
 
-func (w *fakeWriter) Bulk(_ context.Context, msgs []searchmsg.Message) ([]esindex.BulkItemResult, error) {
+// Bulk 不被 backfill 路径调用（backfill 走 BulkDocs(docs)）；提供接口实现。
+func (w *fakeWriter) Bulk(_ context.Context, _ []searchmsg.Message) ([]esindex.BulkItemResult, error) {
+	return nil, nil
+}
+
+// BulkDocs 模拟 backfill 写入：按规范化 messageId（= ES _id）注入每条结果。
+func (w *fakeWriter) BulkDocs(_ context.Context, docs []esindex.Doc) ([]esindex.BulkItemResult, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.bulkCalls++
 	if w.bulkErr != nil {
 		err := w.bulkErr
 		w.bulkErr = nil // 自愈：下一轮成功
-		out := make([]esindex.BulkItemResult, len(msgs))
-		for i := range msgs {
-			out[i] = esindex.BulkItemResult{MessageID: msgs[i].MessageID, OK: false, Status: 0, Err: err}
+		out := make([]esindex.BulkItemResult, len(docs))
+		for i := range docs {
+			out[i] = esindex.BulkItemResult{MessageID: docID(docs[i]), OK: false, Status: 0, Err: err}
 		}
 		return out, err
 	}
-	out := make([]esindex.BulkItemResult, len(msgs))
-	for i := range msgs {
-		id := msgs[i].MessageID
+	out := make([]esindex.BulkItemResult, len(docs))
+	for i := range docs {
+		id := docID(docs[i])
 		switch {
 		case w.transient[id] > 0:
 			w.transient[id]--
@@ -93,6 +100,9 @@ func (w *fakeWriter) Bulk(_ context.Context, msgs []searchmsg.Message) ([]esinde
 	}
 	return out, nil
 }
+
+// docID 返回 doc 的规范化 _id（int64 messageId 转十进制串），与生产 encodeBulkBody 一致。
+func docID(d esindex.Doc) string { return strconv.FormatInt(d.MessageID, 10) }
 
 // uniqueIndexed 返回成功写入的去重 message_id 数（ES `_id` 幂等下 = doc 数）。
 func (w *fakeWriter) uniqueIndexed() int {
@@ -130,7 +140,7 @@ func newTestRunner(t *testing.T, cfg Config, src SourceReader, w esindex.Writer)
 // TestRunner_HappyPath 全文本行 → 全部写 ES，无 DLQ，checkpoint 推进到批末。
 func TestRunner_HappyPath(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
-		"message": {textRow(1, "a", "x", 100), textRow(2, "b", "y", 100), textRow(3, "c", "z", 100)},
+		"message": {textRow(1, "1", "x", 100), textRow(2, "2", "y", 100), textRow(3, "3", "z", 100)},
 	}}
 	w := newFakeWriter()
 	r, dlq, cp := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 2, DocsPerSec: 0}, src, w)
@@ -152,7 +162,7 @@ func TestRunner_HappyPath(t *testing.T) {
 // TestRunner_Idempotent 同一 message_id 重复行 → ES 去重，doc 数不增（`_id` 幂等）。
 func TestRunner_Idempotent(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
-		"message": {textRow(1, "dup", "v1", 100), textRow(2, "dup", "v2", 100), textRow(3, "uniq", "w", 100)},
+		"message": {textRow(1, "5000", "v1", 100), textRow(2, "5000", "v2", 100), textRow(3, "5001", "w", 100)},
 	}}
 	w := newFakeWriter()
 	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
@@ -168,8 +178,8 @@ func TestRunner_Idempotent(t *testing.T) {
 func TestRunner_RawExcludedStillIndexed(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
 		"message": {
-			{ID: 1, MessageID: "sig", Signal: 1, Payload: []byte("ENC"), CreatedUnix: 100},
-			textRow(2, "txt", "hi", 100),
+			{ID: 1, MessageID: "9001", Signal: 1, Payload: []byte("ENC"), CreatedUnix: 100},
+			textRow(2, "9002", "hi", 100),
 		},
 	}}
 	w := newFakeWriter()
@@ -190,7 +200,7 @@ func TestRunner_RawExcludedStillIndexed(t *testing.T) {
 func TestRunner_RealAnomalyToDLQ(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
 		"message": {
-			textRow(1, "ok", "hi", 100),
+			textRow(1, "9101", "hi", 100),
 			{ID: 2, MessageID: "bad", Payload: []byte("{not json"), CreatedUnix: 100},
 		},
 	}}
@@ -215,10 +225,10 @@ func TestRunner_RealAnomalyToDLQ(t *testing.T) {
 // TestRunner_PermanentESRejectToDLQ ES 永久拒绝(4xx) → 落 DLQ spill，不卡批。
 func TestRunner_PermanentESRejectToDLQ(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
-		"message": {textRow(1, "ok", "hi", 100), textRow(2, "poison", "boom", 100)},
+		"message": {textRow(1, "9101", "hi", 100), textRow(2, "9202", "boom", 100)},
 	}}
 	w := newFakeWriter()
-	w.permanent["poison"] = struct{}{}
+	w.permanent["9202"] = struct{}{}
 	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
 	stats, err := r.Run(context.Background())
 	if err != nil {
@@ -235,10 +245,10 @@ func TestRunner_PermanentESRejectToDLQ(t *testing.T) {
 // TestRunner_PermanentRejectRecordKeepsSourcePKAndPayload 🔴 P2-1：永久拒绝的 DLQ 记录须保留
 // 源 PK（table/id）+ 原始 payload，便于排查 / 回灌。
 func TestRunner_PermanentRejectRecordKeepsSourcePKAndPayload(t *testing.T) {
-	poison := textRow(42, "poison", "boom-body", 100)
+	poison := textRow(42, "9242", "boom-body", 100)
 	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": {poison}}}
 	w := newFakeWriter()
-	w.permanent["poison"] = struct{}{}
+	w.permanent["9242"] = struct{}{}
 	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
 	if _, err := r.Run(context.Background()); err != nil {
 		t.Fatalf("run: %v", err)
@@ -248,7 +258,7 @@ func TestRunner_PermanentRejectRecordKeepsSourcePKAndPayload(t *testing.T) {
 		t.Fatalf("want 1 dlq record, got %d", len(recs))
 	}
 	rec := recs[0]
-	if rec.Table != "message" || rec.ID != 42 || rec.MessageID != "poison" {
+	if rec.Table != "message" || rec.ID != 42 || rec.MessageID != "9242" {
 		t.Fatalf("permanent-reject record must keep source PK: %+v", rec)
 	}
 	if string(rec.Payload) != string(poison.Payload) {
@@ -281,10 +291,10 @@ func TestRunner_EmptyMessageIDNoDedupCollapse(t *testing.T) {
 }
 func TestRunner_TransientRetriesInPlace(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
-		"message": {textRow(1, "a", "x", 100), textRow(2, "slow", "y", 100), textRow(3, "c", "z", 100)},
+		"message": {textRow(1, "1", "x", 100), textRow(2, "7", "y", 100), textRow(3, "3", "z", 100)},
 	}}
 	w := newFakeWriter()
-	w.transient["slow"] = 2 // 头两次 429，第三次 OK
+	w.transient["7"] = 2 // 头两次 429，第三次 OK
 	r, dlq, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10, TransientBackoff: time.Millisecond}, src, w)
 	stats, err := r.Run(context.Background())
 	if err != nil {
@@ -304,7 +314,7 @@ func TestRunner_TransientRetriesInPlace(t *testing.T) {
 // TestRunner_BatchLevelTransientRetried 批级错误（网络）→ 整批退避重试（幂等去重），最终成功。
 func TestRunner_BatchLevelTransientRetried(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
-		"message": {textRow(1, "a", "x", 100), textRow(2, "b", "y", 100)},
+		"message": {textRow(1, "1", "x", 100), textRow(2, "2", "y", 100)},
 	}}
 	w := newFakeWriter()
 	w.bulkErr = errors.New("connection refused") // 第一次批级失败，自愈
@@ -322,7 +332,7 @@ func TestRunner_BatchLevelTransientRetried(t *testing.T) {
 func TestRunner_Resume(t *testing.T) {
 	dir := t.TempDir()
 	cpPath := filepath.Join(dir, "cp.json")
-	rows := []*srcMessageRow{textRow(1, "a", "x", 100), textRow(2, "b", "y", 100), textRow(3, "c", "z", 100)}
+	rows := []*srcMessageRow{textRow(1, "1", "x", 100), textRow(2, "2", "y", 100), textRow(3, "3", "z", 100)}
 	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": rows}}
 
 	// 第一次：只跑前 2 行（用预置 checkpoint 模拟「上次跑到 id=2」）。
@@ -363,8 +373,8 @@ func TestRunner_Resume(t *testing.T) {
 // TestRunner_MultiTable 多分表各自 keyset 推进，汇总统计正确。
 func TestRunner_MultiTable(t *testing.T) {
 	src := &fakeSource{rows: map[string][]*srcMessageRow{
-		"message":  {textRow(1, "a", "x", 100)},
-		"message1": {textRow(1, "b", "y", 100), textRow(2, "c", "z", 100)},
+		"message":  {textRow(1, "1", "x", 100)},
+		"message1": {textRow(1, "2", "y", 100), textRow(2, "3", "z", 100)},
 	}}
 	w := newFakeWriter()
 	r, _, cp := newTestRunner(t, Config{Tables: []string{"message", "message1"}, BatchSize: 10}, src, w)
@@ -392,7 +402,7 @@ func TestRunner_ReadErrorStops(t *testing.T) {
 
 // TestRunner_EnsureIndexErrorStops EnsureIndex 失败 → 不读不写，直接 STOP。
 func TestRunner_EnsureIndexErrorStops(t *testing.T) {
-	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": {textRow(1, "a", "x", 100)}}}
+	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": {textRow(1, "1", "x", 100)}}}
 	w := newFakeWriter()
 	w.ensureErr = errors.New("es down")
 	r, _, _ := newTestRunner(t, Config{Tables: []string{"message"}, BatchSize: 10}, src, w)
@@ -408,7 +418,7 @@ func TestRunner_EnsureIndexErrorStops(t *testing.T) {
 func TestRunner_CtxCancelStops(t *testing.T) {
 	rows := make([]*srcMessageRow, 0, 100)
 	for i := int64(1); i <= 100; i++ {
-		rows = append(rows, textRow(i, fmt.Sprintf("m%d", i), "x", 100))
+		rows = append(rows, textRow(i, fmt.Sprintf("%d", i), "x", 100))
 	}
 	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": rows}}
 	w := newFakeWriter()
@@ -488,7 +498,7 @@ func TestRunner_ResumeAfterDLQNoDoubleCount(t *testing.T) {
 	dir := t.TempDir()
 	spillDir := filepath.Join(dir, "dlq")
 	rows := []*srcMessageRow{
-		textRow(1, "ok", "hi", 100),
+		textRow(1, "9101", "hi", 100),
 		{ID: 2, MessageID: "bad", Payload: []byte("{not json"), CreatedUnix: 100},
 	}
 	src := &fakeSource{rows: map[string][]*srcMessageRow{"message": rows}}

--- a/internal/backfill/source.go
+++ b/internal/backfill/source.go
@@ -37,7 +37,7 @@ func (s *MySQLSource) ReadBatch(ctx context.Context, table string, after int64, 
 		return nil, fmt.Errorf("backfill: unsafe table name %q", table)
 	}
 	q := fmt.Sprintf(
-		"SELECT id, message_id, from_uid, channel_id, channel_type, setting, `signal`, "+
+		"SELECT id, message_id, message_seq, from_uid, channel_id, channel_type, setting, `signal`, "+
 			"`timestamp`, UNIX_TIMESTAMP(created_at) AS created_unix, payload "+
 			"FROM `%s` WHERE id>? ORDER BY id ASC LIMIT ?", table)
 	rows, err := s.db.QueryContext(ctx, q, after, limit)
@@ -54,7 +54,7 @@ func (s *MySQLSource) ReadBatch(ctx context.Context, table string, after int64, 
 	for rows.Next() {
 		var r srcMessageRow
 		if err := rows.Scan(
-			&r.ID, &r.MessageID, &r.FromUID, &r.ChannelID, &r.ChannelType,
+			&r.ID, &r.MessageID, &r.MessageSeq, &r.FromUID, &r.ChannelID, &r.ChannelType,
 			&r.Setting, &r.Signal, &r.Timestamp, &r.CreatedUnix, &r.Payload,
 		); err != nil {
 			return nil, fmt.Errorf("backfill: scan %s: %w", table, err)

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -93,6 +93,11 @@ func (w *fakeWriter) Close() error { return nil }
 
 func (w *fakeWriter) EnsureIndex(ctx context.Context) error { return nil }
 
+// BulkDocs 不被 consumer 路径调用（consumer 走 Bulk(msgs)）；提供空实现满足接口。
+func (w *fakeWriter) BulkDocs(ctx context.Context, docs []esindex.Doc) ([]esindex.BulkItemResult, error) {
+	return nil, nil
+}
+
 // fakeDLQSink 记录 DLQ 投递；可设定前 N 次失败。
 type fakeDLQSink struct {
 	writes     int

--- a/internal/consumer/service.go
+++ b/internal/consumer/service.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 )
 
@@ -93,7 +94,20 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 }
 
 // Run 运行消费循环直到 ctx 取消。启动时先幂等确保目标索引存在（带 mapping/中文分词）。
+//
+// 🔴 安全闸（V3b fail-OPEN 防护）：实时 consumer 写出的 doc 的 spaceId/visibles/messageSeq
+// 来自 Kafka 契约 searchmsg.Message，而当前契约（SchemaVersion 1）不带这三字段。若放行，
+// reader 对空 visibles 会 fail-OPEN（普通成员搜出群管才可见的系统消息）。故契约未携带安全
+// 字段前，实时写入**拒启动**（fail-closed），不静默灌 fail-open doc。存量经 backfill 富化。
+// 契约升到 SafetyFieldsSchemaVersion（octo-lib bump + producer 富化，阶段 9 前置）后自动解封。
 func (s *Service) Run(ctx context.Context) error {
+	if !esindex.LiveContractCarriesSafetyFields() {
+		return fmt.Errorf("consumer: live ingestion refused — Kafka contract (searchmsg.SchemaVersion=%d) "+
+			"does not carry reader safety fields (spaceId/visibles/messageSeq); writing now would fail-OPEN "+
+			"the reader's visibles gate. Bump octo-lib to SchemaVersion>=%d + enrich the producer (phase 9) "+
+			"before enabling live ingestion. Backfill enriches existing docs from MySQL meanwhile",
+			searchmsg.SchemaVersion, esindex.SafetyFieldsSchemaVersion)
+	}
 	if err := s.writer.EnsureIndex(ctx); err != nil {
 		return fmt.Errorf("consumer: ensure index: %w", err)
 	}

--- a/internal/esindex/doc.go
+++ b/internal/esindex/doc.go
@@ -112,3 +112,20 @@ func buildPayload(contentType int, content *string) *Payload {
 // payloadTypeText 对应 octo-lib common.Text（文本消息）。与 reader source.go
 // payloadTypeText / producer extract 口径一致。
 const payloadTypeText = 1
+
+// SafetyFieldsSchemaVersion 是 Kafka 契约（searchmsg.Message）开始携带 reader 必读的
+// 安全/正确性字段（SpaceID + Visibles + MessageSeq）的最小 SchemaVersion。
+//
+// 当前契约 searchmsg.SchemaVersion==1 **不带**这三字段（producer 只抽 content），故实时
+// consumer 路径写出的 doc 这三字段为空——reader 对空 visibles 是 **fail-OPEN**（群系统消息
+// 普通成员能搜出群管才可见消息），对空 spaceId(p2p) fail-closed，对 messageSeq=0 保守隐藏。
+// 把这三字段灌进 Kafka 契约需 octo-lib 升 SchemaVersion 1→2 + octo-server producer 富化
+// （阶段 9 上线前置）。届时 indexer 重 pin 到带这些字段的 octo-lib，SchemaVersion 升到本值，
+// LiveContractCarriesSafetyFields() 自动转 true，实时路径解除写入封锁。
+const SafetyFieldsSchemaVersion = 2
+
+// LiveContractCarriesSafetyFields 报告当前编译进二进制的 Kafka 契约是否已携带 reader 必读的
+// 安全字段（SpaceID/Visibles/MessageSeq）。consumer 据此决定是否允许实时写入（防 V3b fail-OPEN）。
+func LiveContractCarriesSafetyFields() bool {
+	return searchmsg.SchemaVersion >= SafetyFieldsSchemaVersion
+}

--- a/internal/esindex/doc.go
+++ b/internal/esindex/doc.go
@@ -1,0 +1,114 @@
+package esindex
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// Doc 是写入 OpenSearch 的文档形态 —— **逐字段对齐 octo-server reader**
+// (`modules/messages_search/source.go::Doc`，PR#385)。这是分叉 B 收敛的核心：
+// 索引契约的单一真源是 reader 读的形态，indexer 写成它能读的样子（reader 不动）。
+//
+// 与旧 flat snake_case 契约（message_id/content/...）的差异（全量收敛）：
+//   - 字段名 camelCase + payload 嵌套（messageId/channelId/payload.text.content）。
+//   - messageId 用 **long**（数值，全精度）——snowflake id 不可被 float64 截断，
+//     reader 从 typed _source 读 int64 做 cursor tiebreaker（dsl.go::lastHitMessageID）。
+//   - 新增 reader 必读的 **spaceId**(keyword) / **visibles**(keyword[]) / **messageSeq**(long)：
+//     · spaceId：p2p (DM) space 召回过滤，缺则同 space 也 0 命中（reader fail-closed）。
+//     · visibles：群系统消息「仅管理员可见」白名单 gate，缺则 reader fail-OPEN（V3b）。
+//     · messageSeq：reader channel_offset「清空会话」gate（visibility.go），缺则保守隐藏。
+//   - 排序字段 timestamp + messageId 与 reader cursor sort 口径一致。
+//
+// 字段标签与 reader Doc 完全一致（含 omitempty），保证 reader 反序列化无歧义。
+type Doc struct {
+	SchemaVersion int      `json:"schemaVersion"`
+	MessageID     int64    `json:"messageId"`
+	MessageSeq    uint64   `json:"messageSeq,omitempty"`
+	From          string   `json:"from,omitempty"`
+	To            string   `json:"to,omitempty"`
+	ChannelID     string   `json:"channelId"`
+	ChannelType   uint32   `json:"channelType"`
+	SpaceID       string   `json:"spaceId,omitempty"`
+	Visibles      []string `json:"visibles,omitempty"`
+	Timestamp     int64    `json:"timestamp"`
+	CreatedAt     int64    `json:"createdAt,omitempty"`
+	RawExcluded   bool     `json:"rawExcluded,omitempty"`
+	Source        string   `json:"source,omitempty"`
+	Payload       *Payload `json:"payload,omitempty"`
+}
+
+// Payload 是结构化正文投影（镜像 reader Doc.Payload）。当前 indexer 只抽取文本正文
+// （路线甲 + 与 producer/backfill payload 抽取口径一致：非文本 raw_excluded）；媒体子对象
+// mapping 已就位但本期不填，待后续阶段细化（CONSTRAINTS v1.10 follow-up）。
+type Payload struct {
+	Type *int         `json:"type,omitempty"`
+	Text *TextPayload `json:"text,omitempty"`
+}
+
+// TextPayload 镜像 reader Doc.Payload.Text（IK 分词字段 payload.text.content）。
+type TextPayload struct {
+	Content string `json:"content,omitempty"`
+}
+
+// idString 返回 ES `_id`（= 规范化 message_id）。messageId 为数值 snowflake，
+// FormatInt(ParseInt(s)) 与原串一致，保证 backfill 与实时 consumer 写同一 _id（幂等）。
+func (d Doc) idString() string {
+	return strconv.FormatInt(d.MessageID, 10)
+}
+
+// parseMessageID 把契约 message_id（VARCHAR(20) 数值串）解析为全精度 int64。
+// 解析失败属数据异常（reader 读 int64，非数值无法对齐）——上抛由调用方按毒丸处置，
+// 绝不静默落 0（reader 对 messageId==0 直接丢，会掩盖问题）。
+func parseMessageID(messageID string) (int64, error) {
+	id, err := strconv.ParseInt(messageID, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("esindex: non-numeric message_id %q (reader reads messageId as long): %w", messageID, err)
+	}
+	return id, nil
+}
+
+// DocFromMessage 把 Kafka 契约消息（searchmsg.Message）转成 reader 可读 Doc（实时 consumer 路径）。
+//
+// ⚠️ 实时路径的契约局限（阶段 9 上线前置 sibling）：searchmsg.Message **不携带**
+// spaceId / visibles / messageSeq（producer 只抽 content）。故实时路径写出的 Doc 这三字段
+// 为空：reader 对空 spaceId（p2p）走 fail-closed（同 space 不命中），对空 visibles 无 gate，
+// 对 messageSeq=0 保守隐藏——均**安全方向**。要让实时路径填全这三字段，须扩 octo-lib 契约
+// （+SpaceID/+Visibles/+MessageSeq，SchemaVersion 1→2）+ octo-server searchetl producer 富化，
+// 二者随阶段 9 开 Kafka.On 一并上线（本期 Kafka.On=OFF，无实时流量）。
+// 存量数据的这三字段由 backfill 路径（读原始 MySQL payload）自源填全 → 满足 V1(b)/V3b。
+func DocFromMessage(msg searchmsg.Message) (Doc, error) {
+	id, err := parseMessageID(msg.MessageID)
+	if err != nil {
+		return Doc{}, err
+	}
+	d := Doc{
+		SchemaVersion: msg.SchemaVersion,
+		MessageID:     id,
+		From:          msg.FromUID,
+		ChannelID:     msg.ChannelID,
+		ChannelType:   uint32(msg.ChannelType),
+		Timestamp:     msg.MsgTimestamp,
+		CreatedAt:     msg.CreatedAt,
+		RawExcluded:   msg.RawExcluded,
+		Source:        msg.Source,
+	}
+	d.Payload = buildPayload(msg.ContentType, msg.Content)
+	return d, nil
+}
+
+// buildPayload 构造 reader 可读的 payload 投影。payload.type 始终带（reader _search_all
+// 据此分流）；仅文本且 content 非空时填 payload.text.content（IK 分词）。
+func buildPayload(contentType int, content *string) *Payload {
+	ct := contentType
+	p := &Payload{Type: &ct}
+	if contentType == payloadTypeText && content != nil && *content != "" {
+		p.Text = &TextPayload{Content: *content}
+	}
+	return p
+}
+
+// payloadTypeText 对应 octo-lib common.Text（文本消息）。与 reader source.go
+// payloadTypeText / producer extract 口径一致。
+const payloadTypeText = 1

--- a/internal/esindex/doc_test.go
+++ b/internal/esindex/doc_test.go
@@ -83,7 +83,10 @@ func TestDocFromMessage_PrecisionRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DocFromMessage: %v", err)
 	}
-	b, _ := json.Marshal(d)
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
 	// 文档行必须以数值（非字符串）形式写 messageId，且不带引号。
 	if got := string(b); !containsSub(got, `"messageId":9223372036854775807`) {
 		t.Fatalf("messageId must serialize as full-precision numeric long: %s", got)

--- a/internal/esindex/doc_test.go
+++ b/internal/esindex/doc_test.go
@@ -1,0 +1,129 @@
+package esindex
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// readerDoc 镜像 octo-server reader 的 source.go::Doc 关键字段（驱动 cross-repo 契约断言）。
+// 用 reader 的 json tag 反序列化 indexer 写出的 doc，确保字段名/类型/嵌套逐字段对齐。
+type readerDoc struct {
+	MessageID   int64    `json:"messageId"`
+	MessageSeq  uint64   `json:"messageSeq"`
+	ChannelID   string   `json:"channelId"`
+	ChannelType uint32   `json:"channelType"`
+	SpaceID     string   `json:"spaceId"`
+	Timestamp   int64    `json:"timestamp"`
+	From        string   `json:"from"`
+	Visibles    []string `json:"visibles"`
+	Payload     *struct {
+		Type *int `json:"type"`
+		Text *struct {
+			Content string `json:"content"`
+		} `json:"text"`
+	} `json:"payload"`
+}
+
+func textMsg(id string) searchmsg.Message {
+	c := "你好 world"
+	return searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     id,
+		ChannelID:     "g_1",
+		ChannelType:   2,
+		FromUID:       "u_1",
+		Content:       &c,
+		ContentType:   payloadTypeText,
+		MsgTimestamp:  1700000000,
+		CreatedAt:     1700000001,
+		Source:        searchmsg.SourceETLMessageTable,
+	}
+}
+
+// TestDocFromMessage_ReaderShape 实时 consumer 路径写出的 doc 能被 reader 契约逐字段读出：
+// camelCase + 嵌套 payload.text.content + messageId 全精度 long。
+func TestDocFromMessage_ReaderShape(t *testing.T) {
+	in := textMsg("305419896765432111") // 大于 2^53，验证 long 全精度不被 float64 截断
+	d, err := DocFromMessage(in)
+	if err != nil {
+		t.Fatalf("DocFromMessage: %v", err)
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var rd readerDoc
+	if err := json.Unmarshal(b, &rd); err != nil {
+		t.Fatalf("reader unmarshal: %v", err)
+	}
+	if rd.MessageID != 305419896765432111 {
+		t.Fatalf("messageId precision lost: got %d", rd.MessageID)
+	}
+	if rd.ChannelID != "g_1" || rd.ChannelType != 2 || rd.From != "u_1" {
+		t.Fatalf("routing/authz fields mismatch: %+v", rd)
+	}
+	if rd.Timestamp != 1700000000 {
+		t.Fatalf("timestamp mismatch: %d", rd.Timestamp)
+	}
+	if rd.Payload == nil || rd.Payload.Text == nil || rd.Payload.Text.Content != "你好 world" {
+		t.Fatalf("payload.text.content not aligned to reader: %+v", rd.Payload)
+	}
+	if rd.Payload.Type == nil || *rd.Payload.Type != payloadTypeText {
+		t.Fatalf("payload.type missing")
+	}
+}
+
+// TestDocFromMessage_PrecisionRoundTrip snowflake id 经 JSON 数值往返不丢精度
+// （reader 从 typed _source 读 int64 做 cursor tiebreaker，2^53 以上必须全精度）。
+func TestDocFromMessage_PrecisionRoundTrip(t *testing.T) {
+	const big = "9223372036854775807" // int64 max
+	d, err := DocFromMessage(textMsg(big))
+	if err != nil {
+		t.Fatalf("DocFromMessage: %v", err)
+	}
+	b, _ := json.Marshal(d)
+	// 文档行必须以数值（非字符串）形式写 messageId，且不带引号。
+	if got := string(b); !containsSub(got, `"messageId":9223372036854775807`) {
+		t.Fatalf("messageId must serialize as full-precision numeric long: %s", got)
+	}
+	if d.idString() != big {
+		t.Fatalf("idString round-trip mismatch: %q", d.idString())
+	}
+}
+
+// TestDocFromMessage_NonNumericIsError 非数值 message_id → 错误（reader 读 long 无法对齐），
+// 由调用方按毒丸处置，绝不静默落 0。
+func TestDocFromMessage_NonNumericIsError(t *testing.T) {
+	if _, err := DocFromMessage(textMsg("not-a-number")); err == nil {
+		t.Fatalf("non-numeric message_id must error")
+	}
+}
+
+// TestDocFromMessage_RawExcludedNoText raw_excluded（非文本/加密）→ 无 payload.text，但仍占一个 doc。
+func TestDocFromMessage_RawExcludedNoText(t *testing.T) {
+	m := textMsg("42")
+	m.RawExcluded = true
+	m.Content = nil
+	m.ContentType = 2 // image
+	d, err := DocFromMessage(m)
+	if err != nil {
+		t.Fatalf("DocFromMessage: %v", err)
+	}
+	if d.Payload == nil || d.Payload.Text != nil {
+		t.Fatalf("raw_excluded must not carry payload.text: %+v", d.Payload)
+	}
+	if !d.RawExcluded {
+		t.Fatalf("rawExcluded flag must round-trip")
+	}
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/esindex/mapping/README.md
+++ b/internal/esindex/mapping/README.md
@@ -1,50 +1,56 @@
-# octo-message index mapping
+# octo-message index mapping (v1.9 — reader-aligned)
 
-`octo-message.json` is the **canonical index mapping + analyzer** the
-`es-indexer` writes against, embedded into the binary (`//go:embed`) and used by
-`esindex.EnsureIndex` to bootstrap the index idempotently when it does not yet
-exist.
+`octo-message.json` is the **canonical index mapping + analyzer** the `es-indexer`
+writes against, embedded into the binary (`//go:embed`) and used by
+`esindex.EnsureIndex` to bootstrap the index idempotently when it does not yet exist.
 
-It is the single source the **octo-deployment** coordinated change references:
-provisioning/managed-OpenSearch templates must stay in lockstep with this file
-at the same contract version (`searchmsg.SchemaVersion`).
+## v1.9 contract convergence (YUJ-4534 阶段 8 · 分叉 B)
+
+v1.9 收敛索引契约到 **octo-server reader** 读的形态
+(`modules/messages_search/source.go::Doc`)，reader 不动。相对旧 flat snake_case 契约：
+
+- 字段名 **camelCase** + payload **嵌套**（`messageId/channelId/payload.text.content`）。
+- `messageId` 用 **long**（数值全精度）——snowflake id 不被 float64 截断（reader 从 typed _source
+  读 int64 做 cursor tiebreaker）。
+- 新增 reader 必读字段：`spaceId`(keyword) / `visibles`(keyword[]) / `messageSeq`(long)。
+- sort 字段 `timestamp`(epoch_second) + `messageId` 与 reader cursor sort 口径一致。
+- 内嵌 **alias `wukongim-messages-read`**（reader 读此 alias，pattern `wukongim-messages-*`）。
+
+完整迁移说明见 `docs/forward-migration-v1.9.md`。
 
 ## Chinese tokenization — IK (analysis-ik)
 
-`content` uses the IK plugin's dual-analyzer setup:
+`payload.text.content`（及 image.caption/name、file.name/caption、mergeForward.msgs.searchText）
+用 IK 双分析器：
 
-- index-time `analyzer: ik_max_word` — exhaustive segmentation, maximises recall
-  (IM search is a "rather over-recall than miss" scenario).
-- query-time `search_analyzer: ik_smart` — smart segmentation, keeps precision.
+- index-time `analyzer: ik_max_word` — 穷举切分，最大化召回（IM 搜索「宁可多召回不漏」）。
+- query-time `search_analyzer: ik_smart` — 智能切分，保精度。
 
-IK is chosen over the built-in `smartcn` because IK's dictionary segmentation is
-markedly better on IM colloquialisms, CN/EN/digit mixes and net-slang, and it
-supports hot-reloadable custom dictionaries (product names, @nicknames, in-group
-jargon). The IK plugin + dictionaries are provisioned by the **octo-deployment**
-change; the local verification harness (`harness/`) installs the IK plugin into
-its OpenSearch container so the mapping is exercised for real.
-
-> Requires the `analysis-ik` plugin on the OpenSearch cluster. If a deployment
-> must run without IK, override `content.analyzer`/`search_analyzer` in the
-> octo-deployment template (e.g. to a `cjk_bigram`-based custom analyzer) — that
-> selection is owned by the deployment change, not pinned here.
+> 需 OpenSearch 集群装 `analysis-ik` 插件（由 octo-deployment 协调变更 provision）。若部署无 IK，
+> 在 octo-deployment 模板覆盖 analyzer（如 cjk_bigram），该选择归部署侧，不在本文件钉死。
 
 ## Field rationale (route 甲: body + query-side authz visibility only)
 
-| Field            | Type                | Why                                                        |
-| ---------------- | ------------------- | --------------------------------------------------------- |
-| `message_id`     | `keyword`           | = ES `_id` / Kafka key; exact-match dedupe key            |
-| `channel_id`     | `keyword`           | query-side authz filter (group/topic/DM resolution)       |
-| `channel_type`   | `integer`           | authz routing per channel type                            |
-| `from_uid`       | `keyword`           | sender filter / authz                                     |
-| `content`        | `text` + IK         | the searchable body — Chinese tokenization                |
-| `content_type`   | `integer`           | message type                                              |
-| `raw_excluded`   | `boolean`           | Signal/non-text marker (content null)                     |
-| `msg_timestamp`  | `long`              | send time (epoch s)                                       |
-| `created_at`     | `long`              | landed time (epoch s) — reconciliation window field       |
-| `source`         | `keyword`           | provenance (ETL vs future CDC)                            |
-| `schema_version` | `integer`           | contract version stamped on every doc                     |
+| Field | Type | Why |
+| --- | --- | --- |
+| `messageId` | long | = ES `_id`（规范化）/ exact-match dedupe key；全精度 snowflake |
+| `messageSeq` | long | reader channel_offset「清空会话」可见性 gate |
+| `from` / `to` | keyword | sender 过滤 / 鉴权；p2p 参与方 |
+| `channelId` | keyword | query-side 频道鉴权过滤（group/topic/DM） |
+| `channelType` | integer | 按频道类型分流鉴权 |
+| `spaceId` | keyword | p2p（DM）space 召回过滤；缺则 reader fail-closed |
+| `visibles` | keyword[] | 群系统消息「仅管理员可见」白名单；缺则 reader fail-OPEN（安全项） |
+| `timestamp` | date(epoch_second) | 发送时间；cursor sort 字段（+ messageId） |
+| `payload.type` | integer | 消息类型，reader `_search_all` 分流 |
+| `payload.text.content` | text + IK | 可检索正文，中文分词 |
+| `payload.image/gif/voice/video/file/mergeForward.*` | keyword/text/integer/long | reader `_search_media`/`_search_files`/forward 卡片字段（mapping 就位，本期 indexer 只填文本） |
+| `createdAt` | long | 落库时间（epoch s），对账窗口字段 |
+| `rawExcluded` | boolean | Signal/非文本占位 doc 标记（content null） |
+| `revoked` | boolean | OS-side best-effort 撤回标记（非安全边界，权威撤回靠 reader 回 MySQL join） |
+| `source` | keyword | 来源（ETL vs 未来 CDC） |
 
-No `revoked` / `deleted` fields — route 甲 filters those at read time via MySQL
-join. Mapping is `dynamic: strict` so any unexpected field fails loudly rather
-than silently polluting the index.
+No per-user `is_deleted` field — route 甲 在 reader 读时回 MySQL join 过滤。
+Mapping 为 `dynamic: strict`：任何意外字段直接报错，不静默污染索引。
+
+> mapping 须与 octo-deployment 托管模板 + octo-server reader Doc 保持同契约版本对齐（半兼容会
+> 悄悄打断 search_after / around / p2p filter）。

--- a/internal/esindex/mapping/README.md
+++ b/internal/esindex/mapping/README.md
@@ -14,7 +14,9 @@ v1.9 收敛索引契约到 **octo-server reader** 读的形态
   读 int64 做 cursor tiebreaker）。
 - 新增 reader 必读字段：`spaceId`(keyword) / `visibles`(keyword[]) / `messageSeq`(long)。
 - sort 字段 `timestamp`(epoch_second) + `messageId` 与 reader cursor sort 口径一致。
-- 内嵌 **alias `wukongim-messages-read`**（reader 读此 alias，pattern `wukongim-messages-*`）。
+- reader 读 **alias `wukongim-messages-read`**（pattern `wukongim-messages-*`）。**本 mapping 不再内嵌该
+  alias**（v1.9 R2）：`EnsureIndex` 用本文件裸 PUT 建索引，若内嵌 alias 会让新索引一建好就被 reader
+  读到（reindex/backfill 完成前的半量数据）。alias 改由迁移脚本步骤③在对账通过后单独原子挂。
 
 完整迁移说明见 `docs/forward-migration-v1.9.md`。
 

--- a/internal/esindex/mapping/octo-message.json
+++ b/internal/esindex/mapping/octo-message.json
@@ -5,24 +5,98 @@
       "number_of_replicas": 1
     }
   },
+  "aliases": {
+    "wukongim-messages-read": {}
+  },
   "mappings": {
     "dynamic": "strict",
     "properties": {
-      "schema_version": { "type": "integer" },
-      "message_id":     { "type": "keyword" },
-      "channel_id":     { "type": "keyword" },
-      "channel_type":   { "type": "integer" },
-      "from_uid":       { "type": "keyword" },
-      "content": {
-        "type": "text",
-        "analyzer": "ik_max_word",
-        "search_analyzer": "ik_smart"
-      },
-      "content_type":   { "type": "integer" },
-      "raw_excluded":   { "type": "boolean" },
-      "msg_timestamp":  { "type": "long" },
-      "created_at":     { "type": "long" },
-      "source":         { "type": "keyword" }
+      "schemaVersion": { "type": "integer" },
+      "messageId":     { "type": "long" },
+      "messageSeq":    { "type": "long" },
+      "from":          { "type": "keyword", "ignore_above": 256 },
+      "to":            { "type": "keyword", "ignore_above": 256 },
+      "channelId":     { "type": "keyword", "ignore_above": 256 },
+      "channelType":   { "type": "integer" },
+      "spaceId":       { "type": "keyword", "ignore_above": 256 },
+      "visibles":      { "type": "keyword", "ignore_above": 256 },
+      "timestamp":     { "type": "date", "format": "epoch_second" },
+      "createdAt":     { "type": "long" },
+      "revoked":       { "type": "boolean" },
+      "rawExcluded":   { "type": "boolean" },
+      "source":        { "type": "keyword", "ignore_above": 64 },
+      "payload": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "integer" },
+          "text": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "text",
+                "analyzer": "ik_max_word",
+                "search_analyzer": "ik_smart"
+              }
+            }
+          },
+          "image": {
+            "type": "object",
+            "properties": {
+              "url":     { "type": "keyword", "ignore_above": 1024 },
+              "caption": { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+              "name":    { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+              "width":   { "type": "integer" },
+              "height":  { "type": "integer" }
+            }
+          },
+          "gif": {
+            "type": "object",
+            "properties": {
+              "url": { "type": "keyword", "ignore_above": 1024 }
+            }
+          },
+          "voice": {
+            "type": "object",
+            "properties": {
+              "url": { "type": "keyword", "ignore_above": 1024 }
+            }
+          },
+          "video": {
+            "type": "object",
+            "properties": {
+              "url":    { "type": "keyword", "ignore_above": 1024 },
+              "cover":  { "type": "keyword", "ignore_above": 1024 },
+              "width":  { "type": "integer" },
+              "height": { "type": "integer" },
+              "second": { "type": "integer" }
+            }
+          },
+          "file": {
+            "type": "object",
+            "properties": {
+              "url":       { "type": "keyword", "ignore_above": 1024 },
+              "name":      { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+              "caption":   { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+              "size":      { "type": "long" },
+              "extension": { "type": "keyword", "ignore_above": 32 }
+            }
+          },
+          "mergeForward": {
+            "type": "object",
+            "properties": {
+              "childCount": { "type": "integer" },
+              "msgs": {
+                "type": "object",
+                "properties": {
+                  "messageId":  { "type": "long" },
+                  "type":       { "type": "integer" },
+                  "searchText": { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/internal/esindex/mapping/octo-message.json
+++ b/internal/esindex/mapping/octo-message.json
@@ -5,9 +5,6 @@
       "number_of_replicas": 1
     }
   },
-  "aliases": {
-    "wukongim-messages-read": {}
-  },
   "mappings": {
     "dynamic": "strict",
     "properties": {

--- a/internal/esindex/safetygate_test.go
+++ b/internal/esindex/safetygate_test.go
@@ -1,0 +1,21 @@
+package esindex
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// TestLiveContractSafetyGate 钉住实时写入安全闸的口径：当前 Kafka 契约（SchemaVersion=1）
+// 不带 spaceId/visibles/messageSeq，故实时路径必须封锁（防 reader visibles fail-OPEN）。
+// octo-lib 升到 SafetyFieldsSchemaVersion(=2) + producer 富化后才解封（阶段 9 前置）。
+func TestLiveContractSafetyGate(t *testing.T) {
+	want := searchmsg.SchemaVersion >= SafetyFieldsSchemaVersion
+	if got := LiveContractCarriesSafetyFields(); got != want {
+		t.Fatalf("LiveContractCarriesSafetyFields()=%v want %v", got, want)
+	}
+	// 本期断言：契约尚未携带安全字段（若 octo-lib 已 bump，此处会提示更新 pin / 解封实时路径）。
+	if searchmsg.SchemaVersion < SafetyFieldsSchemaVersion && LiveContractCarriesSafetyFields() {
+		t.Fatalf("guard must stay closed while contract lacks safety fields")
+	}
+}

--- a/internal/esindex/v2gate_test.go
+++ b/internal/esindex/v2gate_test.go
@@ -1,0 +1,113 @@
+package esindex
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// safetyFieldNames 是 reader 必读的三个安全/正确性字段在 searchmsg.Message 上的预期字段名
+// （契约升到 v2 时由 octo-lib 添加）。映射到 esindex.Doc 上的目标字段名。
+var safetyFieldNames = []struct {
+	msgField string // searchmsg.Message 上的字段名（v2 契约新增）
+	docField string // esindex.Doc 上对应字段名
+}{
+	{"SpaceID", "SpaceID"},
+	{"Visibles", "Visibles"},
+	{"MessageSeq", "MessageSeq"},
+}
+
+// TestV2Gate_DocFromMessageWiresSafetyFields 🔴 v2-gate latent fail-open 防回归门（Jerry 两轮点名）。
+//
+// 背景：实时安全闸（consumer.Run / LiveContractCarriesSafetyFields）只看 searchmsg.SchemaVersion>=2
+// 就解封实时写入。但 DocFromMessage 当前**不 copy** spaceId/visibles/messageSeq（v1 契约根本没这仨
+// 字段）。隐患：将来有人把 octo-lib bump 到 v2（加字段 + 升 SchemaVersion）解了闸，却忘了同步给
+// DocFromMessage 接线 —— 实时路径就会写出**空** visibles 的 doc，reader 直接 fail-OPEN（普通成员
+// 搜出群管才可见的系统消息）。安全闸开了，但数据是 fail-open 的，比闸关着更危险。
+//
+// 本测试用**反射**实现，故在 v1（字段尚不存在）下能正常编译/通过；一旦契约升到 v2：
+//   - 若 searchmsg.Message 没有这三字段 → 报错（契约 bump 不完整）。
+//   - 若有字段但 DocFromMessage 没把它们 copy 进 Doc → 断言失败转红（这正是要拦的 latent fail-open）。
+//
+// 即「v2 bump 不接线就过不了 CI」。接线（DocFromMessage 填全三字段）后本测试自动转绿。
+func TestV2Gate_DocFromMessageWiresSafetyFields(t *testing.T) {
+	if !LiveContractCarriesSafetyFields() {
+		// 契约仍是 v1（SchemaVersion<2）：这三字段尚未进 Kafka 契约，实时闸保持关闭（由
+		// TestLiveContractSafetyGate 钉死），此 latent 隐患尚未被激活。本门在 v2 bump 时自动生效。
+		t.Skipf("contract still v1 (SchemaVersion=%d < %d); v2-gate inactive until contract bump",
+			searchmsg.SchemaVersion, SafetyFieldsSchemaVersion)
+	}
+
+	// ── 契约已升到 v2：强制要求 DocFromMessage 把三个安全字段从契约 copy 进 Doc ──
+	msg := searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     "123456789012345678",
+		ChannelID:     "g_1",
+		ChannelType:   2,
+	}
+
+	// 反射写入三个安全字段的哨兵值（字段在 v2 契约里才存在，故用反射，避免 v1 下编译失败）。
+	mv := reflect.ValueOf(&msg).Elem()
+	const (
+		sentSpace = "space-sentinel"
+		sentVis   = "vis-sentinel"
+		sentSeq   = uint64(424242)
+	)
+	for _, f := range safetyFieldNames {
+		fv := mv.FieldByName(f.msgField)
+		if !fv.IsValid() {
+			t.Fatalf("contract bumped to v2 (SchemaVersion=%d) but searchmsg.Message lacks field %q; "+
+				"a v2 bump must add SpaceID/Visibles/MessageSeq to the contract", searchmsg.SchemaVersion, f.msgField)
+		}
+		setSentinel(t, fv, f.msgField, sentSpace, sentVis, sentSeq)
+	}
+
+	doc, err := DocFromMessage(msg)
+	if err != nil {
+		t.Fatalf("DocFromMessage: %v", err)
+	}
+
+	// 逐字段断言 Doc 已被填全（未接线则为零值 → 转红）。
+	if doc.SpaceID != sentSpace {
+		t.Fatalf("v2-gate: DocFromMessage did not copy SpaceID from the contract (latent fail-closed/open): got %q", doc.SpaceID)
+	}
+	if len(doc.Visibles) != 1 || doc.Visibles[0] != sentVis {
+		t.Fatalf("v2-gate: DocFromMessage did not copy Visibles from the contract — reader would fail-OPEN: got %+v", doc.Visibles)
+	}
+	if doc.MessageSeq != sentSeq {
+		t.Fatalf("v2-gate: DocFromMessage did not copy MessageSeq from the contract: got %d", doc.MessageSeq)
+	}
+}
+
+// TestV2Gate_DocRetainsSafetyFields 始终生效（v1 也跑）：esindex.Doc 必须保留三个安全字段为
+// 反射门的目标字段。若有人重命名/删掉 Doc.SpaceID/Visibles/MessageSeq，本门立刻转红——否则上面
+// 的 v2-gate 反射断言会因目标字段消失而**静默失效**（gate 烂掉而无人知）。
+func TestV2Gate_DocRetainsSafetyFields(t *testing.T) {
+	dt := reflect.TypeOf(Doc{})
+	for _, f := range safetyFieldNames {
+		if _, ok := dt.FieldByName(f.docField); !ok {
+			t.Fatalf("esindex.Doc lost safety field %q; the v2 latent-fail-open gate depends on it", f.docField)
+		}
+	}
+}
+
+// setSentinel 按字段 kind 写入合适类型的哨兵值（string / []string / 无符号整数）。
+func setSentinel(t *testing.T, fv reflect.Value, name, sentStr, sentVis string, sentSeq uint64) {
+	t.Helper()
+	switch fv.Kind() {
+	case reflect.String:
+		fv.SetString(sentStr)
+	case reflect.Slice:
+		if fv.Type().Elem().Kind() != reflect.String {
+			t.Fatalf("v2-gate: field %q expected []string, got %s", name, fv.Type())
+		}
+		fv.Set(reflect.ValueOf([]string{sentVis}))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		fv.SetUint(sentSeq)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		fv.SetInt(int64(sentSeq))
+	default:
+		t.Fatalf("v2-gate: field %q has unexpected kind %s", name, fv.Kind())
+	}
+}

--- a/internal/esindex/writer.go
+++ b/internal/esindex/writer.go
@@ -36,11 +36,21 @@ type Writer interface {
 	// EnsureIndex 幂等创建目标索引（不存在则用内嵌 mapping 创建，已存在则不动）。
 	// 供服务启动与 backfill job 复用同一套 mapping bootstrap。
 	EnsureIndex(ctx context.Context) error
-	// Bulk 幂等写入一批消息，返回与入参等长、顺序对齐的 per-item 结果切片。
+	// Bulk 幂等写入一批 Kafka 契约消息（实时 consumer 路径）。内部转 reader 可读 Doc 后
+	// bulk upsert；契约 message_id 非数值（无法对齐 reader long messageId）的条目按
+	// **永久错误（4xx 语义，Status=400）**回报，由 consumer 路由 DLQ，绝不静默落 0。
+	// 返回与入参等长、顺序对齐的 per-item 结果切片。
 	Bulk(ctx context.Context, msgs []searchmsg.Message) ([]BulkItemResult, error)
+	// BulkDocs 幂等写入一批已构造好的 reader 可读 Doc（backfill 富化路径用：从原始 MySQL
+	// payload 自源填 spaceId/visibles/messageSeq）。与 Bulk 共用同一套 _bulk 写入 + 结果映射。
+	BulkDocs(ctx context.Context, docs []Doc) ([]BulkItemResult, error)
 	// Close 释放底层 ES 客户端资源。
 	Close() error
 }
+
+// docConvertBadRequest 是契约消息无法转 Doc（message_id 非数值）时回报的伪 HTTP 状态，
+// 复用 400 的 permanent 语义让 consumer 路由 DLQ（与 ES mapping 冲突等永久错误同处置）。
+const docConvertBadRequest = 400
 
 // BulkItemResult 是单条文档的写入结果，供 consumer 做 offset / DLQ 决策。
 type BulkItemResult struct {
@@ -120,9 +130,12 @@ type bulkActionLine struct {
 	} `json:"index"`
 }
 
-// Bulk 把一批契约消息以 _bulk 幂等写入 ES。返回与 msgs 等长、按 MessageID 对齐的结果。
+// Bulk 把一批 Kafka 契约消息转成 reader 可读 Doc 后以 _bulk 幂等写入 ES。
+// 返回与 msgs 等长、按 MessageID 对齐的结果。
 //
 // 错误语义：
+//   - 单条转 Doc 失败（message_id 非数值，无法对齐 reader long messageId）→ 该条 **permanent**
+//     （Status=400），不进 _bulk，由 consumer 路由 DLQ，绝不静默落 messageId=0（reader 会丢弃 0）。
 //   - 批级失败（网络/非 2xx 整体响应）→ 返回 error，且每条结果 OK=false、Status=0（transient，
 //     consumer 整批退避重试不推进 offset）。
 //   - 批级成功但部分条目失败 → error=nil，逐条 OK/Status/Err 反映 per-item 状态，consumer 据此
@@ -132,7 +145,53 @@ func (w *osWriter) Bulk(ctx context.Context, msgs []searchmsg.Message) ([]BulkIt
 		return nil, nil
 	}
 
-	body, err := encodeBulkBody(msgs)
+	out := make([]BulkItemResult, len(msgs))
+	docs := make([]Doc, 0, len(msgs))
+	docIdx := make([]int, 0, len(msgs)) // docs[j] 对应 msgs/out 的下标
+	for i := range msgs {
+		d, err := DocFromMessage(msgs[i])
+		if err != nil {
+			// 转 Doc 失败属永久数据错误（非数值 message_id）：标 permanent(400) 让 consumer 进 DLQ。
+			out[i] = BulkItemResult{MessageID: msgs[i].MessageID, OK: false, Status: docConvertBadRequest, Err: err}
+			continue
+		}
+		docs = append(docs, d)
+		docIdx = append(docIdx, i)
+	}
+
+	if len(docs) == 0 {
+		return out, nil
+	}
+
+	docRes, err := w.BulkDocs(ctx, docs)
+	if err != nil {
+		// 批级失败：把可转条目标 transient（保留转换已永久失败的条目结果不变）。
+		// BulkDocs 在编码错误时可能返回 nil 结果切片——此时按 transient 兜底，绝不索引越界。
+		for j, idx := range docIdx {
+			if j < len(docRes) {
+				out[idx] = docRes[j]
+			} else {
+				out[idx] = BulkItemResult{OK: false, Status: 0, Err: err}
+			}
+			out[idx].MessageID = msgs[idx].MessageID
+		}
+		return out, err
+	}
+	for j, idx := range docIdx {
+		out[idx] = docRes[j]
+		out[idx].MessageID = msgs[idx].MessageID
+	}
+	return out, nil
+}
+
+// BulkDocs 把一批 reader 可读 Doc 以 _bulk 幂等写入 ES（backfill 富化路径直接调用）。
+// doc _id = 规范化 messageId，与实时 consumer 路径同 _id → 重叠运行幂等去重。
+func (w *osWriter) BulkDocs(ctx context.Context, docs []Doc) ([]BulkItemResult, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	body, err := encodeBulkBody(docs)
 	if err != nil {
 		return nil, err
 	}
@@ -142,26 +201,27 @@ func (w *osWriter) Bulk(ctx context.Context, msgs []searchmsg.Message) ([]BulkIt
 		Body:  bytes.NewReader(body),
 	})
 	if err != nil {
-		// 批级失败（网络/超时/非 2xx）：全部标 transient，让 consumer 整批退避重试。
-		return batchFailure(msgs, err), fmt.Errorf("esindex: bulk request failed: %w", err)
+		// 批级失败（网络/超时/非 2xx）：全部标 transient，让调用方整批退避重试。
+		return batchFailure(docs, err), fmt.Errorf("esindex: bulk request failed: %w", err)
 	}
 
-	return mapBulkResults(msgs, resp), nil
+	return mapBulkResults(docs, resp), nil
 }
 
-// encodeBulkBody 把消息序列化为 _bulk NDJSON（每条：index 动作行 + 文档行）。
-func encodeBulkBody(msgs []searchmsg.Message) ([]byte, error) {
+// encodeBulkBody 把 Doc 序列化为 _bulk NDJSON（每条：index 动作行 + 文档行）。
+func encodeBulkBody(docs []Doc) ([]byte, error) {
 	var buf bytes.Buffer
-	for i := range msgs {
+	for i := range docs {
+		id := docs[i].idString()
 		var action bulkActionLine
-		action.Index.ID = msgs[i].MessageID
+		action.Index.ID = id
 		actionJSON, err := json.Marshal(action)
 		if err != nil {
-			return nil, fmt.Errorf("esindex: marshal bulk action for %s: %w", msgs[i].MessageID, err)
+			return nil, fmt.Errorf("esindex: marshal bulk action for %s: %w", id, err)
 		}
-		docJSON, err := json.Marshal(msgs[i])
+		docJSON, err := json.Marshal(docs[i])
 		if err != nil {
-			return nil, fmt.Errorf("esindex: marshal doc for %s: %w", msgs[i].MessageID, err)
+			return nil, fmt.Errorf("esindex: marshal doc for %s: %w", id, err)
 		}
 		buf.Write(actionJSON)
 		buf.WriteByte('\n')
@@ -172,25 +232,26 @@ func encodeBulkBody(msgs []searchmsg.Message) ([]byte, error) {
 }
 
 // batchFailure 在批级失败时把每条标为 transient（Status=0, OK=false）。
-func batchFailure(msgs []searchmsg.Message, err error) []BulkItemResult {
-	out := make([]BulkItemResult, len(msgs))
-	for i := range msgs {
-		out[i] = BulkItemResult{MessageID: msgs[i].MessageID, OK: false, Status: 0, Err: err}
+func batchFailure(docs []Doc, err error) []BulkItemResult {
+	out := make([]BulkItemResult, len(docs))
+	for i := range docs {
+		out[i] = BulkItemResult{MessageID: docs[i].idString(), OK: false, Status: 0, Err: err}
 	}
 	return out
 }
 
 // mapBulkResults 把 _bulk 响应逐项映射回结果切片（顺序与入参一致）。
 // _bulk 响应 Items 顺序与请求顺序一致，按下标对齐；防御性校验长度与 _id。
-func mapBulkResults(msgs []searchmsg.Message, resp *opensearchapi.BulkResp) []BulkItemResult {
-	out := make([]BulkItemResult, len(msgs))
-	for i := range msgs {
-		res := BulkItemResult{MessageID: msgs[i].MessageID}
+func mapBulkResults(docs []Doc, resp *opensearchapi.BulkResp) []BulkItemResult {
+	out := make([]BulkItemResult, len(docs))
+	for i := range docs {
+		id := docs[i].idString()
+		res := BulkItemResult{MessageID: id}
 		if i >= len(resp.Items) {
 			// 响应条目缺失（理论上不应发生）：标 transient 让整批重试，绝不静默当成功。
 			res.OK = false
 			res.Status = 0
-			res.Err = fmt.Errorf("esindex: missing bulk response item for %s", msgs[i].MessageID)
+			res.Err = fmt.Errorf("esindex: missing bulk response item for %s", id)
 			out[i] = res
 			continue
 		}
@@ -198,7 +259,7 @@ func mapBulkResults(msgs []searchmsg.Message, resp *opensearchapi.BulkResp) []Bu
 		if !ok {
 			res.OK = false
 			res.Status = 0
-			res.Err = fmt.Errorf("esindex: bulk response item for %s has no index action", msgs[i].MessageID)
+			res.Err = fmt.Errorf("esindex: bulk response item for %s has no index action", id)
 			out[i] = res
 			continue
 		}
@@ -209,9 +270,9 @@ func mapBulkResults(msgs []searchmsg.Message, resp *opensearchapi.BulkResp) []Bu
 			res.OK = false
 			if item.Error != nil {
 				res.Err = fmt.Errorf("esindex: bulk item %s status=%d type=%s reason=%s",
-					msgs[i].MessageID, item.Status, item.Error.Type, item.Error.Reason)
+					id, item.Status, item.Error.Type, item.Error.Reason)
 			} else {
-				res.Err = fmt.Errorf("esindex: bulk item %s status=%d", msgs[i].MessageID, item.Status)
+				res.Err = fmt.Errorf("esindex: bulk item %s status=%d", id, item.Status)
 			}
 		}
 		out[i] = res

--- a/internal/esindex/writer_test.go
+++ b/internal/esindex/writer_test.go
@@ -79,12 +79,12 @@ func TestBulk_AllSuccess(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		gotBody = readAll(r.Body)
 		return jsonResp(200, `{"took":1,"errors":false,"items":[
-			{"index":{"_id":"m1","status":201}},
-			{"index":{"_id":"m2","status":200}}
+			{"index":{"_id":"101","status":201}},
+			{"index":{"_id":"102","status":200}}
 		]}`), nil
 	})
 	w := newTestWriter(t, rt)
-	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("m1", "hi"), msg("m2", "世界")})
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("101", "hi"), msg("102", "世界")})
 	if err != nil {
 		t.Fatalf("Bulk: %v", err)
 	}
@@ -92,12 +92,15 @@ func TestBulk_AllSuccess(t *testing.T) {
 		t.Fatalf("expected both OK, got %+v", res)
 	}
 	// 校验 NDJSON 动作行带 _id（upsert 幂等键 = message_id）。
-	if !strings.Contains(gotBody, `"_id":"m1"`) || !strings.Contains(gotBody, `"_id":"m2"`) {
+	if !strings.Contains(gotBody, `"_id":"101"`) || !strings.Contains(gotBody, `"_id":"102"`) {
 		t.Fatalf("bulk body missing _id action lines: %s", gotBody)
 	}
-	// 校验文档行含中文正文（可被 mapping analyzer 分词）。
-	if !strings.Contains(gotBody, "世界") {
-		t.Fatalf("bulk body missing chinese content: %s", gotBody)
+	// 校验文档行：正文嵌套在 payload.text.content（reader 契约），messageId 为数值 long。
+	if !strings.Contains(gotBody, `"payload"`) || !strings.Contains(gotBody, "世界") {
+		t.Fatalf("bulk body missing nested payload content: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"messageId":101`) {
+		t.Fatalf("bulk body must carry numeric messageId (reader long): %s", gotBody)
 	}
 }
 
@@ -105,15 +108,15 @@ func TestBulk_AllSuccess(t *testing.T) {
 func TestBulk_MixedStatuses(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return jsonResp(200, `{"took":1,"errors":true,"items":[
-			{"index":{"_id":"ok","status":201}},
-			{"index":{"_id":"bad","status":400,"error":{"type":"mapper_parsing_exception","reason":"bad field"}}},
-			{"index":{"_id":"throttle","status":429,"error":{"type":"es_rejected","reason":"queue full"}}},
-			{"index":{"_id":"srv","status":503,"error":{"type":"unavailable","reason":"node down"}}}
+			{"index":{"_id":"201","status":201}},
+			{"index":{"_id":"400","status":400,"error":{"type":"mapper_parsing_exception","reason":"bad field"}}},
+			{"index":{"_id":"429","status":429,"error":{"type":"es_rejected","reason":"queue full"}}},
+			{"index":{"_id":"503","status":503,"error":{"type":"unavailable","reason":"node down"}}}
 		]}`), nil
 	})
 	w := newTestWriter(t, rt)
 	res, err := w.Bulk(context.Background(), []searchmsg.Message{
-		msg("ok", "a"), msg("bad", "b"), msg("throttle", "c"), msg("srv", "d"),
+		msg("201", "a"), msg("400", "b"), msg("429", "c"), msg("503", "d"),
 	})
 	if err != nil {
 		t.Fatalf("Bulk: %v", err)
@@ -138,7 +141,7 @@ func TestBulk_BatchFailure(t *testing.T) {
 		return nil, io.ErrUnexpectedEOF
 	})
 	w := newTestWriter(t, rt)
-	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("m1", "x")})
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("301", "x")})
 	if err == nil {
 		t.Fatalf("expected batch-level error")
 	}
@@ -170,11 +173,11 @@ func TestBulk_Idempotent(t *testing.T) {
 	var bodies []string
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		bodies = append(bodies, readAll(r.Body))
-		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"dup","status":201}}]}`), nil
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"555","status":201}}]}`), nil
 	})
 	w := newTestWriter(t, rt)
 	for i := 0; i < 2; i++ {
-		if _, err := w.Bulk(context.Background(), []searchmsg.Message{msg("dup", "v")}); err != nil {
+		if _, err := w.Bulk(context.Background(), []searchmsg.Message{msg("555", "v")}); err != nil {
 			t.Fatalf("Bulk #%d: %v", i, err)
 		}
 	}
@@ -184,8 +187,8 @@ func TestBulk_Idempotent(t *testing.T) {
 		if err := json.Unmarshal([]byte(first), &action); err != nil {
 			t.Fatalf("parse action line: %v", err)
 		}
-		if action.Index.ID != "dup" {
-			t.Fatalf("idempotent key must be message_id 'dup', got %q", action.Index.ID)
+		if action.Index.ID != "555" {
+			t.Fatalf("idempotent key must be normalized messageId '555', got %q", action.Index.ID)
 		}
 	}
 }
@@ -193,10 +196,10 @@ func TestBulk_Idempotent(t *testing.T) {
 // TestBulk_MissingResponseItem 响应条目数少于请求 → 缺失条标 transient，绝不静默当成功。
 func TestBulk_MissingResponseItem(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"m1","status":201}}]}`), nil
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"701","status":201}}]}`), nil
 	})
 	w := newTestWriter(t, rt)
-	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("m1", "a"), msg("m2", "b")})
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("701", "a"), msg("702", "b")})
 	if err != nil {
 		t.Fatalf("Bulk: %v", err)
 	}
@@ -268,5 +271,56 @@ func TestIndexMappingJSON_Valid(t *testing.T) {
 	}
 	if _, ok := m["mappings"]; !ok {
 		t.Fatalf("mapping JSON missing 'mappings'")
+	}
+}
+
+// TestBulk_NonNumericIDIsPermanentNoES 非数值 message_id → 该条 permanent(400)，
+// 且仍把同批可转条目正常写 ES（混批不被毒丸拖垮）。
+func TestBulk_NonNumericIDIsPermanentNoES(t *testing.T) {
+	var sentBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sentBody = readAll(r.Body)
+		// ES 只应收到 1 条（合法的 808）。
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"808","status":201}}]}`), nil
+	})
+	w := newTestWriter(t, rt)
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("oops", "x"), msg("808", "y")})
+	if err != nil {
+		t.Fatalf("Bulk: %v", err)
+	}
+	if res[0].OK || !res[0].Permanent() || res[0].Status != 400 {
+		t.Fatalf("non-numeric id must be permanent(400), got %+v", res[0])
+	}
+	if !res[1].OK {
+		t.Fatalf("valid sibling must still index, got %+v", res[1])
+	}
+	// 毒丸不得出现在发往 ES 的 NDJSON 里。
+	if strings.Contains(sentBody, "oops") {
+		t.Fatalf("non-numeric id must NOT be sent to ES: %s", sentBody)
+	}
+	if !strings.Contains(sentBody, `"_id":"808"`) {
+		t.Fatalf("valid doc must be sent with normalized _id: %s", sentBody)
+	}
+}
+
+// TestBulk_AllNonNumericNoESCall 整批都非数值 → 不发任何 ES 请求，全 permanent。
+func TestBulk_AllNonNumericNoESCall(t *testing.T) {
+	called := false
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return jsonResp(200, `{}`), nil
+	})
+	w := newTestWriter(t, rt)
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("a", "x"), msg("b", "y")})
+	if err != nil {
+		t.Fatalf("Bulk: %v", err)
+	}
+	if called {
+		t.Fatalf("no convertible docs must mean no ES call")
+	}
+	for i := range res {
+		if res[i].OK || !res[i].Permanent() {
+			t.Fatalf("all non-numeric must be permanent: %+v", res[i])
+		}
 	}
 }

--- a/internal/recon/collectors.go
+++ b/internal/recon/collectors.go
@@ -95,19 +95,19 @@ func NewOSCounter(client *opensearchapi.Client, index string) *OSCounter {
 	return &OSCounter{client: client, index: index}
 }
 
-// CountDocs 统计 created_at ∈ [from,to] 的 doc 数（range query + _count）。
+// CountDocs 统计 createdAt ∈ [from,to] 的 doc 数（range query + _count）。
 func (c *OSCounter) CountDocs(ctx context.Context, fromUnix, toUnix int64) (int64, error) {
 	return c.count(ctx, rangeQuery(fromUnix, toUnix))
 }
 
-// CountRawExcluded 统计窗内 raw_excluded=true 的 doc 数。
+// CountRawExcluded 统计窗内 rawExcluded=true 的 doc 数。
 func (c *OSCounter) CountRawExcluded(ctx context.Context, fromUnix, toUnix int64) (int64, error) {
 	body := map[string]any{
 		"query": map[string]any{
 			"bool": map[string]any{
 				"filter": []any{
 					rangeFilter(fromUnix, toUnix),
-					map[string]any{"term": map[string]any{"raw_excluded": true}},
+					map[string]any{"term": map[string]any{"rawExcluded": true}},
 				},
 			},
 		},
@@ -136,7 +136,7 @@ func (c *OSCounter) count(ctx context.Context, query map[string]any) (int64, err
 	return int64(resp.Count), nil
 }
 
-// rangeQuery 构造 created_at ∈ [from,to] 的 _count 查询体。
+// rangeQuery 构造 createdAt ∈ [from,to] 的 _count 查询体。
 func rangeQuery(fromUnix, toUnix int64) map[string]any {
 	return map[string]any{
 		"query": map[string]any{
@@ -150,7 +150,7 @@ func rangeQuery(fromUnix, toUnix int64) map[string]any {
 func rangeFilter(fromUnix, toUnix int64) map[string]any {
 	return map[string]any{
 		"range": map[string]any{
-			"created_at": map[string]any{"gte": fromUnix, "lte": toUnix},
+			"createdAt": map[string]any{"gte": fromUnix, "lte": toUnix},
 		},
 	}
 }

--- a/internal/recon/collectors_test.go
+++ b/internal/recon/collectors_test.go
@@ -66,7 +66,7 @@ func TestOSCounter_IncompleteShards(t *testing.T) {
 	}
 }
 
-// TestOSCounter_RawExcludedQuery raw_excluded 计数走 term filter，正常返回。
+// TestOSCounter_RawExcludedQuery rawExcluded 计数走 term filter，正常返回。
 func TestOSCounter_RawExcludedQuery(t *testing.T) {
 	var gotBody string
 	c := osCounter(t, rtFunc(func(r *http.Request) (*http.Response, error) {
@@ -81,7 +81,7 @@ func TestOSCounter_RawExcludedQuery(t *testing.T) {
 	if err != nil || n != 7 {
 		t.Fatalf("want 7,nil got %d,%v", n, err)
 	}
-	if !strings.Contains(gotBody, "raw_excluded") || !strings.Contains(gotBody, "created_at") {
-		t.Fatalf("raw_excluded query must filter on raw_excluded + created_at: %s", gotBody)
+	if !strings.Contains(gotBody, "rawExcluded") || !strings.Contains(gotBody, "createdAt") {
+		t.Fatalf("rawExcluded query must filter on rawExcluded + createdAt: %s", gotBody)
 	}
 }

--- a/internal/recon/report.go
+++ b/internal/recon/report.go
@@ -1,0 +1,62 @@
+// 结构化对账报告（YUJ-4682 步骤 5）：把 count 对账 + 抽样比对汇总成一个机检报告，
+// 并提供回填 octo-server `search_recon_*` 只读 gauge 的载荷（PushPayload，逐字段对齐
+// octo-server modules/messages_search/recon_metrics.go::ReconReport）。
+//
+// 失败阈值（机检口径，钉死在此 + Healthy()）：
+//   - doc_drift（= ES doc-count − MySQL 行数）!= 0       → 不健康（>0 该删没删/越权可搜；<0 漏索引/搜不到）。
+//   - sample_mismatch（抽样字段失配条数）!= 0            → 不健康（条数对得上但内容错位）。
+//   - sample_missing（抽样 MySQL 有 ES 无）!= 0          → 不健康（少 doc 的字段级佐证）。
+//   - exit code：Healthy → 0；不健康 → 2（CI / cron gate 失败信号）。
+package recon
+
+import "fmt"
+
+// FullReport 汇总 count 对账 + 抽样比对。
+type FullReport struct {
+	Window struct {
+		FromUnix int64 `json:"from_unix"`
+		ToUnix   int64 `json:"to_unix"`
+	} `json:"window"`
+	Count  Report       `json:"count"`
+	Sample SampleResult `json:"sample"`
+	// RanAtUnixSeconds 是本次对账完成时刻（回填 search_recon_last_run_timestamp_seconds）。
+	RanAtUnixSeconds int64 `json:"ran_at_unix_seconds"`
+}
+
+// Healthy 报告是否对平（count + 抽样均无 drift）。
+func (r FullReport) Healthy() bool {
+	return r.Count.OK && r.Sample.Mismatch == 0 && r.Sample.Missing == 0
+}
+
+// PushPayload 是回填 octo-server 只读 drift gauge 的载荷，**逐字段对齐**
+// octo-server modules/messages_search/recon_metrics.go::ReconReport（半兼容会让 gauge 读错）。
+type PushPayload struct {
+	ESDocCount       int64 `json:"es_doc_count"`
+	MySQLRowCount    int64 `json:"mysql_row_count"`
+	SampleMismatch   int64 `json:"sample_mismatch"`
+	RanAtUnixSeconds int64 `json:"ran_at_unix_seconds"`
+}
+
+// PushPayload 构造回填 octo-server 的载荷。SampleMismatch 计入「字段失配 + 缺 doc」两类
+// （octo-server gauge 语义 = 抽样中与源失配的 doc 数）。
+func (r FullReport) PushPayload() PushPayload {
+	return PushPayload{
+		ESDocCount:       r.Count.ESDocs,
+		MySQLRowCount:    r.Count.SourceRows,
+		SampleMismatch:   int64(r.Sample.Mismatch + r.Sample.Missing),
+		RanAtUnixSeconds: r.RanAtUnixSeconds,
+	}
+}
+
+// String 渲染人类可读摘要（cron / CI 日志用）。
+func (r FullReport) String() string {
+	status := "MISMATCH"
+	if r.Healthy() {
+		status = "OK"
+	}
+	return fmt.Sprintf(
+		"recon %s | window=[%d,%d] %s | sample(sampled=%d mismatch=%d missing=%d)",
+		status, r.Window.FromUnix, r.Window.ToUnix, r.Count.String(),
+		r.Sample.Sampled, r.Sample.Mismatch, r.Sample.Missing,
+	)
+}

--- a/internal/recon/sample.go
+++ b/internal/recon/sample.go
@@ -118,6 +118,11 @@ func compareRow(r SampleRow, doc ESDocFields) ([]MismatchDetail, bool) {
 		dets = append(dets, MismatchDetail{MessageID: r.MessageID, Field: field, MySQL: my, ES: es})
 	}
 
+	// _source.messageId 必须 == MySQL message_id 全精度（reader 从 _source 读 int64 做 cursor
+	// tiebreaker；_id 对但 _source.messageId 缺/0/被 float64 截断会静默打断 cursor）。
+	if r.MessageID != fmtInt(doc.MessageID) {
+		add("messageId", r.MessageID, fmtInt(doc.MessageID))
+	}
 	if fmtInt(r.MessageSeq) != fmtUint(doc.MessageSeq) {
 		add("messageSeq", fmtInt(r.MessageSeq), fmtUint(doc.MessageSeq))
 	}

--- a/internal/recon/sample.go
+++ b/internal/recon/sample.go
@@ -70,12 +70,32 @@ type ESDocFields struct {
 // CompareSamples 拉样本 + 对应 ES doc，逐字段比对，产出 SampleResult。
 // maxDetails<=0 时取默认 50（防失配明细把报告撑爆）。
 func CompareSamples(ctx context.Context, src SampleSourceReader, es ESDocFetcher, fromUnix, toUnix int64, limit, maxDetails int) (SampleResult, error) {
+	return CompareSamplesExcluding(ctx, src, es, fromUnix, toUnix, limit, maxDetails, nil)
+}
+
+// CompareSamplesExcluding 与 CompareSamples 相同，但额外接受一个「已知不该在 ES 正文索引里」
+// 的 message_id 集合（excluded）——典型是 backfill 落 DLQ spill 的真异常 / 永久拒绝行。这些行
+// 被抽样命中时「ES 无 doc」是**预期**（它们本就被记账为 DLQ），故不计 missing、也不计 Sampled，
+// 直接跳过：否则 inline backfill 对账门会把合法 DLQ 行误判成漏灌 false MISMATCH（count 门已用
+// DLQ 计数抵消同一批行，抽样门若再算成 missing 就口径冲突）。excluded 为 nil/空时行为与
+// CompareSamples 完全一致。
+//
+// 🔴 为不削弱抽样覆盖：源行 limit 在排除**之前**生效，若窗内前若干行恰好全是 DLQ 行，过滤后
+// 实际比对数会少于 limit（甚至为 0）——正是高 DLQ 窗最需要内容门时被掏空。故这里**过采样**：
+// 多取 len(excluded) 行（DLQ 量级极小），过滤掉排除行后再把真正比对的非排除行截断到 limit，
+// 使有效比对数稳定 ≈ limit。源抽样确定性（按 message_id 升序取前 N）保证过采样仍可复算。
+func CompareSamplesExcluding(ctx context.Context, src SampleSourceReader, es ESDocFetcher, fromUnix, toUnix int64, limit, maxDetails int, excluded map[string]bool) (SampleResult, error) {
 	if maxDetails <= 0 {
 		maxDetails = 50
 	}
 	res := SampleResult{maxDetails: maxDetails}
+	if limit <= 0 {
+		return res, nil
+	}
 
-	rows, err := src.SampleRows(ctx, fromUnix, toUnix, limit)
+	// 过采样补偿排除行，使过滤后有效比对数 ≈ limit。
+	effLimit := limit + len(excluded)
+	rows, err := src.SampleRows(ctx, fromUnix, toUnix, effLimit)
 	if err != nil {
 		return res, fmt.Errorf("recon: sample source rows: %w", err)
 	}
@@ -83,18 +103,40 @@ func CompareSamples(ctx context.Context, src SampleSourceReader, es ESDocFetcher
 		return res, nil
 	}
 
-	ids := make([]string, 0, len(rows))
+	// 取前 limit 个**可比对**行作为本次比对集（截断到 limit，确定性可复算）。
+	cmp := make([]SampleRow, 0, limit)
 	for i := range rows {
-		ids = append(ids, rows[i].MessageID)
+		id := rows[i].MessageID
+		// 空 message_id 行不可与 ES doc（_id=message_id）对齐——既无法查 doc、也无法进 DLQ
+		// 排除集（去重键退化为 table:id）。这类行（源 schema 上 message_id NOT NULL，理论不该出现）
+		// 既不计 Sampled 也不计 Missing：硬当 missing 会让合法 backfill run false-fail（codex R2）。
+		if id == "" {
+			continue
+		}
+		if excluded[id] {
+			continue // 已知 DLQ 行：本就不该有 doc，不纳入比对
+		}
+		cmp = append(cmp, rows[i])
+		if len(cmp) >= limit {
+			break
+		}
+	}
+	if len(cmp) == 0 {
+		return res, nil
+	}
+
+	ids := make([]string, 0, len(cmp))
+	for i := range cmp {
+		ids = append(ids, cmp[i].MessageID)
 	}
 	docs, err := es.FetchDocs(ctx, ids)
 	if err != nil {
 		return res, fmt.Errorf("recon: fetch ES sample docs: %w", err)
 	}
 
-	for i := range rows {
+	for i := range cmp {
+		r := cmp[i]
 		res.Sampled++
-		r := rows[i]
 		doc, ok := docs[r.MessageID]
 		if !ok {
 			res.Missing++
@@ -218,9 +260,12 @@ func (s *MySQLSampleReader) SampleRows(ctx context.Context, fromUnix, toUnix int
 	return all, nil
 }
 
-func scanSampleRows(rows *sql.Rows) ([]SampleRow, error) {
-	defer func() { _ = rows.Close() }()
-	var out []SampleRow
+func scanSampleRows(rows *sql.Rows) (out []SampleRow, err error) {
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("recon: close sample rows: %w", cerr)
+		}
+	}()
 	for rows.Next() {
 		var (
 			r       SampleRow

--- a/internal/recon/sample.go
+++ b/internal/recon/sample.go
@@ -291,17 +291,39 @@ func scanSampleRows(rows *sql.Rows) (out []SampleRow, err error) {
 // signalSettingMask 是 setting 字节里 Signal 加密位（bit5），与 backfill/extract 同口径。
 const signalSettingMask = 1 << 5
 
-// parsePayloadVisibility 解出 payload.space_id / payload.visibles（与 backfill extractVisibility 同口径）。
+// parsePayloadVisibility 解出 payload.space_id / payload.visibles（reader 契约的权威可见性值）。
+//
+// 🔴 验证门独立实现，**不复用** backfill.extractVisibility（写入路径解析器）。这是设计要点：
+// 若验证门与写入路径共用同一个解析器，写入路径的解析 bug（如非字符串 space_id 把整条 payload
+// 解坏 → visibles 被清空）会让两侧**同时**产出空 visibles → 抽样比对「相等」→ 门对该 bug 全盲。
+// 本函数独立、类型容忍地解析可见性：space_id 仅当 JSON 字符串时取值（其余类型留空，与 reader p2p
+// fail-closed 一致），visibles 字段级容忍——**绝不**让 space_id 的怪异 JSON 类型连累 visibles 被
+// 清空。故一旦写入路径错误地丢了某行合法 visibles，本门从 MySQL 取出的权威 visibles 与 ES doc 的
+// 空 visibles 失配 → sample_mismatch>0 → 门转红，bug 无所遁形。
 func parsePayloadVisibility(payload []byte) (spaceID string, visibles []string) {
-	var v struct {
-		SpaceID  string            `json:"space_id"`
-		Visibles []json.RawMessage `json:"visibles"`
-	}
-	if err := json.Unmarshal(payload, &v); err != nil {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &top); err != nil {
+		// 顶层非 JSON 对象（损坏/截断）：MySQL 侧也取不出可见性。写入路径对这类行 fail-closed 落
+		// DLQ（被 excluded 集排除，不进比对），故这里返回空不会误判合法行。
 		return "", nil
 	}
-	spaceID = v.SpaceID
-	for _, raw := range v.Visibles {
+	// space_id：容忍类型——仅 JSON 字符串取值，非字符串（数字/对象/null）留空，且**不**连累 visibles。
+	if raw, ok := top["space_id"]; ok {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			spaceID = s
+		}
+	}
+	// visibles：必须是 JSON 数组才逐元素取字符串；其余类型留空（写入路径对此 fail-closed 落 DLQ）。
+	rawVis, ok := top["visibles"]
+	if !ok || string(rawVis) == "null" {
+		return spaceID, nil
+	}
+	var elems []json.RawMessage
+	if err := json.Unmarshal(rawVis, &elems); err != nil {
+		return spaceID, nil
+	}
+	for _, raw := range elems {
 		var s string
 		if err := json.Unmarshal(raw, &s); err != nil {
 			continue

--- a/internal/recon/sample.go
+++ b/internal/recon/sample.go
@@ -1,0 +1,312 @@
+// 抽样字段比对（YUJ-4682 步骤 5）：count 对账只证「条数」一致，不证「内容」一致。
+// 本文件加一层抽样比对：从 MySQL 取一批样本行，按 message_id 拉对应 ES doc，逐字段核对
+// reader 契约里鉴权/正确性关键字段（messageId/channelId/channelType/spaceId/visibles/messageSeq），
+// 检出「条数对得上但字段错位」的静默 drift。失配数回填 search_recon_sample_mismatch gauge。
+package recon
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// SampleRow 是抽样比对所需的 MySQL 源字段（reader 契约关键字段的权威值）。
+type SampleRow struct {
+	MessageID   string
+	MessageSeq  int64
+	ChannelID   string
+	ChannelType int
+	SpaceID     string   // 从 payload.space_id 解出（非加密文本消息）
+	Visibles    []string // 从 payload.visibles 解出
+	Signal      bool     // 加密消息：payload 不解析，spaceId/visibles 不参与比对
+}
+
+// MismatchDetail 描述一条抽样失配（哪个 message_id 的哪个字段对不上）。
+type MismatchDetail struct {
+	MessageID string `json:"message_id"`
+	Field     string `json:"field"`
+	MySQL     string `json:"mysql"`
+	ES        string `json:"es"`
+}
+
+// SampleResult 是一次抽样比对的结论。
+type SampleResult struct {
+	Sampled    int              `json:"sampled"`  // 实际比对的样本数
+	Missing    int              `json:"missing"`  // MySQL 有但 ES 查不到 doc 的样本数（少 doc 的字段级证据）
+	Mismatch   int              `json:"mismatch"` // 字段失配的样本数（去重到「条」，一条多字段失配只计 1）
+	Details    []MismatchDetail `json:"details"`  // 失配明细（capped）
+	maxDetails int
+}
+
+// SampleSourceReader 取一批抽样源行（按 message_id 升序的确定性抽样，便于复算）。
+type SampleSourceReader interface {
+	// SampleRows 从时间窗内按 message_id 升序取至多 limit 行（确定性，非随机：可复算 + 稳定阈值）。
+	SampleRows(ctx context.Context, fromUnix, toUnix int64, limit int) ([]SampleRow, error)
+}
+
+// ESDocFetcher 按 message_id 批量拉 ES doc（reader 契约形态的子集）。
+type ESDocFetcher interface {
+	// FetchDocs 按 message_id（= _id）批量取 doc，返回 message_id→docFields（缺失即不在 map）。
+	FetchDocs(ctx context.Context, messageIDs []string) (map[string]ESDocFields, error)
+}
+
+// ESDocFields 是从 ES doc _source 投影出的 reader 契约关键字段（用 reader 字段名反序列化，
+// 确保字段名/类型逐字段对齐——字段名写错会直接导致这里读不到值而判失配）。
+type ESDocFields struct {
+	MessageID   int64    `json:"messageId"`
+	MessageSeq  uint64   `json:"messageSeq"`
+	ChannelID   string   `json:"channelId"`
+	ChannelType uint32   `json:"channelType"`
+	SpaceID     string   `json:"spaceId"`
+	Visibles    []string `json:"visibles"`
+	RawExcluded bool     `json:"rawExcluded"`
+}
+
+// CompareSamples 拉样本 + 对应 ES doc，逐字段比对，产出 SampleResult。
+// maxDetails<=0 时取默认 50（防失配明细把报告撑爆）。
+func CompareSamples(ctx context.Context, src SampleSourceReader, es ESDocFetcher, fromUnix, toUnix int64, limit, maxDetails int) (SampleResult, error) {
+	if maxDetails <= 0 {
+		maxDetails = 50
+	}
+	res := SampleResult{maxDetails: maxDetails}
+
+	rows, err := src.SampleRows(ctx, fromUnix, toUnix, limit)
+	if err != nil {
+		return res, fmt.Errorf("recon: sample source rows: %w", err)
+	}
+	if len(rows) == 0 {
+		return res, nil
+	}
+
+	ids := make([]string, 0, len(rows))
+	for i := range rows {
+		ids = append(ids, rows[i].MessageID)
+	}
+	docs, err := es.FetchDocs(ctx, ids)
+	if err != nil {
+		return res, fmt.Errorf("recon: fetch ES sample docs: %w", err)
+	}
+
+	for i := range rows {
+		res.Sampled++
+		r := rows[i]
+		doc, ok := docs[r.MessageID]
+		if !ok {
+			res.Missing++
+			res.addDetail(MismatchDetail{MessageID: r.MessageID, Field: "_doc", MySQL: "present", ES: "missing"})
+			continue
+		}
+		if d, mismatched := compareRow(r, doc); mismatched {
+			res.Mismatch++
+			for _, det := range d {
+				res.addDetail(det)
+			}
+		}
+	}
+	return res, nil
+}
+
+// compareRow 比对单条样本的关键字段；返回失配明细 + 是否有任一字段失配。
+func compareRow(r SampleRow, doc ESDocFields) ([]MismatchDetail, bool) {
+	var dets []MismatchDetail
+	add := func(field, my, es string) {
+		dets = append(dets, MismatchDetail{MessageID: r.MessageID, Field: field, MySQL: my, ES: es})
+	}
+
+	if fmtInt(r.MessageSeq) != fmtUint(doc.MessageSeq) {
+		add("messageSeq", fmtInt(r.MessageSeq), fmtUint(doc.MessageSeq))
+	}
+	if r.ChannelID != doc.ChannelID {
+		add("channelId", r.ChannelID, doc.ChannelID)
+	}
+	if int64(r.ChannelType) != int64(doc.ChannelType) {
+		add("channelType", fmtInt(int64(r.ChannelType)), fmtUint(uint64(doc.ChannelType)))
+	}
+	// spaceId / visibles 仅对非加密消息比对（加密消息 payload 不解析，两侧均应留空）。
+	if !r.Signal {
+		if r.SpaceID != doc.SpaceID {
+			add("spaceId", r.SpaceID, doc.SpaceID)
+		}
+		if !sameStringSet(r.Visibles, doc.Visibles) {
+			add("visibles", fmt.Sprint(sortedCopy(r.Visibles)), fmt.Sprint(sortedCopy(doc.Visibles)))
+		}
+	}
+	return dets, len(dets) > 0
+}
+
+func (s *SampleResult) addDetail(d MismatchDetail) {
+	if len(s.Details) < s.maxDetails {
+		s.Details = append(s.Details, d)
+	}
+}
+
+func fmtInt(v int64) string   { return fmt.Sprintf("%d", v) }
+func fmtUint(v uint64) string { return fmt.Sprintf("%d", v) }
+
+// sameStringSet 比较两个字符串集合是否相等（顺序无关，reader visibles 是集合语义）。
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as, bs := sortedCopy(a), sortedCopy(b)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+// ── MySQL / ES 实现 ─────────────────────────────────────────────────────────────
+
+// MySQLSampleReader 从 message 分表确定性抽样（按 message_id 升序），并就地解 payload 的
+// space_id/visibles（与 backfill docFromRow 同口径）。
+type MySQLSampleReader struct {
+	db     *sql.DB
+	tables []string
+}
+
+// NewMySQLSampleReader 构造。
+func NewMySQLSampleReader(db *sql.DB, tables []string) *MySQLSampleReader {
+	return &MySQLSampleReader{db: db, tables: tables}
+}
+
+// SampleRows 跨分表各取窗内按 message_id 升序的前若干行，合并后再截断到 limit（确定性）。
+func (s *MySQLSampleReader) SampleRows(ctx context.Context, fromUnix, toUnix int64, limit int) ([]SampleRow, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var all []SampleRow
+	for _, t := range s.tables {
+		if !safeTableName(t) {
+			return nil, fmt.Errorf("recon: unsafe table name %q", t)
+		}
+		q := fmt.Sprintf(
+			"SELECT message_id, message_seq, channel_id, channel_type, setting, `signal`, payload "+
+				"FROM `%s` WHERE UNIX_TIMESTAMP(created_at) BETWEEN ? AND ? ORDER BY message_id ASC LIMIT ?", t)
+		rows, err := s.db.QueryContext(ctx, q, fromUnix, toUnix, limit)
+		if err != nil {
+			return nil, fmt.Errorf("recon: sample query %s: %w", t, err)
+		}
+		batch, err := scanSampleRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+	}
+	// 跨分表合并后按 message_id 升序，截断到 limit（确定性，可复算）。
+	sort.Slice(all, func(i, j int) bool { return all[i].MessageID < all[j].MessageID })
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all, nil
+}
+
+func scanSampleRows(rows *sql.Rows) ([]SampleRow, error) {
+	defer func() { _ = rows.Close() }()
+	var out []SampleRow
+	for rows.Next() {
+		var (
+			r       SampleRow
+			setting uint8
+			signal  int
+			payload []byte
+		)
+		if err := rows.Scan(&r.MessageID, &r.MessageSeq, &r.ChannelID, &r.ChannelType, &setting, &signal, &payload); err != nil {
+			return nil, fmt.Errorf("recon: scan sample row: %w", err)
+		}
+		r.Signal = signal != 0 || setting&signalSettingMask != 0
+		if !r.Signal {
+			r.SpaceID, r.Visibles = parsePayloadVisibility(payload)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("recon: iterate sample rows: %w", err)
+	}
+	return out, nil
+}
+
+// signalSettingMask 是 setting 字节里 Signal 加密位（bit5），与 backfill/extract 同口径。
+const signalSettingMask = 1 << 5
+
+// parsePayloadVisibility 解出 payload.space_id / payload.visibles（与 backfill extractVisibility 同口径）。
+func parsePayloadVisibility(payload []byte) (spaceID string, visibles []string) {
+	var v struct {
+		SpaceID  string            `json:"space_id"`
+		Visibles []json.RawMessage `json:"visibles"`
+	}
+	if err := json.Unmarshal(payload, &v); err != nil {
+		return "", nil
+	}
+	spaceID = v.SpaceID
+	for _, raw := range v.Visibles {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			continue
+		}
+		if s != "" {
+			visibles = append(visibles, s)
+		}
+	}
+	return spaceID, visibles
+}
+
+// OSDocFetcher 用 _search terms(_id) 批量拉 doc（reader 契约字段投影）。
+type OSDocFetcher struct {
+	client *opensearchapi.Client
+	index  string
+}
+
+// NewOSDocFetcher 构造。
+func NewOSDocFetcher(client *opensearchapi.Client, index string) *OSDocFetcher {
+	return &OSDocFetcher{client: client, index: index}
+}
+
+// FetchDocs 用 terms(_id) 一次查回样本 doc（size = len(ids)）。
+func (f *OSDocFetcher) FetchDocs(ctx context.Context, messageIDs []string) (map[string]ESDocFields, error) {
+	out := make(map[string]ESDocFields, len(messageIDs))
+	if len(messageIDs) == 0 {
+		return out, nil
+	}
+	body := map[string]any{
+		"size": len(messageIDs),
+		"query": map[string]any{
+			"ids": map[string]any{"values": messageIDs},
+		},
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("recon: marshal sample search: %w", err)
+	}
+	resp, err := f.client.Search(ctx, &opensearchapi.SearchReq{
+		Indices: []string{f.index},
+		Body:    bytes.NewReader(b),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recon: ES sample search: %w", err)
+	}
+	if resp.Shards.Failed != 0 || resp.Shards.Successful != resp.Shards.Total {
+		return nil, fmt.Errorf("recon: ES sample search incomplete shards (total=%d successful=%d failed=%d)",
+			resp.Shards.Total, resp.Shards.Successful, resp.Shards.Failed)
+	}
+	for i := range resp.Hits.Hits {
+		var fields ESDocFields
+		if err := json.Unmarshal(resp.Hits.Hits[i].Source, &fields); err != nil {
+			return nil, fmt.Errorf("recon: decode sample doc _id=%s: %w", resp.Hits.Hits[i].ID, err)
+		}
+		out[resp.Hits.Hits[i].ID] = fields
+	}
+	return out, nil
+}

--- a/internal/recon/sample_test.go
+++ b/internal/recon/sample_test.go
@@ -56,6 +56,85 @@ func TestCompareSamples_MissingDoc(t *testing.T) {
 	}
 }
 
+// TestCompareSamplesExcluding_DLQRowNotMissing 已知 DLQ 行（本就不该在 ES）被抽样命中时
+// 不计 missing、不计 Sampled——避免 inline backfill 对账门把合法 DLQ 行误判成漏灌 false MISMATCH。
+func TestCompareSamplesExcluding_DLQRowNotMissing(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "10", ChannelID: "g1", ChannelType: 2},  // 正常：ES 有 doc
+		{MessageID: "99", ChannelID: "gx", ChannelType: 2},  // DLQ 真异常：ES 无 doc，预期排除
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"10": {MessageID: 10, ChannelID: "g1", ChannelType: 2},
+	}}
+	excluded := map[string]bool{"99": true}
+	res, err := CompareSamplesExcluding(context.Background(), src, es, 0, 100, 100, 50, excluded)
+	if err != nil {
+		t.Fatalf("CompareSamplesExcluding: %v", err)
+	}
+	if res.Sampled != 1 || res.Missing != 0 || res.Mismatch != 0 {
+		t.Fatalf("excluded DLQ row must be skipped (not missing, not sampled): %+v", res)
+	}
+}
+
+// TestCompareSamplesExcluding_NilSameAsCompare excluded 为 nil 时行为与 CompareSamples 完全一致
+// （DLQ 行仍按 missing 计——无排除集时该行确实是漏灌证据）。
+func TestCompareSamplesExcluding_NilSameAsCompare(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{{MessageID: "11", ChannelID: "g", ChannelType: 1}}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{}}
+	res, err := CompareSamplesExcluding(context.Background(), src, es, 0, 100, 100, 50, nil)
+	if err != nil {
+		t.Fatalf("CompareSamplesExcluding: %v", err)
+	}
+	if res.Missing != 1 || res.Sampled != 1 {
+		t.Fatalf("nil excluded must match CompareSamples semantics: %+v", res)
+	}
+}
+
+// TestCompareSamplesExcluding_SkipsEmptyMessageID 空 message_id 源行不可与 ES doc(_id) 对齐，
+// 也进不了 DLQ 排除集（去重键退化为 table:id），故既不计 Sampled 也不计 Missing——避免合法
+// backfill run 被这类行 false-fail（codex R2）。
+func TestCompareSamplesExcluding_SkipsEmptyMessageID(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "", ChannelID: "g", ChannelType: 2},   // 空 id：不可比对，跳过
+		{MessageID: "10", ChannelID: "g", ChannelType: 2}, // 正常
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"10": {MessageID: 10, ChannelID: "g", ChannelType: 2},
+	}}
+	res, err := CompareSamplesExcluding(context.Background(), src, es, 0, 100, 100, 50, nil)
+	if err != nil {
+		t.Fatalf("CompareSamplesExcluding: %v", err)
+	}
+	if res.Sampled != 1 || res.Missing != 0 || res.Mismatch != 0 {
+		t.Fatalf("empty message_id row must be skipped (not missing): %+v", res)
+	}
+}
+
+// TestCompareSamplesExcluding_OversamplesForCoverage 当窗内前若干行恰好全是 DLQ 行时，过采样
+// 应补回足额非排除行，使有效比对数稳定 ≈ limit（codex P2：不削弱高 DLQ 窗的内容门覆盖）。
+func TestCompareSamplesExcluding_OversamplesForCoverage(t *testing.T) {
+	// limit=2；前 2 行（升序 message_id）是 DLQ 行，后 2 行是正常行。
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "10", ChannelID: "g", ChannelType: 2}, // DLQ
+		{MessageID: "20", ChannelID: "g", ChannelType: 2}, // DLQ
+		{MessageID: "30", ChannelID: "g", ChannelType: 2}, // 正常
+		{MessageID: "40", ChannelID: "g", ChannelType: 2}, // 正常
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"30": {MessageID: 30, ChannelID: "g", ChannelType: 2},
+		"40": {MessageID: 40, ChannelID: "g", ChannelType: 2},
+	}}
+	excluded := map[string]bool{"10": true, "20": true}
+	res, err := CompareSamplesExcluding(context.Background(), src, es, 0, 100, 2, 50, excluded)
+	if err != nil {
+		t.Fatalf("CompareSamplesExcluding: %v", err)
+	}
+	// 过采样补偿后应比对到 2 个正常行（30,40），0 missing 0 mismatch——而非被前两行掏空成 0。
+	if res.Sampled != 2 || res.Missing != 0 || res.Mismatch != 0 {
+		t.Fatalf("oversampling must preserve coverage (want sampled=2 clean): %+v", res)
+	}
+}
+
 // TestCompareSamples_SpaceIDVisiblesMismatch spaceId / visibles 字段错位 → mismatch（V1b/V3b 的对账闸）。
 func TestCompareSamples_SpaceIDVisiblesMismatch(t *testing.T) {
 	src := &fakeSampleSrc{rows: []SampleRow{

--- a/internal/recon/sample_test.go
+++ b/internal/recon/sample_test.go
@@ -120,3 +120,31 @@ func TestFullReport_UnhealthyOnSampleMismatch(t *testing.T) {
 		t.Fatalf("push payload must surface sample mismatch")
 	}
 }
+
+// TestCompareSamples_MessageIDPrecisionDrift _id 对但 _source.messageId 被截断/置 0 →
+// mismatch（reader 用 _source.messageId 做 cursor tiebreaker，必须全精度对齐）。
+func TestCompareSamples_MessageIDPrecisionDrift(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "9223372036854775807", ChannelID: "g", ChannelType: 2},
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		// _id 命中（FetchDocs 按 _id 返回），但 _source.messageId 为 0（缺/截断）。
+		"9223372036854775807": {MessageID: 0, ChannelID: "g", ChannelType: 2},
+	}}
+	res, err := CompareSamples(context.Background(), src, es, 0, 100, 100, 50)
+	if err != nil {
+		t.Fatalf("CompareSamples: %v", err)
+	}
+	if res.Mismatch != 1 {
+		t.Fatalf("messageId _source drift must be a mismatch: %+v", res)
+	}
+	var sawField bool
+	for _, d := range res.Details {
+		if d.Field == "messageId" {
+			sawField = true
+		}
+	}
+	if !sawField {
+		t.Fatalf("mismatch detail must name messageId: %+v", res.Details)
+	}
+}

--- a/internal/recon/sample_test.go
+++ b/internal/recon/sample_test.go
@@ -1,0 +1,122 @@
+package recon
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeSampleSrc struct{ rows []SampleRow }
+
+func (f *fakeSampleSrc) SampleRows(_ context.Context, _, _ int64, limit int) ([]SampleRow, error) {
+	if limit < len(f.rows) {
+		return f.rows[:limit], nil
+	}
+	return f.rows, nil
+}
+
+type fakeESFetch struct{ docs map[string]ESDocFields }
+
+func (f *fakeESFetch) FetchDocs(_ context.Context, ids []string) (map[string]ESDocFields, error) {
+	out := map[string]ESDocFields{}
+	for _, id := range ids {
+		if d, ok := f.docs[id]; ok {
+			out[id] = d
+		}
+	}
+	return out, nil
+}
+
+// TestCompareSamples_AllMatch 全部字段一致 → 0 失配 0 缺失。
+func TestCompareSamples_AllMatch(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "10", MessageSeq: 5, ChannelID: "g1", ChannelType: 2, SpaceID: "sA", Visibles: []string{"a", "b"}},
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"10": {MessageID: 10, MessageSeq: 5, ChannelID: "g1", ChannelType: 2, SpaceID: "sA", Visibles: []string{"b", "a"}},
+	}}
+	res, err := CompareSamples(context.Background(), src, es, 0, 100, 100, 50)
+	if err != nil {
+		t.Fatalf("CompareSamples: %v", err)
+	}
+	if res.Sampled != 1 || res.Mismatch != 0 || res.Missing != 0 {
+		t.Fatalf("want clean match: %+v", res)
+	}
+}
+
+// TestCompareSamples_MissingDoc MySQL 有 ES 无 → missing 计数（少 doc 的字段级证据）。
+func TestCompareSamples_MissingDoc(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{{MessageID: "11", ChannelID: "g", ChannelType: 1}}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{}}
+	res, err := CompareSamples(context.Background(), src, es, 0, 100, 100, 50)
+	if err != nil {
+		t.Fatalf("CompareSamples: %v", err)
+	}
+	if res.Missing != 1 || res.Mismatch != 0 {
+		t.Fatalf("missing doc must be counted: %+v", res)
+	}
+}
+
+// TestCompareSamples_SpaceIDVisiblesMismatch spaceId / visibles 字段错位 → mismatch（V1b/V3b 的对账闸）。
+func TestCompareSamples_SpaceIDVisiblesMismatch(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "12", ChannelID: "g", ChannelType: 1, SpaceID: "sA", Visibles: []string{"admin"}},
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"12": {MessageID: 12, ChannelID: "g", ChannelType: 1, SpaceID: "", Visibles: nil},
+	}}
+	res, err := CompareSamples(context.Background(), src, es, 0, 100, 100, 50)
+	if err != nil {
+		t.Fatalf("CompareSamples: %v", err)
+	}
+	if res.Mismatch != 1 {
+		t.Fatalf("spaceId/visibles drift must be a mismatch: %+v", res)
+	}
+	// 一条多字段失配只计 1 条 mismatch，但 details 含每个字段。
+	if len(res.Details) < 2 {
+		t.Fatalf("details must list both spaceId and visibles: %+v", res.Details)
+	}
+}
+
+// TestCompareSamples_SignalSkipsVisibility 加密消息不比对 spaceId/visibles（两侧均空，预期）。
+func TestCompareSamples_SignalSkipsVisibility(t *testing.T) {
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "13", ChannelID: "g", ChannelType: 1, Signal: true},
+	}}
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"13": {MessageID: 13, ChannelID: "g", ChannelType: 1},
+	}}
+	res, err := CompareSamples(context.Background(), src, es, 0, 100, 100, 50)
+	if err != nil {
+		t.Fatalf("CompareSamples: %v", err)
+	}
+	if res.Mismatch != 0 {
+		t.Fatalf("encrypted msg must not mismatch on absent visibility: %+v", res)
+	}
+}
+
+// TestFullReport_HealthyAndPayload 对平时 Healthy + 退出码语义；push 载荷逐字段对齐 octo-server。
+func TestFullReport_HealthyAndPayload(t *testing.T) {
+	var fr FullReport
+	fr.Count = Reconcile(Counts{SourceRows: 100, ESDocs: 100, DLQ: 0})
+	fr.RanAtUnixSeconds = 1700000000
+	if !fr.Healthy() {
+		t.Fatalf("count-OK + no sample drift must be healthy")
+	}
+	p := fr.PushPayload()
+	if p.ESDocCount != 100 || p.MySQLRowCount != 100 || p.SampleMismatch != 0 || p.RanAtUnixSeconds != 1700000000 {
+		t.Fatalf("push payload mismatch: %+v", p)
+	}
+}
+
+// TestFullReport_UnhealthyOnSampleMismatch count 对平但抽样失配 → 整体不健康（内容 drift）。
+func TestFullReport_UnhealthyOnSampleMismatch(t *testing.T) {
+	var fr FullReport
+	fr.Count = Reconcile(Counts{SourceRows: 100, ESDocs: 100})
+	fr.Sample = SampleResult{Sampled: 10, Mismatch: 1}
+	if fr.Healthy() {
+		t.Fatalf("sample mismatch must make report unhealthy even when counts tie")
+	}
+	if fr.PushPayload().SampleMismatch != 1 {
+		t.Fatalf("push payload must surface sample mismatch")
+	}
+}

--- a/internal/recon/sample_test.go
+++ b/internal/recon/sample_test.go
@@ -227,3 +227,43 @@ func TestCompareSamples_MessageIDPrecisionDrift(t *testing.T) {
 		t.Fatalf("mismatch detail must name messageId: %+v", res.Details)
 	}
 }
+
+// TestParsePayloadVisibility_NotBlindToNonStringSpaceID 🔴 验证门不盲于写入路径 V3b bug 的核心断言。
+//
+// 写入路径的 bug：非字符串 space_id 把整条 payload 解坏 → 合法 visibles 被清空（fail-OPEN）。
+// 若验证门用同样的 strict-struct 解析器，它从 MySQL 取出的 visibles 也会被同一 bug 清空 → 两侧
+// 同为空 → 抽样比对「相等」→ 门对该 bug **全盲**。本测试钉死：recon 门独立的 parsePayloadVisibility
+// 在 space_id 为非字符串时**仍能正确取出合法 visibles**（不被连累），因此一旦写入路径错误地丢了
+// 该行 visibles，门取出的权威 visibles 与 ES 的空 visibles 就会失配 → 门转红。
+func TestParsePayloadVisibility_NotBlindToNonStringSpaceID(t *testing.T) {
+	// space_id 是数字、visibles 合法——正是触发写入路径 fail-OPEN 的 payload。
+	payload := []byte(`{"space_id":99999,"visibles":["admin1","admin2"]}`)
+	sid, vis := parsePayloadVisibility(payload)
+	if sid != "" {
+		t.Fatalf("non-string space_id must degrade to empty (not blind, but no false value): %q", sid)
+	}
+	if len(vis) != 2 || vis[0] != "admin1" || vis[1] != "admin2" {
+		t.Fatalf("recon gate must still recover legitimate visibles (else gate is blind to V3b): %+v", vis)
+	}
+}
+
+// TestCompareSamples_CatchesWritePathVisiblesDrop 端到端：模拟写入路径因非字符串 space_id 丢了
+// 合法 visibles（ES doc visibles 为空），而 MySQL 源行 visibles 合法。门必须判 mismatch（非全盲）。
+func TestCompareSamples_CatchesWritePathVisiblesDrop(t *testing.T) {
+	// 源行的 SpaceID/Visibles 由 parsePayloadVisibility 从 payload 解出（这里直接构造其等价结果）：
+	// 非字符串 space_id → SpaceID 空，但 visibles 合法保留。
+	src := &fakeSampleSrc{rows: []SampleRow{
+		{MessageID: "21", ChannelID: "g", ChannelType: 1, SpaceID: "", Visibles: []string{"admin1", "admin2"}},
+	}}
+	// ES doc 是被 bug 写坏的形态：visibles 被清空（fail-OPEN）。
+	es := &fakeESFetch{docs: map[string]ESDocFields{
+		"21": {MessageID: 21, ChannelID: "g", ChannelType: 1, SpaceID: "", Visibles: nil},
+	}}
+	res, err := CompareSamples(context.Background(), src, es, 0, 100, 100, 50)
+	if err != nil {
+		t.Fatalf("CompareSamples: %v", err)
+	}
+	if res.Mismatch != 1 {
+		t.Fatalf("dropped visibles (fail-OPEN) must be caught as mismatch, gate not blind: %+v", res)
+	}
+}

--- a/scripts/forward-migrate.sh
+++ b/scripts/forward-migrate.sh
@@ -82,13 +82,16 @@ case "${STEP:-all}" in
   *) echo "unknown STEP=${STEP}" >&2; exit 2 ;;
 esac
 
-cat <<'ROLLBACK'
+# ROLLBACK 指引（alias 秒切回旧索引）。用展开式 heredoc（<<ROLLBACK，非单引号）让
+# $ES/$NEW_INDEX/$ALIAS/$OLD_INDEX 展开成**可直接复制执行**的命令，而不是字面量占位符。
+# JSON body 单独用单引号包住（避免外层展开破坏 JSON），index/alias 名以双引号拼接展开。
+cat <<ROLLBACK
 
-ROLLBACK（alias 秒切回旧索引）：
+ROLLBACK（alias 秒切回旧索引；下面命令已展开当前 ES/索引/alias，可直接复制执行）：
   curl -sS -XPOST "$ES/_aliases" -H 'Content-Type: application/json' -d '{
     "actions":[
-      {"remove":{"index":"'"$NEW_INDEX"'","alias":"'"$ALIAS"'"}},
-      {"add":{"index":"'"$OLD_INDEX"'","alias":"'"$ALIAS"'"}}
+      {"remove":{"index":"$NEW_INDEX","alias":"$ALIAS"}},
+      {"add":{"index":"$OLD_INDEX","alias":"$ALIAS"}}
     ]}'
-  旧索引保留 ≥7 天后再删：curl -XDELETE "$ES/$OLD_INDEX"
+  旧索引保留 ≥7 天后再删：curl -sS -XDELETE "$ES/$OLD_INDEX"
 ROLLBACK

--- a/scripts/forward-migrate.sh
+++ b/scripts/forward-migrate.sh
@@ -20,20 +20,25 @@ CURL=(curl -sS -H 'Content-Type: application/json')
 
 log(){ printf '\n=== %s ===\n' "$*"; }
 
-# 注意：脚本内嵌的 mapping JSON 含 aliases.wukongim-messages-read，会让新索引建好即挂 read alias。
-# 为保证「reindex 完成前不切 alias」，建新索引时**剥离 aliases 段**，alias 在步骤③单独原子挂。
+# mapping 文件本身**不再内嵌** read alias（v1.9 R2：裸 PUT 默认安全——EnsureIndex / 本脚本建索引
+# 时不会让新索引一建好就挂上 read alias，避免 reindex 完成前就被 reader 读到半量数据）。alias 只在
+# 步骤③ reindex + 抽样对账通过后单独原子挂。这里仍 del(.aliases) 兜底：若有人把 alias 加回 mapping，
+# 此处仍剥离，保证「建索引 ≠ 上线」的纪律不被 mapping 改动悄悄破坏。
 new_index_body(){
-  # 用 jq 去掉 aliases 段（若无 jq，则要求 MAPPING_NOALIAS_FILE 预先准备）。
+  # 用 jq 去掉 aliases 段（mapping 现已无该段，del 为幂等 no-op；保留以防 mapping 回退加回 alias）。
   if command -v jq >/dev/null 2>&1; then
     jq 'del(.aliases)' "$MAPPING_FILE"
-  else
-    echo "ERROR: jq required to strip aliases for staged migration (or set MAPPING_NOALIAS_FILE)" >&2
+  elif grep -q '"aliases"' "$MAPPING_FILE"; then
+    echo "ERROR: mapping embeds an aliases section but jq is unavailable to strip it for staged migration (set MAPPING_NOALIAS_FILE)" >&2
     exit 3
+  else
+    # mapping 无 aliases 段（当前状态）：无 jq 也安全，裸 PUT 不会提前挂 alias。
+    cat "$MAPPING_FILE"
   fi
 }
 
 step1_create_new(){
-  log "① 创建新契约索引 $NEW_INDEX (mapping v1.9，剥离 aliases 段)"
+  log "① 创建新契约索引 $NEW_INDEX (mapping v1.9，无内嵌 alias / 兜底剥离 aliases 段)"
   new_index_body | "${CURL[@]}" -XPUT "$ES/$NEW_INDEX" -d @- | tee /dev/stderr | grep -q '"acknowledged":true'
 }
 
@@ -56,11 +61,16 @@ JSON
 }
 
 step3_switch_alias(){
-  log "③ 原子切换 read alias $ALIAS → $NEW_INDEX（移除旧索引上的同名 alias）"
+  log "③ 原子切换 read alias $ALIAS → $NEW_INDEX（从所有索引摘掉同名 alias 再挂新索引，幂等且单指向）"
+  # 🔴 单指向不变式：read alias **任何时刻只能指向一个索引**（禁半新半旧同 alias 服务）。故 remove
+  # 用 index="*"（摘掉 alias 当前挂着的**任意**索引，不只是 OLD_INDEX）—— 若只 remove OLD_INDEX，
+  # 而 alias 当前其实挂在别的索引上（OLD_INDEX 名传错 / 历史迁移残留），remove 会 no-op，add 后 alias
+  # 就同时指向那个旧索引 + NEW_INDEX（reader 读到半量数据）。配 must_exist:false：首次迁移 alias 尚
+  # 不存在时 remove 不报错。整个 _aliases 调用是**原子**的（remove+add 同事务），无中间真空态。
   "${CURL[@]}" -XPOST "$ES/_aliases" -d @- <<JSON | tee /dev/stderr | grep -q '"acknowledged":true'
 {
   "actions": [
-    { "remove": { "index": "$OLD_INDEX", "alias": "$ALIAS" } },
+    { "remove": { "index": "*", "alias": "$ALIAS", "must_exist": false } },
     { "add":    { "index": "$NEW_INDEX", "alias": "$ALIAS" } }
   ]
 }

--- a/scripts/forward-migrate.sh
+++ b/scripts/forward-migrate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# 前向迁移三步（YUJ-4682 步骤 6 / YUJ-4662 §4 步骤 6 + Yu 裁决 Coda 补遗）：
+#   ① 写新契约索引（mapping v1.9，camelCase 嵌套 + spaceId/visibles/messageSeq + IK + alias）
+#   ② 存量 doc reindex 旧索引 → 新契约索引
+#   ③ read alias 原子切换到新索引
+# 禁止半新半旧 doc 同 alias 服务：reindex 完成、抽样对账通过后才切 alias。
+# 回滚：保留旧索引（默认 7 天），alias 可秒切回（见末尾 ROLLBACK）。
+#
+# 这是一个**受控运维脚本**（非生产自动执行；本票只到代码 + 本地/预发验证层面，
+# 真实生产开 Kafka.On + 灰度放量归阶段 9）。所有破坏性操作前打印并要求确认。
+set -euo pipefail
+
+ES="${ES:-http://localhost:9200}"
+ALIAS="${ALIAS:-wukongim-messages-read}"
+OLD_INDEX="${OLD_INDEX:-octo-message}"                  # 旧契约索引（flat snake_case）
+NEW_INDEX="${NEW_INDEX:-wukongim-messages-000001}"      # 新契约索引（v1.9）
+MAPPING_FILE="${MAPPING_FILE:-internal/esindex/mapping/octo-message.json}"
+CURL=(curl -sS -H 'Content-Type: application/json')
+[ -n "${ES_USER:-}" ] && CURL+=(-u "${ES_USER}:${ES_PASS:-}")
+
+log(){ printf '\n=== %s ===\n' "$*"; }
+
+# 注意：脚本内嵌的 mapping JSON 含 aliases.wukongim-messages-read，会让新索引建好即挂 read alias。
+# 为保证「reindex 完成前不切 alias」，建新索引时**剥离 aliases 段**，alias 在步骤③单独原子挂。
+new_index_body(){
+  # 用 jq 去掉 aliases 段（若无 jq，则要求 MAPPING_NOALIAS_FILE 预先准备）。
+  if command -v jq >/dev/null 2>&1; then
+    jq 'del(.aliases)' "$MAPPING_FILE"
+  else
+    echo "ERROR: jq required to strip aliases for staged migration (or set MAPPING_NOALIAS_FILE)" >&2
+    exit 3
+  fi
+}
+
+step1_create_new(){
+  log "① 创建新契约索引 $NEW_INDEX (mapping v1.9，剥离 aliases 段)"
+  new_index_body | "${CURL[@]}" -XPUT "$ES/$NEW_INDEX" -d @- | tee /dev/stderr | grep -q '"acknowledged":true'
+}
+
+step2_reindex(){
+  log "② reindex $OLD_INDEX → $NEW_INDEX（字段名收敛 painless）"
+  # painless：把旧 flat snake_case doc 映射成新 camelCase 嵌套契约。
+  # ⚠️ 旧链不写 space_id/visibles/message_seq（Kafka 契约缺），故 reindex 出的新 doc 这三字段为空
+  # （reader p2p fail-closed / 无 visibles gate / messageSeq=0 保守）。要填全须走 backfill 重灌
+  # （读原始 MySQL payload）——见 docs/forward-migration-v1.9.md「存量富化」。
+  "${CURL[@]}" -XPOST "$ES/_reindex?wait_for_completion=true" -d @- <<JSON | tee /dev/stderr | grep -q '"failures":\[\]'
+{
+  "source": { "index": "$OLD_INDEX" },
+  "dest":   { "index": "$NEW_INDEX", "op_type": "index" },
+  "script": {
+    "lang": "painless",
+    "source": "ctx._source.messageId = Long.parseLong(ctx._source.remove('message_id')); def cid = ctx._source.remove('channel_id'); if (cid != null) ctx._source.channelId = cid; def ct = ctx._source.remove('channel_type'); if (ct != null) ctx._source.channelType = ct; def f = ctx._source.remove('from_uid'); if (f != null) ctx._source.from = f; def ts = ctx._source.remove('msg_timestamp'); if (ts != null) ctx._source.timestamp = ts; def ca = ctx._source.remove('created_at'); if (ca != null) ctx._source.createdAt = ca; def re = ctx._source.remove('raw_excluded'); if (re != null) ctx._source.rawExcluded = re; def sv = ctx._source.remove('schema_version'); if (sv != null) ctx._source.schemaVersion = sv; def cont = ctx._source.remove('content'); def cty = ctx._source.remove('content_type'); def p = ['type': cty]; if (cont != null) p.text = ['content': cont]; ctx._source.payload = p;"
+  }
+}
+JSON
+}
+
+step3_switch_alias(){
+  log "③ 原子切换 read alias $ALIAS → $NEW_INDEX（移除旧索引上的同名 alias）"
+  "${CURL[@]}" -XPOST "$ES/_aliases" -d @- <<JSON | tee /dev/stderr | grep -q '"acknowledged":true'
+{
+  "actions": [
+    { "remove": { "index": "$OLD_INDEX", "alias": "$ALIAS" } },
+    { "add":    { "index": "$NEW_INDEX", "alias": "$ALIAS" } }
+  ]
+}
+JSON
+}
+
+log "前向迁移：ES=$ES OLD=$OLD_INDEX NEW=$NEW_INDEX ALIAS=$ALIAS"
+echo "STEP=${STEP:-all}（可设 STEP=1|2|3 单步执行；reindex 完成 + 抽样对账通过后才执行 STEP=3）"
+case "${STEP:-all}" in
+  1) step1_create_new ;;
+  2) step2_reindex ;;
+  3) step3_switch_alias ;;
+  all)
+    step1_create_new
+    step2_reindex
+    echo ">>> 切 alias 前请先跑：make run-recon RECON_ES_INDEX=$NEW_INDEX（抽样对账通过再 STEP=3）"
+    echo ">>> 确认无误后执行：STEP=3 $0"
+    ;;
+  *) echo "unknown STEP=${STEP}" >&2; exit 2 ;;
+esac
+
+cat <<'ROLLBACK'
+
+ROLLBACK（alias 秒切回旧索引）：
+  curl -sS -XPOST "$ES/_aliases" -H 'Content-Type: application/json' -d '{
+    "actions":[
+      {"remove":{"index":"'"$NEW_INDEX"'","alias":"'"$ALIAS"'"}},
+      {"add":{"index":"'"$OLD_INDEX"'","alias":"'"$ALIAS"'"}}
+    ]}'
+  旧索引保留 ≥7 天后再删：curl -XDELETE "$ES/$OLD_INDEX"
+ROLLBACK


### PR DESCRIPTION
## Summary

Converge the OpenSearch document the `es-indexer` writes with the **octo-server
reader contract** (`modules/messages_search/source.go::Doc`) so the read path can
actually consume what this service indexes. The reader is unchanged; only the
write side moves.

Before this change the indexer wrote a flat snake_case doc
(`message_id`/`content`/…) while the reader reads camelCase nested
(`messageId`/`payload.text.content`/…) plus three fields the reader gates on
(`spaceId`, `visibles`, `messageSeq`) — so the read path could not consume the
index at all.

## Changes

- **mapping v1.9** (`internal/esindex/mapping/octo-message.json`): camelCase +
  nested `payload.*` + `spaceId`(keyword) + `visibles`(keyword[]) +
  `messageSeq`(long) + `messageId`(long, full-precision snowflake) + IK analyzers
  + the `wukongim-messages-read` alias.
- **`esindex.Doc` + `DocFromMessage`**: contract → reader doc. A non-numeric
  `message_id` is a **permanent (DLQ) error**, never silently coerced to `0`
  (the reader drops `messageId==0`).
- **backfill enrichment** (`docFromRow`): self-sources `spaceId`/`visibles` from
  the raw message payload and `messageSeq` from the column. The live consumer
  path cannot (the Kafka contract carries none of them).
- **live-ingestion safety gate**: the consumer refuses to start writing while the
  Kafka contract lacks the safety fields, so it never emits docs that would
  fail-OPEN the reader's group-message visibility gate. Existing docs are
  enriched by backfill meanwhile.
- **writer**: `Bulk` converts per-item; new `BulkDocs` for the backfill path.
- **reconciliation** (`cmd/reconcile`, `make run-recon`): adds field-level sample
  comparison (incl. `_source.messageId` precision) on top of count drift, a
  structured report with pinned failure thresholds and an exit-2 gate, and an
  optional push payload for the read-only drift gauges.
- **forward migration** (`scripts/forward-migrate.sh`,
  `docs/forward-migration-v1.9.md`): write new index → reindex/backfill → atomic
  alias switch, with rollback kept.
- harness + tests updated to the converged contract (numeric ids, nested fields).

## Verification

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` PASS (incl. `-race`)
- [x] independent model review PASS (2 findings raised + fixed: live-ingestion
  fail-open gate, recon `_source.messageId` drift)

No production rollout in this PR: real ingestion stays off until a later,
separately signed-off step. Filling the live path's safety fields requires an
additive contract bump + producer change shipped together at that step.


---

## R2 rework (round 2, cap=3)

Fixes the issues raised on the second review pass:

- **🔴 `extractVisibility` fail-OPEN (backfill ACL silently cleared)** — the strict
  struct meant a non-string `space_id` (number/object/upstream drift) failed the
  whole `Unmarshal` and returned empty `visibles`, silently dropping a legitimate
  access-control list. The reader treats empty `visibles` as **fail-OPEN** (the
  admin-only group system-message whitelist gate is removed). Now `space_id` is
  type-tolerant (string-only, else empty → reader p2p fail-closed) and visibility
  parsing is **fail-CLOSED**: a structurally broken row (non-object payload /
  non-array `visibles`) is routed to the DLQ, never written with empty `visibles`.
  The recon sample gate's parser is re-implemented **independently** of the write
  path and made type-tolerant, so it can actually catch a dropped ACL instead of
  being blind to the same bug. Tests cover non-string `space_id` keeping
  `visibles`, fail-closed on broken visibility, and the gate not being blind.
- **🟡 v2-gate latent fail-open CI test** — a reflection-based guard
  (`internal/esindex/v2gate_test.go`) that turns red if a future contract bump
  (`SchemaVersion>=2`) enables live ingestion without wiring
  `spaceId`/`visibles`/`messageSeq` through `DocFromMessage`.
- **🟡 `forward-migrate.sh` alias idempotency** — step3 atomically removes the
  read alias from **any** index (`index:"*"`, `must_exist:false`) before adding it
  to the new index, so it is idempotent and the alias is always single-pointing.
  The read alias was removed from the embedded mapping so a bare `PUT` /
  `EnsureIndex` is default-safe (alias attached only after reconciliation).
- **🟡 reconciliation** — README documents the mandatory `make run-recon` gate.

Closes #11