### PR TITLE
feat(producer): forensic DLQ envelope + run first tick on start

### DIFF
--- a/cmd/searchetl-producer/main.go
+++ b/cmd/searchetl-producer/main.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -48,14 +49,24 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	cfg, enabled := producer.LoadConfig()
-	if !enabled {
-		log.Printf("searchetl-producer: PRODUCER_ENABLED not true (or brokers/DSN/Redis unset); idling (no backend connection)")
+	cfg, requested := producer.LoadConfig()
+	if !requested {
+		log.Printf("searchetl-producer: PRODUCER_ENABLED not true; idling (no backend connection)")
+		// Serve health endpoints even while idling so an orchestrator's
+		// liveness/readiness probes do not crashloop a deliberately-disabled
+		// pod (the opt-in "deployed but off" posture). Both /healthz and /readyz
+		// report 200: per the plan, "idling normally" is a ready state — it lets
+		// the opt-in deploy roll out cleanly without receiving any traffic (the
+		// producer exposes no Service). It connects to no backend.
+		serveIdleObs(ctx, cfg.ObsAddr)
 		<-ctx.Done()
 		return nil
 	}
+	// 🔴 PRODUCER_ENABLED=true means the operator intends this to run. Missing
+	// DSN/brokers/Redis/lag is then a hard error (fail-fast crashloop), NOT a
+	// silent idle — otherwise a cut-over would no-op while reporting healthy.
 	if err := cfg.Validate(); err != nil {
-		return err
+		return fmt.Errorf("searchetl-producer: PRODUCER_ENABLED=true but config invalid (refusing to idle on a requested producer): %w", err)
 	}
 
 	// Source DB with an explicit connection pool (no bare driver defaults).
@@ -138,4 +149,30 @@ func run(ctx context.Context) error {
 	}
 	sched.Stop()
 	return nil
+}
+
+// serveIdleObs starts the observability HTTP server for the idle (disabled)
+// posture: /healthz and /readyz both return 200. Per the plan, "idling
+// normally" is a ready state — this keeps a deliberately-disabled pod
+// (PRODUCER_ENABLED=false, the opt-in "deployed but off" default) from
+// crashlooping under an orchestrator's HTTP probes and lets the opt-in deploy
+// roll out cleanly. It connects to no backend (ready check is nil; the producer
+// exposes no Service so a ready idle pod receives no traffic). A graceful
+// shutdown stops it on ctx cancel.
+func serveIdleObs(ctx context.Context, addr string) {
+	if addr == "" {
+		return
+	}
+	obs := producer.NewObsServer(addr, nil, nil)
+	obs.SetReady(true) // idling normally is a ready state (no backend dialed)
+	obs.Start(log.Printf)
+	go func() {
+		<-ctx.Done()
+		sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if serr := obs.Shutdown(sctx); serr != nil {
+			log.Printf("searchetl-producer: idle obs shutdown: %v", serr)
+		}
+	}()
+	log.Printf("searchetl-producer: idle observability server on %s (/healthz + /readyz 200, idle)", addr)
 }

--- a/cmd/searchetl-producer/main_test.go
+++ b/cmd/searchetl-producer/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestServeIdleObs_HealthAndReady verifies the idle (disabled) posture serves
+// both /healthz and /readyz as 200, so a deliberately-off pod does not crashloop
+// under HTTP liveness/readiness probes.
+func TestServeIdleObs_HealthAndReady(t *testing.T) {
+	// Grab a free localhost port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if cerr := ln.Close(); cerr != nil {
+		t.Fatalf("close probe listener: %v", cerr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveIdleObs(ctx, addr)
+
+	base := fmt.Sprintf("http://%s", addr)
+	deadline := time.Now().Add(3 * time.Second)
+	for _, path := range []string{"/healthz", "/readyz"} {
+		var got int
+		for time.Now().Before(deadline) {
+			resp, gerr := http.Get(base + path) //nolint:noctx // short-lived test probe
+			if gerr != nil {
+				time.Sleep(20 * time.Millisecond)
+				continue
+			}
+			got = resp.StatusCode
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Fatalf("close body: %v", cerr)
+			}
+			break
+		}
+		if got != http.StatusOK {
+			t.Fatalf("idle %s = %d, want 200", path, got)
+		}
+	}
+}

--- a/harness/producer/README.md
+++ b/harness/producer/README.md
@@ -16,9 +16,11 @@ seeds a controlled message fixture (`seed.sql`), and runs the Go verifier
 1. **poll → enrich → Kafka** — stable rows land on the body topic with the right
    enrichment (text body, `visibles` whitelist, `raw_excluded` for Signal/media),
    and genuine anomalies + fail-closed visibility violations land on the DLQ
-   topic. This is a **field-level** assertion (not a bare doc count): it checks
-   the actual contract contents, including the #1124 fail-closed guard that the
-   empty-`visibles` row must route to DLQ, never to the body topic.
+   topic as forensic **DLQ envelopes** (reason + raw payload + source locator,
+   not bare body contracts). This is a **field-level** assertion (not a bare doc
+   count): it checks the actual contract contents, including the #1124
+   fail-closed guard that the empty-`visibles` row must route to DLQ, never to
+   the body topic.
 2. **Redis lock mutual exclusion** — two concurrent `RunIncremental` calls
    sharing the same lock key never both produce; exactly one wins, the other
    skips.

--- a/harness/producer/main.go
+++ b/harness/producer/main.go
@@ -191,15 +191,15 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("drain main topic: %w", err)
 	}
-	dlqMsgs, err := drainTopic(ctx, cfg.Brokers, cfg.DLQTopic, 2)
+	dlqEnvelopes, err := drainDLQ(ctx, cfg.Brokers, cfg.DLQTopic, 2)
 	if err != nil {
 		return fmt.Errorf("drain dlq topic: %w", err)
 	}
 	if len(mainMsgs) != 4 {
 		return fmt.Errorf("main topic: want 4 messages, got %d", len(mainMsgs))
 	}
-	if len(dlqMsgs) != 2 {
-		return fmt.Errorf("dlq topic: want 2 messages, got %d", len(dlqMsgs))
+	if len(dlqEnvelopes) != 2 {
+		return fmt.Errorf("dlq topic: want 2 messages, got %d", len(dlqEnvelopes))
 	}
 
 	// Assert enrichment correctness on the main stream.
@@ -228,18 +228,39 @@ func run() error {
 	if _, leaked := byID["1000000000000000006"]; leaked {
 		return fmt.Errorf("SECURITY: empty-visibles row leaked into main topic (fail-OPEN)")
 	}
-	dlqIDs := map[string]bool{}
-	for _, m := range dlqMsgs {
-		dlqIDs[m.MessageID] = true
+	// 🟡 DLQ records are forensic envelopes (reason + raw payload + source locator),
+	// not bare body contracts — assert the triage context survived.
+	dlqByID := map[string]producer.DLQEnvelope{}
+	for _, e := range dlqEnvelopes {
+		dlqByID[e.MessageID] = e
+		if e.SchemaVersion != 1 {
+			return fmt.Errorf("dlq envelope %s wrong schema_version %d", e.MessageID, e.SchemaVersion)
+		}
+		if e.Reason == "" || len(e.RawPayload) == 0 || e.ShardTable == "" || e.SourceID == 0 {
+			return fmt.Errorf("dlq envelope %s missing forensic context: %+v", e.MessageID, e)
+		}
+		if e.ProducedAt == 0 {
+			return fmt.Errorf("dlq envelope %s must be stamped with produced_at", e.MessageID)
+		}
 	}
-	if !dlqIDs["1000000000000000006"] {
-		return fmt.Errorf("empty-visibles row must be routed to DLQ (fail-closed), dlq ids=%v", dlqIDs)
+	if _, ok := dlqByID["1000000000000000006"]; !ok {
+		return fmt.Errorf("empty-visibles row must be routed to DLQ (fail-closed), dlq ids=%v", dlqKeys(dlqByID))
 	}
-	if !dlqIDs["1000000000000000005"] {
-		return fmt.Errorf("bad-json row must be routed to DLQ, dlq ids=%v", dlqIDs)
+	if _, ok := dlqByID["1000000000000000005"]; !ok {
+		return fmt.Errorf("bad-json row must be routed to DLQ, dlq ids=%v", dlqKeys(dlqByID))
 	}
-	log.Printf("invariant ① OK: 4 main (text/visibles/raw×2) + 2 dlq (bad-json + empty-visibles fail-closed)")
+	log.Printf("invariant ① OK: 4 main (text/visibles/raw×2) + 2 dlq envelopes (bad-json + empty-visibles fail-closed, reasons=%q/%q)",
+		dlqByID["1000000000000000005"].Reason, dlqByID["1000000000000000006"].Reason)
 	return nil
+}
+
+// dlqKeys returns the message ids present in a DLQ-envelope map (error messages).
+func dlqKeys(m map[string]producer.DLQEnvelope) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // countingSink counts produced rows and sleeps to force temporal overlap; it does
@@ -256,9 +277,9 @@ func (s *countingSink) ProduceBatch(_ context.Context, msgs []searchmsg.Message)
 	time.Sleep(s.delay)
 	return nil
 }
-func (s *countingSink) ProduceDLQ(_ context.Context, msgs []searchmsg.Message) error {
-	if len(msgs) > 0 {
-		s.counter.Add(int64(len(msgs)))
+func (s *countingSink) ProduceDLQ(_ context.Context, envelopes []producer.DLQEnvelope) error {
+	if len(envelopes) > 0 {
+		s.counter.Add(int64(len(envelopes)))
 	}
 	return nil
 }
@@ -311,6 +332,41 @@ func drainTopic(ctx context.Context, brokers []string, topic string, want int) (
 			return nil, fmt.Errorf("decode %s offset %d: %w", topic, m.Offset, uerr)
 		}
 		out = append(out, msg)
+	}
+	return out, nil
+}
+
+// drainDLQ reads up to want DLQ records from the DLQ topic and decodes them as
+// producer.DLQEnvelope (the producer-specific forensic shape, NOT the body
+// contract).
+func drainDLQ(ctx context.Context, brokers []string, topic string, want int) ([]producer.DLQEnvelope, error) {
+	r := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:     brokers,
+		Topic:       topic,
+		Partition:   0,
+		StartOffset: kafka.FirstOffset,
+		MinBytes:    1,
+		MaxBytes:    10 << 20,
+	})
+	defer func() {
+		if cerr := r.Close(); cerr != nil {
+			log.Printf("close kafka reader for %s: %v", topic, cerr)
+		}
+	}()
+
+	var out []producer.DLQEnvelope
+	for len(out) < want {
+		rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		m, err := r.ReadMessage(rctx)
+		cancel()
+		if err != nil {
+			break // idle timeout / no more messages
+		}
+		var env producer.DLQEnvelope
+		if uerr := json.Unmarshal(m.Value, &env); uerr != nil {
+			return nil, fmt.Errorf("decode dlq %s offset %d: %w", topic, m.Offset, uerr)
+		}
+		out = append(out, env)
 	}
 	return out, nil
 }

--- a/internal/producer/chunk.go
+++ b/internal/producer/chunk.go
@@ -7,10 +7,12 @@ import "github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 // The caller produces main + dlq (all confirmed) THEN advances the cursor to maxID.
 type chunkPlan struct {
 	// main goes to the body topic (outcomeOK bodies + outcomeRawExcluded
-	// content=null messages).
+	// content=null messages) as searchmsg.Message contracts.
 	main []searchmsg.Message
-	// dlq goes to the DLQ topic (outcomeDLQ: genuine anomalies).
-	dlq []searchmsg.Message
+	// dlq goes to the DLQ topic (outcomeDLQ: genuine anomalies) as forensic
+	// DLQEnvelope records (reason + raw payload + source locator), NOT bare body
+	// contracts — the DLQ stream is terminal and optimized for triage/replay.
+	dlq []DLQEnvelope
 	// stableCount is the number of rows in the stable prefix (= len(main)+len(dlq);
 	// used to decide whether the unstable tail was reached).
 	stableCount int
@@ -23,12 +25,15 @@ type chunkPlan struct {
 
 // planChunk applies, over an id-ascending batch: ① the stability gate truncation
 // (C1, cutoff=DB_NOW-lag) → ② per-row extraction three-state routing (OK/Raw →
-// main, DLQ → dlq).
+// main as searchmsg.Message, DLQ → dlq as a forensic DLQEnvelope tagged with the
+// dead-letter reason + source locator).
 //
-// Pure function: rows + cutoff in, plan out, touches no DB/Kafka. The cursor
-// watermark is the last stable-prefix row id regardless of outcome — raw_excluded
-// / DLQ rows are consumed too, their ids must count toward the watermark.
-func planChunk(rows []*srcMessageRow, cutoff int64) chunkPlan {
+// Pure function: rows + cutoff in, plan out, touches no DB/Kafka/clock. The
+// cursor watermark is the last stable-prefix row id regardless of outcome —
+// raw_excluded / DLQ rows are consumed too, their ids must count toward the
+// watermark. The DLQ envelope's produce timestamp is stamped later by the sink so
+// this stays deterministic.
+func planChunk(table string, rows []*srcMessageRow, cutoff int64) chunkPlan {
 	stable := stablePrefix(rows, cutoff)
 	plan := chunkPlan{stableCount: len(stable)}
 	if len(stable) == 0 {
@@ -36,10 +41,10 @@ func planChunk(rows []*srcMessageRow, cutoff int64) chunkPlan {
 	}
 	plan.main = make([]searchmsg.Message, 0, len(stable))
 	for _, row := range stable {
-		msg, outcome := extractMessage(row)
+		msg, outcome, reason := extractMessage(row)
 		switch outcome {
 		case outcomeDLQ:
-			plan.dlq = append(plan.dlq, msg)
+			plan.dlq = append(plan.dlq, newDLQEnvelope(table, row, reason))
 		default: // outcomeOK / outcomeRawExcluded both go to the body stream
 			plan.main = append(plan.main, msg)
 		}

--- a/internal/producer/config.go
+++ b/internal/producer/config.go
@@ -126,8 +126,16 @@ const (
 var defaultTables = []string{"message", "message1", "message2", "message3", "message4"}
 
 // LoadConfig builds Config from the environment and reports whether the producer
-// is enabled. enabled=false means the binary idles (zero runtime behavior) —
-// PRODUCER_ENABLED must be true AND brokers + DSN + Redis addr present.
+// was REQUESTED via the master switch (PRODUCER_ENABLED=true).
+//
+// 🔴 The returned bool is the master switch ALONE — it deliberately does NOT
+// fold in config completeness. The caller distinguishes two states so a cut-over
+// can never silently no-op:
+//   - requested=false → the producer is intentionally off; idle (zero runtime
+//     behavior, no backend connection).
+//   - requested=true → the operator means for it to run; the caller MUST then
+//     Validate() and fail-fast (loud crashloop) if DSN/brokers/Redis/lag are
+//     missing, rather than idling "ready" while producing nothing.
 func LoadConfig() (Config, bool) {
 	cfg := Config{
 		MySQLDSN: os.Getenv(envMySQLDSN),
@@ -158,9 +166,8 @@ func LoadConfig() (Config, bool) {
 		cfg.DBMaxIdleConns = cfg.DBMaxOpenConns
 	}
 
-	enabled := strings.EqualFold(os.Getenv(envEnabled), "true") &&
-		cfg.MySQLDSN != "" && len(cfg.Brokers) > 0 && cfg.RedisAddr != ""
-	return cfg, enabled
+	requested := strings.EqualFold(os.Getenv(envEnabled), "true")
+	return cfg, requested
 }
 
 // Validate checks an enabled config is internally coherent (fail-fast on boot).

--- a/internal/producer/config_test.go
+++ b/internal/producer/config_test.go
@@ -5,31 +5,40 @@ import (
 	"testing"
 )
 
-// TestLoadConfig_DisabledByDefault: no env → disabled, idles, no backend connect.
+// TestLoadConfig_DisabledByDefault: no env → not requested, idles, no backend connect.
 func TestLoadConfig_DisabledByDefault(t *testing.T) {
 	t.Setenv(envEnabled, "")
-	_, enabled := LoadConfig()
-	if enabled {
-		t.Fatalf("producer must be disabled by default (zero production risk)")
+	_, requested := LoadConfig()
+	if requested {
+		t.Fatalf("producer must be off by default (zero production risk)")
 	}
 }
 
-// TestLoadConfig_EnabledRequiresAllBackends: enabled flag alone is not enough.
-func TestLoadConfig_EnabledRequiresAllBackends(t *testing.T) {
+// TestLoadConfig_RequestedIsMasterSwitchOnly: PRODUCER_ENABLED alone flips
+// "requested" true — config completeness is the caller's Validate() concern, NOT
+// folded into the master switch (so an enabled-but-misconfigured producer
+// fail-fasts instead of silently idling "ready").
+func TestLoadConfig_RequestedIsMasterSwitchOnly(t *testing.T) {
+	// Enabled but NO backends set: still requested=true (caller must Validate).
 	t.Setenv(envEnabled, "true")
 	t.Setenv(envMySQLDSN, "")
 	t.Setenv(envBrokers, "")
 	t.Setenv(envRedisAddr, "")
-	if _, enabled := LoadConfig(); enabled {
-		t.Fatalf("must stay disabled without DSN/brokers/redis")
+	cfg, requested := LoadConfig()
+	if !requested {
+		t.Fatalf("PRODUCER_ENABLED=true must report requested=true regardless of backend config")
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("a requested-but-misconfigured producer must fail Validate (not silently idle)")
 	}
 
+	// All backends set: requested + valid.
 	t.Setenv(envMySQLDSN, "user:pass@tcp(h:3306)/db")
 	t.Setenv(envBrokers, "localhost:9092")
 	t.Setenv(envRedisAddr, "localhost:6379")
-	cfg, enabled := LoadConfig()
-	if !enabled {
-		t.Fatalf("must be enabled when DSN+brokers+redis all set")
+	cfg, requested = LoadConfig()
+	if !requested {
+		t.Fatalf("must be requested when enabled")
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("validate: %v", err)

--- a/internal/producer/dlq.go
+++ b/internal/producer/dlq.go
@@ -1,0 +1,91 @@
+package producer
+
+// DLQEnvelope is the producer-specific dead-letter record.
+//
+// The body topic carries the octo-lib searchmsg.Message contract (a clean,
+// indexable shape the es-indexer consumer reads). A DLQ record has a different
+// job: forensic triage + replay. Serializing dead-lettered rows as a bare
+// searchmsg.Message (the pre-envelope behavior) dropped the context an operator
+// needs to understand and replay a poison row — WHY it failed, the raw source
+// payload, and which shard row it came from. This envelope captures that.
+//
+// Shape rationale (kept consistent with the other DLQ schemas in this repo so a
+// triage tool can reason across all three): the realtime consumer's dlqRecord
+// (internal/consumer) and the backfill dlqRecord (internal/backfill) both key on
+// {reason, source locator, raw bytes, timestamps}. This producer envelope mirrors
+// that vocabulary — reason / shard_table / source_id / message_id / raw_payload /
+// created_at — rather than reusing the body contract.
+//
+// It is intentionally NOT a searchmsg.Message: the DLQ stream is terminal (the
+// es-indexer consumer never reads it), so the envelope is free to diverge from
+// the body contract and optimize for replay instead of indexing.
+type DLQEnvelope struct {
+	// SchemaVersion identifies the DLQ envelope shape. Independent of the body
+	// contract's searchmsg.SchemaVersion so the two can evolve separately.
+	SchemaVersion int `json:"schema_version"`
+
+	// Reason is the machine-readable dead-letter cause (see dlqReason* below),
+	// the primary triage key.
+	Reason string `json:"reason"`
+
+	// ── source locator (replay: re-read this exact row) ──────────────────────
+	// ShardTable is the source message shard the row was read from.
+	ShardTable string `json:"shard_table"`
+	// SourceID is the source row auto-increment id (message.id) within ShardTable.
+	SourceID int64 `json:"source_id"`
+	// MessageID is the business message id (= the would-be ES _id / Kafka key).
+	// May be empty for a malformed row; SourceID+ShardTable still locate it.
+	MessageID string `json:"message_id"`
+	// ChannelID / ChannelType carry routing context (omitted when empty).
+	ChannelID   string `json:"channel_id,omitempty"`
+	ChannelType int    `json:"channel_type,omitempty"`
+
+	// ── forensic payload (triage: see what could not be parsed) ──────────────
+	// RawPayload is the original source payload bytes, preserved verbatim so a
+	// replay/triage tool can re-attempt extraction or inspect the anomaly.
+	RawPayload []byte `json:"raw_payload"`
+
+	// ── timestamps ───────────────────────────────────────────────────────────
+	// CreatedAt is the source row created_at (epoch seconds) — windowed triage.
+	CreatedAt int64 `json:"created_at"`
+	// MsgTimestamp is the source send time (epoch seconds), when present.
+	MsgTimestamp int64 `json:"msg_timestamp,omitempty"`
+	// ProducedAt is when this DLQ record was produced (epoch seconds). Stamped at
+	// produce time, not at extraction time, so planChunk stays a pure function.
+	ProducedAt int64 `json:"produced_at"`
+}
+
+// dlqSchemaVersion is the current DLQEnvelope schema version.
+const dlqSchemaVersion = 1
+
+// Dead-letter reasons (machine-readable triage keys). The producer namespaces
+// them so a shared triage tool can tell producer DLQ rows apart from the
+// consumer / backfill ones.
+const (
+	// dlqReasonPayloadUnparseable: a non-encrypted message whose payload is not
+	// valid JSON / is an empty object (a genuine anomaly — encrypted messages are
+	// raw_excluded on the body topic, never dead-lettered).
+	dlqReasonPayloadUnparseable = "producer_payload_unparseable"
+	// dlqReasonVisibilityUntrusted: the visibility ACL could not be trusted
+	// (fail-closed #1124 guard) — the row is dead-lettered rather than written
+	// with empty visibles (which the reader would treat as fail-OPEN).
+	dlqReasonVisibilityUntrusted = "producer_visibility_untrusted"
+)
+
+// newDLQEnvelope builds a dead-letter envelope from a source row + reason. It is
+// a pure function (no clock): ProducedAt is stamped later, at produce time, by
+// the Kafka sink — keeping planChunk deterministic and unit-testable.
+func newDLQEnvelope(table string, row *srcMessageRow, reason string) DLQEnvelope {
+	return DLQEnvelope{
+		SchemaVersion: dlqSchemaVersion,
+		Reason:        reason,
+		ShardTable:    table,
+		SourceID:      row.ID,
+		MessageID:     row.MessageID,
+		ChannelID:     row.ChannelID,
+		ChannelType:   int(row.ChannelType),
+		RawPayload:    row.Payload,
+		CreatedAt:     row.CreatedUnix,
+		MsgTimestamp:  row.Timestamp,
+	}
+}

--- a/internal/producer/dlq_test.go
+++ b/internal/producer/dlq_test.go
@@ -1,0 +1,82 @@
+package producer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDLQEnvelope_ReasonMapping pins the dead-letter reason returned by
+// extractMessage for each genuine-anomaly path.
+func TestDLQEnvelope_ReasonMapping(t *testing.T) {
+	// bad JSON / empty map → payload unparseable.
+	badJSON := &srcMessageRow{MessageID: "m-bad", Payload: []byte("{not json")}
+	if _, outcome, reason := extractMessage(badJSON); outcome != outcomeDLQ || reason != dlqReasonPayloadUnparseable {
+		t.Fatalf("bad json: outcome=%v reason=%q, want DLQ/%s", outcome, reason, dlqReasonPayloadUnparseable)
+	}
+
+	// non-DLQ paths must carry an empty reason.
+	okRow := &srcMessageRow{MessageID: "m-ok", ChannelType: 2, Payload: []byte(`{"type":1,"content":"hi"}`)}
+	if _, outcome, reason := extractMessage(okRow); outcome != outcomeOK || reason != "" {
+		t.Fatalf("ok row: outcome=%v reason=%q, want OK/empty", outcome, reason)
+	}
+}
+
+// TestDLQEnvelope_VisibilityUntrusted runs the shared fail-closed vectors and
+// asserts the ones that DLQ carry the visibility-untrusted reason — so triage can
+// tell a fail-closed ACL drop apart from a malformed payload.
+func TestDLQEnvelope_VisibilityUntrusted(t *testing.T) {
+	// A row with a present-but-empty visibles list is the canonical fail-closed
+	// case (reader would treat empty visibles as fail-OPEN, so it is dead-lettered).
+	row := &srcMessageRow{MessageID: "m-vis", ChannelType: 2, Payload: []byte(`{"type":99,"content":"x","visibles":[]}`)}
+	_, outcome, reason := extractMessage(row)
+	if outcome != outcomeDLQ {
+		t.Fatalf("empty-visibles must DLQ, got %v", outcome)
+	}
+	if reason != dlqReasonVisibilityUntrusted {
+		t.Fatalf("empty-visibles reason = %q, want %q", reason, dlqReasonVisibilityUntrusted)
+	}
+}
+
+// TestDLQEnvelope_BuildAndMarshal locks the envelope build + JSON shape (the
+// forensic fields the source contract dropped: reason / raw payload / source
+// locator), and confirms ProducedAt is left for the sink (planChunk stays pure).
+func TestDLQEnvelope_BuildAndMarshal(t *testing.T) {
+	row := &srcMessageRow{
+		ID: 42, MessageID: "msg-42", ChannelID: "c1", ChannelType: 2,
+		Timestamp: 111, CreatedUnix: 222, Payload: []byte(`{"broken`),
+	}
+	env := newDLQEnvelope("message3", row, dlqReasonPayloadUnparseable)
+	if env.SchemaVersion != dlqSchemaVersion {
+		t.Fatalf("schema_version = %d, want %d", env.SchemaVersion, dlqSchemaVersion)
+	}
+	if env.ShardTable != "message3" || env.SourceID != 42 || env.MessageID != "msg-42" {
+		t.Fatalf("source locator wrong: %+v", env)
+	}
+	if env.ChannelID != "c1" || env.ChannelType != 2 {
+		t.Fatalf("routing context wrong: %+v", env)
+	}
+	if string(env.RawPayload) != `{"broken` {
+		t.Fatalf("raw payload not preserved: %q", env.RawPayload)
+	}
+	if env.CreatedAt != 222 || env.MsgTimestamp != 111 {
+		t.Fatalf("timestamps wrong: %+v", env)
+	}
+	if env.ProducedAt != 0 {
+		t.Fatalf("ProducedAt must be stamped by the sink, not at build time, got %d", env.ProducedAt)
+	}
+
+	// JSON shape: forensic fields present + snake_case keys.
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"schema_version", "reason", "shard_table", "source_id", "message_id", "raw_payload", "created_at", "produced_at"} {
+		if _, ok := m[k]; !ok {
+			t.Fatalf("dlq envelope JSON missing key %q: %s", k, b)
+		}
+	}
+}

--- a/internal/producer/etl.go
+++ b/internal/producer/etl.go
@@ -167,7 +167,7 @@ func runChunk(ctx context.Context, store Store, sink Sink, table string, cutoff 
 			table, bad, rows[bad-1].ID, rows[bad].ID)
 	}
 
-	plan := planChunk(rows, cutoff)
+	plan := planChunk(table, rows, cutoff)
 	if !plan.advanced {
 		// Head row not yet stable: do not advance this round; wait for it to age lag.
 		return plan, 0, nil

--- a/internal/producer/etl_test.go
+++ b/internal/producer/etl_test.go
@@ -75,7 +75,7 @@ func (f *fakeStore) AdvanceCursor(_ context.Context, table string, expected, new
 type fakeSink struct {
 	mu       sync.Mutex
 	main     []searchmsg.Message
-	dlq      []searchmsg.Message
+	dlq      []DLQEnvelope
 	mainErr  error
 	dlqErr   error
 	closeErr error
@@ -91,12 +91,12 @@ func (s *fakeSink) ProduceBatch(_ context.Context, msgs []searchmsg.Message) err
 	return nil
 }
 
-func (s *fakeSink) ProduceDLQ(_ context.Context, msgs []searchmsg.Message) error {
+func (s *fakeSink) ProduceDLQ(_ context.Context, envelopes []DLQEnvelope) error {
 	if s.dlqErr != nil {
 		return s.dlqErr
 	}
 	s.mu.Lock()
-	s.dlq = append(s.dlq, msgs...)
+	s.dlq = append(s.dlq, envelopes...)
 	s.mu.Unlock()
 	return nil
 }
@@ -264,7 +264,7 @@ func (b *blockingSinkT) ProduceBatch(context.Context, []searchmsg.Message) error
 	<-b.release
 	return nil
 }
-func (b *blockingSinkT) ProduceDLQ(context.Context, []searchmsg.Message) error { return nil }
+func (b *blockingSinkT) ProduceDLQ(context.Context, []DLQEnvelope) error { return nil }
 func (b *blockingSinkT) Close() error                                          { return nil }
 
 // TestPlanChunk_DLQRouting: bad-json row routed to dlq, cursor watermark counts it.
@@ -275,11 +275,29 @@ func TestPlanChunk_DLQRouting(t *testing.T) {
 		textRow(1, "ok", cutoff-10),
 		{ID: 2, MessageID: "1002", ChannelType: 2, Payload: []byte("{bad"), CreatedUnix: cutoff - 10},
 	}
-	plan := planChunk(rows, cutoff)
+	plan := planChunk("message", rows, cutoff)
 	if len(plan.main) != 1 || len(plan.dlq) != 1 {
 		t.Fatalf("want 1 main + 1 dlq, got main=%d dlq=%d", len(plan.main), len(plan.dlq))
 	}
 	if plan.maxID != 2 || !plan.advanced {
 		t.Fatalf("watermark must include the DLQ row id=2, got maxID=%d advanced=%v", plan.maxID, plan.advanced)
+	}
+	// 🟡 The DLQ entry must be a forensic envelope carrying the source locator +
+	// reason + raw payload, not a bare body contract.
+	dl := plan.dlq[0]
+	if dl.ShardTable != "message" || dl.SourceID != 2 || dl.MessageID != "1002" {
+		t.Fatalf("dlq envelope source locator wrong: %+v", dl)
+	}
+	if dl.Reason != dlqReasonPayloadUnparseable {
+		t.Fatalf("dlq reason = %q, want %q", dl.Reason, dlqReasonPayloadUnparseable)
+	}
+	if string(dl.RawPayload) != "{bad" {
+		t.Fatalf("dlq envelope must preserve the raw payload, got %q", dl.RawPayload)
+	}
+	if dl.SchemaVersion != dlqSchemaVersion {
+		t.Fatalf("dlq envelope schema_version = %d, want %d", dl.SchemaVersion, dlqSchemaVersion)
+	}
+	if dl.ProducedAt != 0 {
+		t.Fatalf("planChunk must stay pure (no clock): ProducedAt should be 0, got %d", dl.ProducedAt)
 	}
 }

--- a/internal/producer/extract.go
+++ b/internal/producer/extract.go
@@ -60,14 +60,19 @@ type srcMessageRow struct {
 }
 
 // extractMessage enriches one source row into the Kafka body contract
-// (searchmsg.Message) + a three-state outcome.
+// (searchmsg.Message) + a three-state outcome + a dead-letter reason.
+//
+// The third return value is the machine-readable DLQ reason (one of the
+// dlqReason* constants); it is non-empty ONLY when outcome == outcomeDLQ and is
+// "" otherwise. The caller (planChunk) uses it to build a forensic DLQEnvelope —
+// keeping the WHY of a dead-letter next to the row instead of re-deriving it.
 //
 // Branch-for-branch aligned with octo-server/modules/searchetl/payload.go:
 //   - Signal-encrypted (setting bit OR signal column) → raw_excluded (do not try
 //     to parse the ciphertext, avoid misclassifying it as broken JSON → DLQ).
 //     spaceId/visibles stay empty (reader fail-closed, safe — body is excluded).
 //   - non-Signal → payload should be plaintext JSON; parse failure / empty map
-//     (a genuine anomaly) → DLQ.
+//     (a genuine anomaly) → DLQ (reason: payload unparseable).
 //   - on parse success, classify by type (tolerating float64/int/json.Number):
 //     · type=Text with string content → take it as the body (outcomeOK).
 //     · non-Text or non-string content → conservative raw_excluded.
@@ -76,9 +81,10 @@ type srcMessageRow struct {
 // non-encrypted messages we additionally extract SpaceID/Visibles via the SHARED
 // octo-lib searchmsg.ExtractVisibility. If visibility cannot be trusted (payload
 // not a JSON object, visibles present-but-unparseable or valid-but-empty) → the
-// whole row goes to DLQ; we NEVER write empty Visibles (the reader treats empty
-// visibles as fail-OPEN). MessageSeq comes from the message.message_seq column.
-func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
+// whole row goes to DLQ (reason: visibility untrusted); we NEVER write empty
+// Visibles (the reader treats empty visibles as fail-OPEN). MessageSeq comes
+// from the message.message_seq column.
+func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome, string) {
 	msg := searchmsg.Message{
 		SchemaVersion: searchmsg.SchemaVersion,
 		MessageID:     row.MessageID,
@@ -96,14 +102,14 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 		// not an anomaly. spaceId/visibles stay empty (reader fail-closed, safe).
 		msg.RawExcluded = true
 		msg.Content = nil
-		return msg, outcomeRawExcluded
+		return msg, outcomeRawExcluded, ""
 	}
 
 	var m map[string]interface{}
 	if err := json.Unmarshal(row.Payload, &m); err != nil || len(m) == 0 {
 		// Non-encrypted message should be plaintext JSON; parse failure / empty
 		// map is a genuine anomaly → DLQ (cursor still advances).
-		return msg, outcomeDLQ
+		return msg, outcomeDLQ, dlqReasonPayloadUnparseable
 	}
 
 	// 🔴 Fail-closed visibility (access-control ACL): if it cannot be trusted →
@@ -111,7 +117,7 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 	// type does not drag down valid visibles (ExtractVisibility isolates that).
 	spaceID, visibles, verr := searchmsg.ExtractVisibility(row.Payload)
 	if verr != nil {
-		return msg, outcomeDLQ
+		return msg, outcomeDLQ, dlqReasonVisibilityUntrusted
 	}
 	msg.SpaceID = spaceID
 	msg.Visibles = visibles
@@ -124,7 +130,7 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 		// phase, raw_excluded.
 		msg.RawExcluded = true
 		msg.Content = nil
-		return msg, outcomeRawExcluded
+		return msg, outcomeRawExcluded, ""
 	}
 
 	c, ok := m["content"].(string)
@@ -133,12 +139,12 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome) {
 		// conservative raw_excluded, do not coerce.
 		msg.RawExcluded = true
 		msg.Content = nil
-		return msg, outcomeRawExcluded
+		return msg, outcomeRawExcluded, ""
 	}
 
 	content := c
 	msg.Content = &content
-	return msg, outcomeOK
+	return msg, outcomeOK, ""
 }
 
 // isSignalEncrypted reports whether a message is Signal-encrypted: the setting

--- a/internal/producer/extract_test.go
+++ b/internal/producer/extract_test.go
@@ -43,7 +43,7 @@ func TestExtract_ConstantsMatchOctoLib(t *testing.T) {
 // TestExtract_Text normal text → outcomeOK, content taken, not raw_excluded.
 func TestExtract_Text(t *testing.T) {
 	row := &srcMessageRow{MessageID: "m1", ChannelType: 2, Payload: textPayload(t, "hello 世界")}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeOK {
 		t.Fatalf("want outcomeOK, got %v", outcome)
 	}
@@ -61,7 +61,7 @@ func TestExtract_Text(t *testing.T) {
 // TestExtract_SignalViaSetting Signal (setting bit) → raw_excluded, content nil.
 func TestExtract_SignalViaSetting(t *testing.T) {
 	row := &srcMessageRow{MessageID: "m2", Setting: signalSettingByte(), Payload: []byte("ENCRYPTED-NOT-JSON")}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeRawExcluded || !msg.RawExcluded || msg.Content != nil {
 		t.Fatalf("signal msg must be raw_excluded with nil content: outcome=%v msg=%+v", outcome, msg)
 	}
@@ -70,7 +70,7 @@ func TestExtract_SignalViaSetting(t *testing.T) {
 // TestExtract_SignalViaColumn Signal (signal column) → raw_excluded even if JSON.
 func TestExtract_SignalViaColumn(t *testing.T) {
 	row := &srcMessageRow{MessageID: "m3", Signal: 1, Payload: textPayload(t, "ignored")}
-	_, outcome := extractMessage(row)
+	_, outcome, _ := extractMessage(row)
 	if outcome != outcomeRawExcluded {
 		t.Fatalf("signal-column msg must be raw_excluded, got %v", outcome)
 	}
@@ -80,7 +80,7 @@ func TestExtract_SignalViaColumn(t *testing.T) {
 func TestExtract_NonTextRawExcluded(t *testing.T) {
 	b := mustJSON(t, map[string]interface{}{"type": 2, "url": "http://x/y.png"})
 	row := &srcMessageRow{MessageID: "m4", Payload: b}
-	_, outcome := extractMessage(row)
+	_, outcome, _ := extractMessage(row)
 	if outcome != outcomeRawExcluded {
 		t.Fatalf("want outcomeRawExcluded for non-text, got %v", outcome)
 	}
@@ -90,7 +90,7 @@ func TestExtract_NonTextRawExcluded(t *testing.T) {
 func TestExtract_TextContentObjectRawExcluded(t *testing.T) {
 	b := mustJSON(t, map[string]interface{}{"type": contentTypeText, "content": map[string]interface{}{"k": "v"}})
 	row := &srcMessageRow{MessageID: "m5", Payload: b}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeRawExcluded || msg.Content != nil {
 		t.Fatalf("want raw_excluded nil content for text/object content, got outcome=%v content=%v", outcome, msg.Content)
 	}
@@ -99,7 +99,7 @@ func TestExtract_TextContentObjectRawExcluded(t *testing.T) {
 // TestExtract_NonSignalBadJSON non-encrypted invalid JSON → outcomeDLQ.
 func TestExtract_NonSignalBadJSON(t *testing.T) {
 	row := &srcMessageRow{MessageID: "m6", Payload: []byte("{not valid json")}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeDLQ || msg.MessageID != "m6" {
 		t.Fatalf("want outcomeDLQ keeping message_id, got outcome=%v id=%q", outcome, msg.MessageID)
 	}
@@ -108,7 +108,7 @@ func TestExtract_NonSignalBadJSON(t *testing.T) {
 // TestExtract_EmptyMapDLQ empty JSON object → DLQ.
 func TestExtract_EmptyMapDLQ(t *testing.T) {
 	row := &srcMessageRow{MessageID: "m6b", Payload: []byte("{}")}
-	if _, outcome := extractMessage(row); outcome != outcomeDLQ {
+	if _, outcome, _ := extractMessage(row); outcome != outcomeDLQ {
 		t.Fatalf("empty map payload must be DLQ, got %v", outcome)
 	}
 }
@@ -116,7 +116,7 @@ func TestExtract_EmptyMapDLQ(t *testing.T) {
 // TestExtract_TypeAsFloat tolerate type as float64 (json default).
 func TestExtract_TypeAsFloat(t *testing.T) {
 	row := &srcMessageRow{MessageID: "m7", Payload: []byte(`{"type":1,"content":"x"}`)}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeOK || msg.Content == nil || *msg.Content != "x" {
 		t.Fatalf("float64 type Text not handled: outcome=%v content=%v", outcome, msg.Content)
 	}
@@ -125,7 +125,7 @@ func TestExtract_TypeAsFloat(t *testing.T) {
 // TestExtract_MessageSeqEnriched messageSeq is taken from the column into the contract.
 func TestExtract_MessageSeqEnriched(t *testing.T) {
 	row := &srcMessageRow{MessageID: "seq", MessageSeq: 4242, ChannelType: 2, Payload: []byte(`{"type":1,"content":"x"}`)}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeOK {
 		t.Fatalf("want outcomeOK, got %v", outcome)
 	}
@@ -137,7 +137,7 @@ func TestExtract_MessageSeqEnriched(t *testing.T) {
 // TestExtract_ValidVisiblesEnriched valid targeted system msg → main + visibles in contract.
 func TestExtract_ValidVisiblesEnriched(t *testing.T) {
 	row := &srcMessageRow{MessageID: "vis-ok", ChannelType: 2, Payload: []byte(`{"type":99,"content":"removed","visibles":["u_alice","u_bob"]}`)}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome == outcomeDLQ {
 		t.Fatalf("valid targeted system msg must not DLQ, got %v", outcome)
 	}
@@ -149,7 +149,7 @@ func TestExtract_ValidVisiblesEnriched(t *testing.T) {
 // TestExtract_NormalGroupChatBroadcast no visibles key → main broadcast, empty visibles.
 func TestExtract_NormalGroupChatBroadcast(t *testing.T) {
 	row := &srcMessageRow{MessageID: "chat", ChannelType: 2, Payload: []byte(`{"type":1,"content":"hi all"}`)}
-	msg, outcome := extractMessage(row)
+	msg, outcome, _ := extractMessage(row)
 	if outcome != outcomeOK {
 		t.Fatalf("normal group chat must be outcomeOK (broadcast), got %v", outcome)
 	}
@@ -166,7 +166,7 @@ func TestExtract_SharedFailClosedVectors(t *testing.T) {
 		v := v
 		t.Run(v.Name, func(t *testing.T) {
 			row := &srcMessageRow{MessageID: "m_" + v.Name, ChannelType: 2, Payload: v.Payload}
-			msg, outcome := extractMessage(row)
+			msg, outcome, _ := extractMessage(row)
 			if v.WantErr {
 				if outcome != outcomeDLQ {
 					t.Fatalf("%s: fail-closed must route to DLQ, got outcome=%v visibles=%v", v.Name, outcome, msg.Visibles)

--- a/internal/producer/kafka.go
+++ b/internal/producer/kafka.go
@@ -13,9 +13,13 @@ import (
 // Sink abstracts batch delivery to Kafka (implemented by *KafkaProducer), so the
 // chunk pipeline can be unit-tested with a fake sink: the whole batch is produced
 // outside the DB read transaction and any failure leaves the cursor un-advanced.
+//
+// The body batch is searchmsg.Message contracts; the DLQ batch is forensic
+// DLQEnvelope records (reason + raw payload + source locator), a different shape
+// optimized for triage/replay rather than indexing.
 type Sink interface {
 	ProduceBatch(ctx context.Context, msgs []searchmsg.Message) error
-	ProduceDLQ(ctx context.Context, msgs []searchmsg.Message) error
+	ProduceDLQ(ctx context.Context, envelopes []DLQEnvelope) error
 	Close() error
 }
 
@@ -72,10 +76,30 @@ func (p *KafkaProducer) ProduceBatch(ctx context.Context, msgs []searchmsg.Messa
 	return produce(ctx, p.writer, p.topic, msgs)
 }
 
-// ProduceDLQ produces a DLQ batch. A DLQ write failure also returns an error so
-// the whole chunk does not advance — never "DLQ write failed → silently drop".
-func (p *KafkaProducer) ProduceDLQ(ctx context.Context, msgs []searchmsg.Message) error {
-	return produce(ctx, p.dlqWriter, p.dlqTopic, msgs)
+// ProduceDLQ produces a DLQ batch of forensic envelopes. A DLQ write failure also
+// returns an error so the whole chunk does not advance — never "DLQ write failed →
+// silently drop". The Kafka key stays message_id (so DLQ records for the same row
+// land in the same partition and replay tooling can co-locate by key); ProducedAt
+// is stamped here, at produce time, keeping planChunk a pure function.
+func (p *KafkaProducer) ProduceDLQ(ctx context.Context, envelopes []DLQEnvelope) error {
+	if len(envelopes) == 0 {
+		return nil
+	}
+	now := time.Now().Unix()
+	kmsgs := make([]kafka.Message, 0, len(envelopes))
+	for i := range envelopes {
+		envelopes[i].ProducedAt = now
+		b, err := json.Marshal(envelopes[i])
+		if err != nil {
+			return fmt.Errorf("producer: marshal dlq envelope (table=%s id=%d msg=%s): %w",
+				envelopes[i].ShardTable, envelopes[i].SourceID, envelopes[i].MessageID, err)
+		}
+		kmsgs = append(kmsgs, kafka.Message{Key: []byte(envelopes[i].MessageID), Value: b})
+	}
+	if err := p.dlqWriter.WriteMessages(ctx, kmsgs...); err != nil {
+		return fmt.Errorf("producer: produce dlq batch to %s: %w", p.dlqTopic, err)
+	}
+	return nil
 }
 
 func produce(ctx context.Context, w *kafka.Writer, topic string, msgs []searchmsg.Message) error {

--- a/internal/producer/scheduler.go
+++ b/internal/producer/scheduler.go
@@ -9,10 +9,11 @@ import (
 // Scheduler drives the slow-cursor incremental extraction on a fixed tick.
 //
 // This is the slim mirror of the source module's scheduler: a minute-grade
-// time.Ticker, each tick calling RunIncremental once. Slow cursor only (lag held
-// at the conservative default). Cross-replica mutual exclusion / lock-loss abort
-// is handled inside RunIncremental's Redis run-lock; the scheduler only owns
-// "fire on cadence + lifecycle".
+// time.Ticker, each tick calling RunIncremental once. It runs one round
+// immediately on Start (no wait for the first interval), then ticks on cadence.
+// Slow cursor only (lag held at the conservative default). Cross-replica mutual
+// exclusion / lock-loss abort is handled inside RunIncremental's Redis run-lock;
+// the scheduler only owns "fire on cadence + lifecycle".
 type Scheduler struct {
 	interval time.Duration
 	tables   []string
@@ -60,6 +61,17 @@ func (s *Scheduler) loop(ctx context.Context) {
 	defer close(s.done)
 	t := time.NewTicker(s.interval)
 	defer t.Stop()
+	// 🔵 Run one round immediately on start, before waiting out the first ticker
+	// interval. Otherwise the producer idles for a full tick (default 60s) after
+	// boot before it streams anything — slow first-light on deploy and, more
+	// importantly, a long blind window during the runtime cut-over when the
+	// independent producer is expected to pick up the cursor "within seconds"
+	// (gate A2). The run-lock + cursor CAS + idempotent sink make an extra early
+	// round safe; respect ctx cancellation so a fast SIGTERM right after Start
+	// does not still fire a round.
+	if ctx.Err() == nil {
+		s.tick(ctx)
+	}
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/producer/scheduler_test.go
+++ b/internal/producer/scheduler_test.go
@@ -59,3 +59,45 @@ func TestScheduler_StopWithoutStart(t *testing.T) {
 	s := NewScheduler(time.Second, nil, func(context.Context, []string) error { return nil }, nil, nil)
 	s.Stop() // must not panic / block
 }
+
+// TestScheduler_FirstTickImmediate: the scheduler runs one round immediately on
+// Start, well before the first ticker interval elapses (🔵 no slow first-light /
+// no long blind window at cut-over).
+func TestScheduler_FirstTickImmediate(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	// A long interval: if the first tick waited for the ticker, this test would
+	// time out instead of seeing a tick within the deadline.
+	s := NewScheduler(10*time.Second, []string{"message"}, func(context.Context, []string) error {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+		return nil
+	}, nil, nil)
+	s.Start()
+	defer s.Stop()
+	select {
+	case <-fired:
+		// Got the immediate first tick — good.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("scheduler did not run an immediate first tick (waited for the interval)")
+	}
+}
+
+// TestScheduler_NoTickIfCancelledBeforeStart: if the loop ctx is already done,
+// the immediate first tick is skipped (Stop right after Start must not fire).
+func TestScheduler_ImmediateTickRespectsFastStop(t *testing.T) {
+	var ticks atomic.Int32
+	s := NewScheduler(time.Hour, nil, func(context.Context, []string) error {
+		ticks.Add(1)
+		return nil
+	}, nil, nil)
+	s.Start()
+	s.Stop()
+	// At most one immediate tick may have raced in before Stop cancelled ctx; the
+	// invariant under test is simply that Start+Stop does not deadlock or panic and
+	// the ticker path never fires (interval is 1h).
+	if got := ticks.Load(); got > 1 {
+		t.Fatalf("expected at most the single immediate tick, got %d", got)
+	}
+}


### PR DESCRIPTION
## What

Two non-blocking refinements to the standalone `searchetl-producer` raised in
the #17 review, plus a small idle-posture fix so the service can be deployed
disabled-by-default. **No change to the body-topic contract or the correctness
path** (stability gate, cursor CAS, produce-before-advance, Redis run-lock,
idempotent sink).

### 1. Producer-specific forensic DLQ envelope 🟡
Dead-lettered rows were serialized as a bare `searchmsg.Message` (the body
contract), which dropped the context needed to triage/replay a poison row and
did not match the `{reason, source locator, raw bytes, timestamps}` vocabulary
the consumer (`internal/consumer`) and backfill (`internal/backfill`) DLQ
records already use.

- New `DLQEnvelope` carrying `reason`, `shard_table`, `source_id`, `message_id`,
  `raw_payload`, and timestamps.
- `extractMessage` now also returns a machine-readable reason
  (`producer_payload_unparseable` vs `producer_visibility_untrusted`) so triage
  can tell a malformed payload apart from a fail-closed ACL drop.
- The DLQ stream is terminal (es-indexer never reads it), so the envelope is free
  to diverge from the indexable body shape. `planChunk` stays a pure function:
  `produced_at` is stamped by the Kafka sink at produce time.
- DLQ write failures still fail the whole chunk (never silently drop); the Kafka
  key stays `message_id`.

### 2. Scheduler runs its first tick on start 🔵
The scheduler waited a full ticker interval (default 60s) before its first round
— slow first-light on deploy and a long blind window at the runtime cut-over
(the cursor is expected to advance within seconds). It now runs one round
immediately on `Start`, then ticks on cadence. The run-lock + cursor CAS +
idempotent sink make the early round safe; it respects ctx cancellation so a
fast shutdown right after `Start` fires nothing.

### 3. Idle-posture health endpoints (enables opt-in deploy)
For the "deployed but off" posture (`PRODUCER_ENABLED` unset/false), the binary
now serves `/healthz` + `/readyz` (both 200, idling-is-ready) so a disabled pod
does not crashloop under HTTP liveness/readiness probes. `LoadConfig` returns
the master switch alone; `main` fail-fasts when `PRODUCER_ENABLED=true` but the
config is incomplete (a requested producer must not silently idle "ready" and
no-op a cut-over). Still connects to no backend while idle.

## Tests
- DLQ reason mapping + envelope shape/marshal; `planChunk` DLQ-envelope assertions.
- Scheduler immediate-first-tick; idle obs health/ready.
- `LoadConfig` master-switch-only semantics + requested-but-misconfigured fails Validate.
- e2e producer harness now decodes + asserts the forensic envelope on the DLQ topic.

## Review
- `go build` / `go vet` / `go test -race -shuffle=on ./...`: all green
- golangci-lint v2.2.0: 0 issues
- Independent model review (gpt-5.5, high): 2 findings, both fixed and confirmed RESOLVED on re-review.

## Pairs with
The octo-deployment change that wires this service into the `search` profile
(opt-in, OFF by default). **Merge this first** so the published image carries the
forensic DLQ envelope + first-tick behavior the deployment references.
