### PR TITLE
fix(deploy): install-ik 补拷 config/analysis-ik 词典 + 守卫检测词典文件

### DIFF
--- a/deploy/k8s/search-opensearch-statefulset.yaml
+++ b/deploy/k8s/search-opensearch-statefulset.yaml
@@ -47,18 +47,28 @@ spec:
             - |
               set -e
               IKVER=2.17.0
-              if [ -d /shared-plugins/analysis-ik ]; then
-                echo "analysis-ik already present, skip"; exit 0
+              # YUJ-5101: 守卫改为检测词典文件 (旧守卫只看 plugins 目录存在即 skip,
+              #   重部署会跳过、永不补词典)。须 plugin 目录 + IKAnalyzer.cfg.xml 词典都在才 skip。
+              if [ -f /shared-config/analysis-ik/IKAnalyzer.cfg.xml ] && [ -d /shared-plugins/analysis-ik ]; then
+                echo "analysis-ik plugin + dict already present, skip"; exit 0
               fi
-              echo "installing analysis-ik ${IKVER} into shared plugins volume"
-              # 装到临时 OPENSEARCH_PATH_PLUGINS, 再 copy 进共享卷
+              echo "installing analysis-ik ${IKVER} (plugin + dict) into shared volumes"
+              # opensearch-plugin install 会把 plugin jar 装到 plugins/analysis-ik,
+              #   并把 IK 词典 (main.dic/extra_*.dic/IKAnalyzer.cfg.xml ~8MB) 重定位到
+              #   config/analysis-ik/ —— 两处都要拷进共享卷, 否则主容器缺词典 → bulk 500 NPE。
               /usr/share/opensearch/bin/opensearch-plugin install --batch \
                 https://release.infinilabs.com/analysis-ik/stable/opensearch-analysis-ik-${IKVER}.zip
+              rm -rf /shared-plugins/analysis-ik
               cp -r /usr/share/opensearch/plugins/analysis-ik /shared-plugins/
-              echo "analysis-ik installed:"; ls -la /shared-plugins/analysis-ik | head
+              mkdir -p /shared-config/analysis-ik
+              cp -r /usr/share/opensearch/config/analysis-ik/* /shared-config/analysis-ik/
+              echo "plugin:"; ls -la /shared-plugins/analysis-ik | head
+              echo "dict:"; ls -la /shared-config/analysis-ik | head
           volumeMounts:
             - name: plugins
               mountPath: /shared-plugins
+            - name: ik-config
+              mountPath: /shared-config
           resources:
             requests:
               cpu: 100m
@@ -104,6 +114,9 @@ spec:
             - name: plugins
               mountPath: /usr/share/opensearch/plugins/analysis-ik
               subPath: analysis-ik   # 把 initContainer 装好的 IK 挂进主容器 plugins 目录
+            - name: ik-config
+              mountPath: /usr/share/opensearch/config/analysis-ik
+              subPath: analysis-ik   # YUJ-5101: IK 词典 (config/analysis-ik) 缺它 → bulk 500 NPE
           readinessProbe:
             httpGet:
               path: /_cluster/health
@@ -120,6 +133,8 @@ spec:
       volumes:
         - name: plugins
           emptyDir: {}            # initContainer 装 IK 到这 → 主容器 subPath 挂载
+        - name: ik-config
+          emptyDir: {}            # YUJ-5101: initContainer 装 IK 词典到这 → 主容器 subPath 挂载
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
## 问题

`search-opensearch` StatefulSet 的 `install-ik` initContainer 只 `cp -r plugins/analysis-ik` 进共享卷，**漏拷** `opensearch-plugin install` 重定位到 `config/analysis-ik/` 的 IK 词典（`main.dic` / `extra_*.dic` / `IKAnalyzer.cfg.xml`，~8MB）。

主容器缺词典 → IK `Dictionary` 单例懒加载 NPE（`_QuantifierDict` / `_StopWords` is null）→ 每条中文消息 bulk 写入返回 HTTP 500 → indexer 判为 transient 无限重试 → consumer offset 永不推进 → 索引零增长。

且原 skip 守卫是「plugins 目录存在即 skip」，重部署会跳过、永不补词典 = 定时炸弹。

## 改动（与 dmwork-test 集群热修复活配置对齐）

1. **initContainer command**：额外拷 `config/analysis-ik` 词典；守卫从 `[ -d /shared-plugins/analysis-ik ]` 改为 `[ -f /shared-config/analysis-ik/IKAnalyzer.cfg.xml ] && [ -d /shared-plugins/analysis-ik ]`，plugin + 词典都在才 skip。initContainer 增加 `ik-config` 挂载 `/shared-config`。
2. **新增 `ik-config` emptyDir volume**（与现有 `plugins` 并列）。
3. **主容器** opensearch volumeMounts 新增 `ik-config` 挂到 `/usr/share/opensearch/config/analysis-ik`（subPath `analysis-ik`）。

## 验证

- `kubectl kustomize deploy/k8s/` build 通过（exit 0，无报错）。
- 渲染产物已确认三处改动正确：init 同时拷 plugin + dict、init 两个 volumeMount、主容器挂 `config/analysis-ik`、新增 `ik-config` emptyDir。
- 不需真部署：集群热修复版已验证 127852 条历史消息全部索引、IK 分词正常、搜索可用；本 PR = 把该热修复回流进源码 manifest，消除「重部署再次丢词典」的定时炸弹。

> base 指向 bundle 分支：该实时索引 bundle 尚未合入 `main`（此前为 local-only + 直接 apply 部署），本 PR 仅含词典 fix 单 commit diff。