### PR TITLE
build: bundle backfill + reconcile binaries in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,24 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /es-indexer ./cmd/es-indexer
+# Build all three pipeline binaries:
+#   es-indexer — the long-running Kafka→OpenSearch consumer (default entrypoint).
+#   backfill   — one-shot historical loader (MySQL shards → OpenSearch, bypass Kafka).
+#   reconcile  — MySQL-vs-OpenSearch count/sample correctness gate (exit 2 on mismatch).
+# backfill + reconcile are on-demand ops tools the deployment upgrade flow runs as
+# one-shot jobs; shipping them in the same image means operators do not need a
+# separate Go toolchain or a second image to turn search on.
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /es-indexer ./cmd/es-indexer \
+  && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /backfill ./cmd/backfill \
+  && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /reconcile ./cmd/reconcile
 
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates tzdata wget \
   && adduser -D -u 10001 appuser
 
 COPY --from=builder /es-indexer /usr/local/bin/es-indexer
+COPY --from=builder /backfill /usr/local/bin/backfill
+COPY --from=builder /reconcile /usr/local/bin/reconcile
 
 USER appuser
 


### PR DESCRIPTION
## What

Build the `backfill` and `reconcile` binaries into the image alongside `es-indexer`.

The image previously shipped only `es-indexer` (the long-running Kafka→OpenSearch consumer). The deployment upgrade flow also needs the one-shot `backfill` (historical loader) and `reconcile` (correctness gate) tools. Bundling all three into the same image lets operators run them as one-shot jobs (e.g. compose `run --rm`) without a separate Go toolchain or a second image.

## Details

- Both new binaries are built CGO-disabled and `-trimpath -ldflags="-s -w"`, same as `es-indexer`.
- The default entrypoint stays `/usr/local/bin/es-indexer`; the upgrade jobs override the entrypoint to call `backfill`/`reconcile`.
- No source/logic changes — Dockerfile only.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` all green.
- `docker build` succeeds; all three binaries present and `-h` runnable in the image.
- Ran the bundled `backfill` against a throwaway MySQL+OpenSearch(IK): 5 docs indexed, inline reconcile gate PASS (diff=0, sample mismatch=0), exit 0.

## Notes

This is the prerequisite image change for the companion octo-deployment PR that wires the opt-in search profile + scripted hot-upgrade flow (its `search-backfill` one-shot job runs the bundled `backfill` binary).
