### PR TITLE
feat(backfill): re-pin octo-lib v2 + converge visibility on shared fail-closed parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Mininglamp-OSS/octo-search-indexer
 go 1.25
 
 require (
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618092744-45384c784102
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/opensearch-project/opensearch-go/v3 v3.1.0
 	github.com/segmentio/kafka-go v0.4.51

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db h1:FudjIbMVhMga/sUsysfzKBI7LTdz0Rgw9EWU2tEJzAo=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260614033907-f62e626a34db/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618092744-45384c784102 h1:Alkam9eQ9y2alz9Y0vo3TRVoyc3OMpgaLQgTmgg1RKU=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618092744-45384c784102/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=

--- a/internal/backfill/doc_enrich.go
+++ b/internal/backfill/doc_enrich.go
@@ -1,10 +1,7 @@
 package backfill
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 )
 
@@ -39,81 +36,26 @@ func docFromRow(row *srcMessageRow) (esindex.Doc, extractOutcome, error) {
 	}
 	// 加密消息 payload 是密文，不解析（与 extract 一致），spaceId/visibles 留空（reader fail-closed）。
 	if !isSignalEncrypted(row) {
-		spaceID, visibles, verr := extractVisibility(row.Payload)
+		// 🔴 可见性解析口径的**单一真源**是 octo-lib searchmsg.ExtractVisibility（票2 落地的共享
+		// fail-closed parser）。backfill 必须 import 它、而非自实现——producer 与 backfill 跑同一
+		// parser + 同一组 searchmsg.FailClosedVisibilityVectors()，锁口径防 #1124 在两仓分叉
+		// （验收门 ii）。共享 parser 比旧自实现更严：对 valid-but-empty visibles（键在但空数组 /
+		// null / 全非字符串）也 fail-closed，而旧自实现把这些当广播 fail-OPEN 放行。
+		spaceID, visibles, verr := searchmsg.ExtractVisibility(row.Payload)
 		if verr != nil {
 			// 🔴 fail-CLOSED：可见性是 access-control ACL。一旦它无法可信解析（payload 非 JSON 对象、
-			// visibles 非数组等结构性损坏），**绝不**写空 visibles —— 否则 reader(doc.go:21) 把空
-			// visibles 当 fail-OPEN（群系统消息「仅管理员可见」白名单门被移除，普通成员能搜到管理员
-			// 可见消息）。这类行一律落 DLQ（永久跳过写入），把 ACL 解析失败显式暴露给对账门而非静默塌掉。
+			// visibles 非数组 / valid-but-empty 等结构性损坏），**绝不**写空 visibles —— 否则 reader
+			// 把空 visibles 当 fail-OPEN（群系统消息「仅管理员可见」白名单门被移除，普通成员能搜到
+			// 管理员可见消息）。这类行一律落 DLQ（永久跳过写入），把 ACL 解析失败显式暴露给对账门而非
+			// 静默塌掉。
 			//
-			// 注意：space_id 的 JSON 类型（数字/对象/上游漂移）**不**触发此路径——extractVisibility 把
-			// space_id 解成容忍类型，非字符串 space_id 退化为空 spaceId（reader p2p fail-closed，安全方向），
-			// 绝不因一个字段类型怪异连累合法的 visibles 一并清空（V3b fail-OPEN 的根因）。
+			// 注意：space_id 的 JSON 类型（数字/对象/上游漂移）**不**触发此路径——ExtractVisibility 把
+			// space_id 解成容忍类型，非字符串 space_id 退化为空 spaceId（reader p2p fail-closed，安全
+			// 方向），绝不因一个字段类型怪异连累合法的 visibles 一并清空（V3b fail-OPEN 的根因）。
 			return esindex.Doc{}, outcomeDLQ, verr
 		}
 		doc.SpaceID = spaceID
 		doc.Visibles = visibles
 	}
 	return doc, outcome, nil
-}
-
-// extractVisibility 从原始 payload 字节解析 reader 鉴权所需的可见性字段：
-//   - space_id：p2p space 召回过滤的真源。**容忍类型**：仅当 JSON 字符串时取值，其余 JSON 类型
-//     （数字/对象/上游漂移）退化为空 spaceId（reader p2p fail-closed，安全方向）——绝不让 space_id
-//     的怪异类型炸掉整条 payload 的解析、连累合法 visibles 被清空（V3b fail-OPEN 根因）。
-//   - visibles（[]string，仅保留字符串元素，与 octo-server visiblesAllows 口径一致）：
-//     群系统消息白名单。空/缺失 → 空切片（reader：无 gate）。
-//
-// 🔴 fail-CLOSED 返回值契约：
-//   - payload 是合法 JSON 对象（即使含怪异字段类型）→ 返回解析出的 spaceID/visibles，err=nil。
-//   - payload **不是** JSON 对象（顶层非 `{...}`，如损坏/截断/数组/标量）→ 返回 err≠nil。
-//     调用方据此 fail-closed（落 DLQ），绝不把无法可信解析的行写成空 visibles（fail-OPEN）。
-//
-// 为何不再用 strict struct unmarshal：strict struct 里 `SpaceID string` 一旦遇非字符串 space_id
-// 会令**整个 struct** Unmarshal 失败 → 旧实现返回 "",nil → 合法 visibles 被静默清空 → reader
-// fail-OPEN。这正是本 PR 要堵的 V3b，却从 active backfill 路径重新引入。改用「先验顶层是对象，
-// 再字段级容忍解析」彻底切断「单字段类型 → 全可见性塌掉」的耦合。
-func extractVisibility(payload []byte) (spaceID string, visibles []string, err error) {
-	// 先把 payload 解成顶层对象（容忍每个字段的 JSON 类型）。顶层不是对象（损坏/截断/数组/标量）
-	// 才是真正「可见性不可信」→ fail-closed。space_id/visibles 字段本身的类型不在此判死。
-	var top map[string]json.RawMessage
-	dec := json.NewDecoder(bytes.NewReader(payload))
-	if derr := dec.Decode(&top); derr != nil {
-		return "", nil, fmt.Errorf("backfill: visibility payload not a JSON object (fail-closed): %w", derr)
-	}
-
-	// space_id：容忍类型——仅 JSON 字符串取值，其余类型留空（不报错、不连累 visibles）。
-	if raw, ok := top["space_id"]; ok {
-		var s string
-		if uerr := json.Unmarshal(raw, &s); uerr == nil {
-			spaceID = s
-		}
-		// 非字符串 space_id（数字/对象/null）→ spaceID 留空（reader p2p fail-closed，安全方向）。
-	}
-
-	// visibles：必须是 JSON 数组（或缺失/null）。是别的类型（对象/标量/字符串）说明白名单结构损坏
-	// → fail-closed（绝不当作「无 gate」放空，那是 fail-OPEN）。
-	rawVis, ok := top["visibles"]
-	if !ok || string(rawVis) == "null" {
-		return spaceID, nil, nil
-	}
-	var elems []json.RawMessage
-	if uerr := json.Unmarshal(rawVis, &elems); uerr != nil {
-		return "", nil, fmt.Errorf("backfill: visibles is not a JSON array (fail-closed, refuse to drop ACL): %w", uerr)
-	}
-	out := make([]string, 0, len(elems))
-	for _, raw := range elems {
-		var s string
-		if uerr := json.Unmarshal(raw, &s); uerr != nil {
-			// 与 server visiblesAllows 一致：非字符串元素跳过，不当作约束。
-			continue
-		}
-		if s != "" {
-			out = append(out, s)
-		}
-	}
-	if len(out) == 0 {
-		return spaceID, nil, nil
-	}
-	return spaceID, out, nil
 }

--- a/internal/backfill/doc_enrich_test.go
+++ b/internal/backfill/doc_enrich_test.go
@@ -3,6 +3,8 @@ package backfill
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 )
 
 // payloadWith 构造一条带 space_id/visibles 的文本 payload（明文 JSON，模拟 enrichPayloadWithSpaceID 产物）。
@@ -95,103 +97,88 @@ func TestDocFromRow_BadJSONToDLQ(t *testing.T) {
 	}
 }
 
-// TestExtractVisibility_DropsNonStringElements visibles 非字符串元素跳过（与 server visiblesAllows 口径一致）。
-func TestExtractVisibility_DropsNonStringElements(t *testing.T) {
-	raw := []byte(`{"space_id":"s1","visibles":["u1",123,"u2",{"x":1}]}`)
-	sid, vis, err := extractVisibility(raw)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if sid != "s1" {
-		t.Fatalf("space_id mismatch: %q", sid)
-	}
-	if len(vis) != 2 || vis[0] != "u1" || vis[1] != "u2" {
-		t.Fatalf("non-string visibles elements must be dropped: %+v", vis)
-	}
-}
-
-// TestExtractVisibility_NonStringSpaceIDKeepsVisibles 🔴 V3b fail-OPEN 根因回归门：
-// 某行 payload 的 space_id 是**非字符串** JSON 类型（数字/对象/上游漂移），而 visibles 数据**合法**。
-// 旧实现用 strict struct（SpaceID string）→ 整条 Unmarshal 失败 → 返回 "",nil → 合法 visibles 被
-// 静默清空 → reader fail-OPEN（普通成员搜出群管才可见消息）。修后：space_id 怪异类型退化为空
-// spaceId（reader p2p fail-closed，安全方向），但 visibles **必须**完整保留——绝不产出空 visibles。
-func TestExtractVisibility_NonStringSpaceIDKeepsVisibles(t *testing.T) {
-	cases := []struct {
-		name    string
-		payload string
-	}{
-		{"space_id is number", `{"space_id":123,"visibles":["admin1","admin2"]}`},
-		{"space_id is object", `{"space_id":{"nested":1},"visibles":["admin1","admin2"]}`},
-		{"space_id is bool", `{"space_id":true,"visibles":["admin1","admin2"]}`},
-		{"space_id is null", `{"space_id":null,"visibles":["admin1","admin2"]}`},
-		{"space_id is array", `{"space_id":["x"],"visibles":["admin1","admin2"]}`},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			sid, vis, err := extractVisibility([]byte(tc.payload))
+// TestBackfillRunsSharedFailClosedVectors 🔴 验收门(ii) 同口径锁：backfill 富化路径必须跑
+// **与 producer 完全相同**的 searchmsg.FailClosedVisibilityVectors() 向量，证明两仓用同一个
+// octo-lib searchmsg.ExtractVisibility（票2 共享 fail-closed parser），口径不分叉（防 #1124）。
+//
+// 第一段直接对 searchmsg.ExtractVisibility 跑向量（锁 parser 本体口径）；第二段把每条向量喂进
+// backfill 的 docFromRow（锁 backfill 实际接线：fail-closed 向量必落 DLQ 绝不写空 visibles，
+// 放行向量 visibles 完整落 doc），证明 backfill 没有在 parser 之外再放水。
+func TestBackfillRunsSharedFailClosedVectors(t *testing.T) {
+	for _, v := range searchmsg.FailClosedVisibilityVectors() {
+		t.Run("parser/"+v.Name, func(t *testing.T) {
+			sid, vis, err := searchmsg.ExtractVisibility(v.Payload)
+			if v.WantErr {
+				if err == nil {
+					t.Fatalf("vector %q: want fail-closed (err), got spaceID=%q visibles=%+v", v.Name, sid, vis)
+				}
+				return
+			}
 			if err != nil {
-				t.Fatalf("a weird space_id type must NOT fail visibility parse: %v", err)
+				t.Fatalf("vector %q: want pass, got err=%v", v.Name, err)
 			}
-			if sid != "" {
-				t.Fatalf("non-string space_id must degrade to empty spaceId (p2p fail-closed), got %q", sid)
+			if sid != v.WantSpaceID {
+				t.Fatalf("vector %q: spaceID=%q want %q", v.Name, sid, v.WantSpaceID)
 			}
-			if len(vis) != 2 || vis[0] != "admin1" || vis[1] != "admin2" {
-				t.Fatalf("legitimate visibles must NOT be cleared by a weird space_id (V3b fail-OPEN): %+v", vis)
-			}
-		})
-	}
-}
-
-// TestExtractVisibility_StringSpaceIDStillParsed 字符串 space_id 仍正常取值（容忍类型未破坏正常路径）。
-func TestExtractVisibility_StringSpaceIDStillParsed(t *testing.T) {
-	sid, vis, err := extractVisibility([]byte(`{"space_id":"space-A","visibles":["u1"]}`))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if sid != "space-A" {
-		t.Fatalf("string space_id must parse: %q", sid)
-	}
-	if len(vis) != 1 || vis[0] != "u1" {
-		t.Fatalf("visibles: %+v", vis)
-	}
-}
-
-// TestExtractVisibility_StructurallyBrokenFailClosed payload 顶层非对象 / visibles 非数组 → err（fail-closed）。
-// 调用方据此落 DLQ，绝不写空 visibles。
-func TestExtractVisibility_StructurallyBrokenFailClosed(t *testing.T) {
-	cases := []struct {
-		name    string
-		payload string
-	}{
-		{"not json", `{not json`},
-		{"top-level array", `["a","b"]`},
-		{"top-level scalar", `42`},
-		{"visibles is object", `{"space_id":"s1","visibles":{"u1":true}}`},
-		{"visibles is string", `{"space_id":"s1","visibles":"u1,u2"}`},
-		{"visibles is number", `{"space_id":"s1","visibles":7}`},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := extractVisibility([]byte(tc.payload))
-			if err == nil {
-				t.Fatalf("structurally broken visibility must fail-closed (err), not silently empty: %q", tc.payload)
+			if !equalStrings(vis, v.WantVisibles) {
+				t.Fatalf("vector %q: visibles=%+v want %+v", v.Name, vis, v.WantVisibles)
 			}
 		})
 	}
 }
 
-// TestExtractVisibility_AbsentVisiblesNoError 缺 visibles / visibles=null → 空切片 + 无错（reader 无 gate，合法）。
-func TestExtractVisibility_AbsentVisiblesNoError(t *testing.T) {
-	for _, p := range []string{`{"space_id":"s1"}`, `{"space_id":"s1","visibles":null}`, `{}`} {
-		sid, vis, err := extractVisibility([]byte(p))
-		if err != nil {
-			t.Fatalf("absent visibles is legitimate (no gate), must not fail-closed: %q err=%v", p, err)
-		}
-		if len(vis) != 0 {
-			t.Fatalf("absent visibles must be empty: %+v", vis)
-		}
-		_ = sid
+// TestDocFromRow_SharedVectorsWiredFailClosed 把共享向量喂进 backfill docFromRow，断言接线正确：
+//   - WantErr 向量（含 valid-but-empty visibles：[] / null / 全非字符串 / 全空串）→ outcomeDLQ，
+//     该行**绝不写入** ES（fail-closed）。这正是验收门(ii) 真正闭合处：旧自实现对 [] / null / 全非
+//     字符串放行 fail-OPEN，共享 parser 一律 fail-closed 落 DLQ。
+//   - 放行向量 → 非 DLQ（OK 或 raw_excluded，取决于 payload 是否带 type=text），且 doc 的
+//     SpaceID/Visibles 与向量期望一致（visibles 被忠实富化进 doc，不放空）。
+//
+// 注：向量是为 ExtractVisibility 本体设计的，部分 payload 不带 type=1 文本正文，故经 extractMessage
+// 内容门后落 raw_excluded（仍写 doc、仍富化 visibles）属预期；本测试只锁「fail-closed 必落 DLQ /
+// 放行必富化 visibles」这条接线不变量，不锁正文 outcome 的 OK/raw_excluded 细分。
+func TestDocFromRow_SharedVectorsWiredFailClosed(t *testing.T) {
+	for _, v := range searchmsg.FailClosedVisibilityVectors() {
+		t.Run(v.Name, func(t *testing.T) {
+			// 非加密文本行（payload = 向量字节），message_id 数值可解析。
+			row := &srcMessageRow{ID: 1, MessageID: "1001", ChannelType: 2, Payload: v.Payload}
+			doc, outcome, err := docFromRow(row)
+			if v.WantErr {
+				// fail-closed：该行必须落 DLQ（永不写入 ES），绝不产出带空 visibles 的可写 doc。
+				if outcome != outcomeDLQ {
+					t.Fatalf("vector %q: fail-closed must route to DLQ (never written), got outcome=%v err=%v doc.Visibles=%+v",
+						v.Name, outcome, err, doc.Visibles)
+				}
+				return
+			}
+			// 放行向量：不得落 DLQ；visibles 必须被富化进 doc（不放空 → reader 不会 fail-OPEN）。
+			if outcome == outcomeDLQ {
+				t.Fatalf("vector %q: legitimate visibility must not DLQ, got err=%v", v.Name, err)
+			}
+			if err != nil {
+				t.Fatalf("vector %q: unexpected err=%v", v.Name, err)
+			}
+			if doc.SpaceID != v.WantSpaceID {
+				t.Fatalf("vector %q: doc.SpaceID=%q want %q", v.Name, doc.SpaceID, v.WantSpaceID)
+			}
+			if !equalStrings(doc.Visibles, v.WantVisibles) {
+				t.Fatalf("vector %q: doc.Visibles=%+v want %+v", v.Name, doc.Visibles, v.WantVisibles)
+			}
+		})
 	}
+}
+
+// equalStrings 比较两个字符串切片（nil 与空切片视为相等：reader 对二者均「无 gate」）。
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestDocFromRow_NonStringSpaceIDKeepsVisibles 🔴 端到端 V3b：backfill doc 富化路径下，

--- a/internal/esindex/doc.go
+++ b/internal/esindex/doc.go
@@ -71,13 +71,15 @@ func parseMessageID(messageID string) (int64, error) {
 
 // DocFromMessage 把 Kafka 契约消息（searchmsg.Message）转成 reader 可读 Doc（实时 consumer 路径）。
 //
-// ⚠️ 实时路径的契约局限（阶段 9 上线前置 sibling）：searchmsg.Message **不携带**
-// spaceId / visibles / messageSeq（producer 只抽 content）。故实时路径写出的 Doc 这三字段
-// 为空：reader 对空 spaceId（p2p）走 fail-closed（同 space 不命中），对空 visibles 无 gate，
-// 对 messageSeq=0 保守隐藏——均**安全方向**。要让实时路径填全这三字段，须扩 octo-lib 契约
-// （+SpaceID/+Visibles/+MessageSeq，SchemaVersion 1→2）+ octo-server searchetl producer 富化，
-// 二者随阶段 9 开 Kafka.On 一并上线（本期 Kafka.On=OFF，无实时流量）。
-// 存量数据的这三字段由 backfill 路径（读原始 MySQL payload）自源填全 → 满足 V1(b)/V3b。
+// ✅ 契约已升到 v2（SchemaVersion=2）：searchmsg.Message 携带 reader 必读的安全/正确性字段
+// SpaceID / Visibles / MessageSeq（octo-server searchetl producer 富化后填全）。DocFromMessage
+// 把这三字段从契约逐字段 copy 进 Doc —— 这正是 TestV2Gate_DocFromMessageWiresSafetyFields 钉死
+// 的「v2 bump 必须同步接线」：若解了实时安全闸（LiveContractCarriesSafetyFields）却不接线，
+// 实时路径会写出空 visibles 的 doc → reader fail-OPEN（普通成员搜出群管才可见的系统消息）。
+//
+// 注意：producer 是否对每条消息填非空 visibles 是 producer 侧 fail-closed（空 visibles → DLQ，
+// 不进 Kafka）的职责（票2）；indexer 侧只负责忠实搬运契约已带的字段。存量数据的这三字段由
+// backfill 路径（读原始 MySQL payload + searchmsg.ExtractVisibility）自源填全。
 func DocFromMessage(msg searchmsg.Message) (Doc, error) {
 	id, err := parseMessageID(msg.MessageID)
 	if err != nil {
@@ -86,9 +88,12 @@ func DocFromMessage(msg searchmsg.Message) (Doc, error) {
 	d := Doc{
 		SchemaVersion: msg.SchemaVersion,
 		MessageID:     id,
+		MessageSeq:    msg.MessageSeq,
 		From:          msg.FromUID,
 		ChannelID:     msg.ChannelID,
 		ChannelType:   uint32(msg.ChannelType),
+		SpaceID:       msg.SpaceID,
+		Visibles:      msg.Visibles,
 		Timestamp:     msg.MsgTimestamp,
 		CreatedAt:     msg.CreatedAt,
 		RawExcluded:   msg.RawExcluded,


### PR DESCRIPTION
## Summary

Re-pin octo-lib to the v2 message-search contract (SchemaVersion=2: adds reader safety fields SpaceID/Visibles/MessageSeq + the shared fail-closed visibility parser `searchmsg.ExtractVisibility`), wire those fields through `DocFromMessage`, and converge the backfill enrichment path off its self-implemented `extractVisibility` onto the shared parser.

## Changes

- **`go.mod`/`go.sum`** — re-pin octo-lib to the v2 contract commit (`45384c78`).
- **`internal/esindex/doc.go`** — `DocFromMessage` now copies `SpaceID`/`Visibles`/`MessageSeq` from the contract. With the contract at v2 the live-ingestion safety gate auto-unlocks; this wiring is what stops the real-time consumer from writing empty-visibles docs (reader fail-OPEN). Enforced by `TestV2Gate_DocFromMessageWiresSafetyFields`, which previously skipped under v1 and is now green.
- **`internal/backfill/doc_enrich.go`** — delete the self-implemented `extractVisibility` and import `searchmsg.ExtractVisibility`. The old impl failed-OPEN on valid-but-empty visibles (`[]` / `null` / all-non-string returned empty visibles); the shared parser fail-closes on those (→ DLQ), matching the producer.
- **`internal/backfill/doc_enrich_test.go`** — run the shared `searchmsg.FailClosedVisibilityVectors()` set through both the parser and `docFromRow`, so producer and backfill exercise the identical vectors (locks the visibility contract against drift).

## Verification

- harness contractgate: **exit 0**, gate=OPEN, schema_version=2.
- `harness/run.sh all` live e2e (Kafka → consumer → OpenSearch): **all 10 invariants PASS**.
- `TestV2Gate_DocFromMessageWiresSafetyFields`: no longer skips, **green**.
- `grep` confirms no residual self-implemented `extractVisibility` in `internal/backfill`.
- `go build` / `go vet` / `go test` (incl. `-race`) all pass.

## Rollout: residual v1 Kafka messages

This period runs with **Kafka.On = OFF** (no real-time traffic), so the body topic is expected empty at cutover. After the v2 bump, `decodeAndValidate` does an **exact** `SchemaVersion` match, so any residual v1 message routes to DLQ as `unknown_schema_version` — never written as an empty-visibles fail-OPEN doc.

**Chosen drain strategy: (i) drain the v1 topic.** Acceptance = topic lag/offset == 0 before enabling live ingestion. Alternative (ii) — one-time DLQ flood + bounded alert-silence + post-check "DLQ only contains `unknown_schema_version`" — is unnecessary here because there is no live traffic this period.

## Out of scope (follow-ups)

- Scheduler wiring, fast-cursor, production deploy.
- `recon/sample.go::parsePayloadVisibility` is intentionally an **independent** parser (validation-gate independence) and is not changed here.
- 5 known P2s (dup-key / whitespace-only UID / double-parse / visibles dedup / message_seq NULL fallback).

Closes #12