### PR TITLE
feat(es-indexer): CDC-style writes — full payload projection + payloadRaw + consumer-side visibility fail-closed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Mininglamp-OSS/octo-search-indexer
 go 1.25
 
 require (
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622121821-8774629e1a69
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622132305-e8f7feac26e7
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/opensearch-project/opensearch-go/v3 v3.1.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Mininglamp-OSS/octo-search-indexer
 go 1.25
 
 require (
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618092744-45384c784102
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622121821-8774629e1a69
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/opensearch-project/opensearch-go/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622121821-8774629e1a69 h1:1t1kpm1e182iFIVCbACaPw4oJLhNJZjCO0WgZ7VAihI=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622121821-8774629e1a69/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622132305-e8f7feac26e7 h1:Z6rtBRWGXc7zygmjP/8gR+JYz+F/k+JLAxRAIvwlXvU=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622132305-e8f7feac26e7/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618092744-45384c784102 h1:Alkam9eQ9y2alz9Y0vo3TRVoyc3OMpgaLQgTmgg1RKU=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260618092744-45384c784102/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622121821-8774629e1a69 h1:1t1kpm1e182iFIVCbACaPw4oJLhNJZjCO0WgZ7VAihI=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260622121821-8774629e1a69/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/internal/backfill/doc_enrich.go
+++ b/internal/backfill/doc_enrich.go
@@ -1,61 +1,59 @@
 package backfill
 
 import (
+	"encoding/json"
+
 	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 )
 
 // docFromRow 把一行源消息抽取为 reader 可读的 esindex.Doc（backfill 富化路径）。
 //
-// 这是分叉 B 在 backfill 侧的核心：backfill 读**原始 MySQL payload**，因此能自源填全
-// reader 必读但 Kafka 契约缺失的三字段：
-//   - spaceId：从 payload.space_id 抽（octo-server 发送时由 enrichPayloadWithSpaceID 写入，
-//     p2p/group/topic 均经服务端权威注入）。reader 对 p2p 缺 spaceId 走 fail-closed。
-//   - visibles：从 payload.visibles 抽（群系统消息「仅管理员可见」白名单）。reader 缺则 fail-OPEN。
-//   - messageSeq：从 message 表 message_seq 列（reader channel_offset「清空会话」gate）。
+// 方案 B（CDC 式写入）：backfill 是**存量路径的 visibility 权威解析落点**（与实时路径的
+// consumer.processBatch 预检对称）。它读**原始 MySQL payload**，故能：
+//   - 把 RawPayload 整包带进契约 → esindex.DocFromMessage 走分支 A：buildPayloadFromRaw 全类型
+//     投影 + payloadRaw 留底（与实时增量同形态 doc，同 _id 幂等覆盖无害）。
+//   - 用 octo-lib searchmsg.ExtractVisibility（共享 fail-closed parser 单一真源）自源解析
+//     spaceId/visibles，**先回填进契约** msg.SpaceID/msg.Visibles，再交 DocFromMessage 消费。
+//     DocFromMessage 分支 A **不二次解析**（唯一权威落点在这里）。
+//   - messageSeq 从 message 表 message_seq 列。
 //
-// 正文 outcome（OK/RawExcluded/DLQ）完全复用 extractMessage 的口径（与实时 producer 一致），
-// 故 backfill 与实时增量对同一条消息产生**同形态 doc**（同 _id 幂等覆盖无害）。
+// 加密消息（密文）走分支 B：RawPayload=nil + RawExcluded=true，跳过解析、visibles 留空
+// （reader fail-closed 安全方向）。
 func docFromRow(row *srcMessageRow) (esindex.Doc, extractOutcome, error) {
 	msg, outcome := extractMessage(row)
 	if outcome == outcomeDLQ {
 		return esindex.Doc{}, outcome, nil
 	}
 
-	// 复用 esindex 的契约→Doc 转换（messageId 全精度 long / payload 嵌套 / 字段名对齐 reader）。
+	if !isSignalEncrypted(row) {
+		// 🔴 可见性解析口径的**单一真源**是 octo-lib searchmsg.ExtractVisibility（共享 fail-closed
+		// parser）。backfill 与实时跑同一 parser + 同一组 FailClosedVisibilityVectors()，锁口径防
+		// #1124 分叉。fail-CLOSED：可见性无法可信解析（payload 非 JSON 对象 / visibles 非数组 /
+		// valid-but-empty）→ **绝不**写空 visibles（reader fail-OPEN），该行落 DLQ。
+		// 注：space_id 的 JSON 类型怪异不触发此路径（ExtractVisibility 容忍隔离），不连累合法 visibles。
+		spaceID, visibles, verr := searchmsg.ExtractVisibility(row.Payload)
+		if verr != nil {
+			return esindex.Doc{}, outcomeDLQ, verr
+		}
+		// 先回填进契约（DocFromMessage 分支 A 直接消费，不二次解析）。
+		msg.SpaceID = spaceID
+		msg.Visibles = visibles
+		// 带 RawPayload 整包 → DocFromMessage 走分支 A 全类型投影 + payloadRaw 留底。
+		msg.RawPayload = json.RawMessage(row.Payload)
+	}
+
+	// 复用 esindex 的契约→Doc 转换（messageId 全精度 long / 全类型投影 / payloadRaw / 字段对齐 reader）。
 	doc, err := esindex.DocFromMessage(msg)
 	if err != nil {
 		// message_id 非数值：reader 读 long messageId 无法对齐 → 当真异常落 DLQ（不静默落 0）。
 		return esindex.Doc{}, outcomeDLQ, err
 	}
 
-	// 富化 reader 必读的安全/正确性字段（仅 backfill 可做：见上）。
+	// 富化 messageSeq（仅 backfill 可从 message 表自源填）。
 	doc.MessageSeq = uint64(row.MessageSeq)
 	if row.MessageSeq < 0 {
 		doc.MessageSeq = 0
-	}
-	// 加密消息 payload 是密文，不解析（与 extract 一致），spaceId/visibles 留空（reader fail-closed）。
-	if !isSignalEncrypted(row) {
-		// 🔴 可见性解析口径的**单一真源**是 octo-lib searchmsg.ExtractVisibility（票2 落地的共享
-		// fail-closed parser）。backfill 必须 import 它、而非自实现——producer 与 backfill 跑同一
-		// parser + 同一组 searchmsg.FailClosedVisibilityVectors()，锁口径防 #1124 在两仓分叉
-		// （验收门 ii）。共享 parser 比旧自实现更严：对 valid-but-empty visibles（键在但空数组 /
-		// null / 全非字符串）也 fail-closed，而旧自实现把这些当广播 fail-OPEN 放行。
-		spaceID, visibles, verr := searchmsg.ExtractVisibility(row.Payload)
-		if verr != nil {
-			// 🔴 fail-CLOSED：可见性是 access-control ACL。一旦它无法可信解析（payload 非 JSON 对象、
-			// visibles 非数组 / valid-but-empty 等结构性损坏），**绝不**写空 visibles —— 否则 reader
-			// 把空 visibles 当 fail-OPEN（群系统消息「仅管理员可见」白名单门被移除，普通成员能搜到
-			// 管理员可见消息）。这类行一律落 DLQ（永久跳过写入），把 ACL 解析失败显式暴露给对账门而非
-			// 静默塌掉。
-			//
-			// 注意：space_id 的 JSON 类型（数字/对象/上游漂移）**不**触发此路径——ExtractVisibility 把
-			// space_id 解成容忍类型，非字符串 space_id 退化为空 spaceId（reader p2p fail-closed，安全
-			// 方向），绝不因一个字段类型怪异连累合法的 visibles 一并清空（V3b fail-OPEN 的根因）。
-			return esindex.Doc{}, outcomeDLQ, verr
-		}
-		doc.SpaceID = spaceID
-		doc.Visibles = visibles
 	}
 	return doc, outcome, nil
 }

--- a/internal/backfill/runner.go
+++ b/internal/backfill/runner.go
@@ -80,6 +80,13 @@ func (r *Runner) Run(ctx context.Context) (Stats, error) {
 	if err := r.writer.EnsureIndex(ctx); err != nil {
 		return total, fmt.Errorf("backfill: ensure index: %w", err)
 	}
+	// 🔴 mapping-compat fail-closed 断言（§6.4）：方案 B 后 backfill 也写 payloadRaw / richText /
+	// mergeForward.msgs.{from,timestamp}。若目标索引未迁这些字段，dynamic:strict 会**永久拒收**
+	// 这些 doc（spill 进 DLQ + 推进 checkpoint，静默漏灌）。故扫描前与 live consumer 同样做断言，
+	// 缺字段则**拒启动**（不静默向 strict 索引灌 4xx），不在扫描后才发现全量塌。
+	if err := r.writer.AssertLiveMappingCompatible(ctx); err != nil {
+		return total, fmt.Errorf("backfill: mapping-compat assertion: %w", err)
+	}
 	for _, table := range r.cfg.Tables {
 		s, err := r.runTable(ctx, table)
 		total.add(s)

--- a/internal/backfill/runner_test.go
+++ b/internal/backfill/runner_test.go
@@ -62,8 +62,9 @@ func newFakeWriter() *fakeWriter {
 	}
 }
 
-func (w *fakeWriter) EnsureIndex(context.Context) error { return w.ensureErr }
-func (w *fakeWriter) Close() error                      { return nil }
+func (w *fakeWriter) EnsureIndex(context.Context) error                 { return w.ensureErr }
+func (w *fakeWriter) AssertLiveMappingCompatible(context.Context) error { return nil }
+func (w *fakeWriter) Close() error                                      { return nil }
 
 // Bulk 不被 backfill 路径调用（backfill 走 BulkDocs(docs)）；提供接口实现。
 func (w *fakeWriter) Bulk(_ context.Context, _ []searchmsg.Message) ([]esindex.BulkItemResult, error) {

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -112,7 +112,11 @@ func (p *Processor) fetchBatch(ctx context.Context) ([]fetchedMessage, error) {
 
 // processBatch 处理一批（C4 核心）：
 //  1. schema_version 校验：未知版本标记为毒丸（不进 bulk，直接 DLQ）。
-//  2. 对**尚未终态**的条目走 esindex bulk；毒丸（schema 非法 + bulk 4xx）按原序送 DLQ。
+//     1b. 🔴 visibility 预检 pass（方案 B §3.4，**visibility 解析的唯一权威落点**）：对分支 A
+//     （len(RawPayload)>0，非加密新形态）逐条调 searchmsg.ExtractVisibility fail-closed；失败者
+//     剔出 bulk + 落 DLQ(reason=visibility_untrusted, status=0)，绝不写空 visibles；成功者把
+//     解析值回填进 parsed[i].SpaceID/Visibles（下游 DocFromMessage 直接消费、不二次解析）。
+//  2. 对**尚未终态**的条目走 esindex bulk；毒丸（schema 非法 + visibility 失败 + bulk 4xx）按原序送 DLQ。
 //  3. 计算**每分区**连续可越过前缀并 commit（多分区各自推进，互不越权）。
 //  4. transient 条目**原地重试同一批**（退避后重跑 bulk，绝不拉新 offset）——直到本批无 transient。
 //     这保证 kafka 单调高水位 commit 永不越过未确认的 transient（杜绝丢消息）。
@@ -121,6 +125,7 @@ func (p *Processor) fetchBatch(ctx context.Context) ([]fetchedMessage, error) {
 func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) error {
 	n := len(batch)
 	schemaInvalid := make([]bool, n)
+	visibilityInvalid := make([]bool, n)
 	parsed := make([]searchmsg.Message, n)
 	for i := range batch {
 		msg, ok := decodeAndValidate(batch[i].Value)
@@ -129,6 +134,23 @@ func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) er
 			continue
 		}
 		parsed[i] = msg
+	}
+
+	// 🔴 visibility 预检 pass（§3.4，唯一权威解析落点）：只对分支 A（schema 合法且
+	// len(RawPayload)>0 = 非加密新形态；加密 RawPayload==nil 天然不入此集，无须看 RawExcluded）
+	// 跑 ExtractVisibility。失败 → 标 visibilityInvalid 剔出 bulk + 落 DLQ；成功 → 回填解析值。
+	for i := range batch {
+		if schemaInvalid[i] || len(parsed[i].RawPayload) == 0 {
+			continue
+		}
+		spaceID, visibles, verr := searchmsg.ExtractVisibility(parsed[i].RawPayload)
+		if verr != nil {
+			// fail-closed：可见性 ACL 不可信，绝不写空 visibles（reader fail-OPEN，#1124）。落 DLQ。
+			visibilityInvalid[i] = true
+			continue
+		}
+		parsed[i].SpaceID = spaceID
+		parsed[i].Visibles = visibles
 	}
 
 	dispositions := make([]itemDisposition, n)
@@ -149,7 +171,7 @@ func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) er
 		}
 
 		// 仅对仍 transient 的条目重跑（已 OK / 已进 DLQ 的不再处理）。
-		changed, err := p.resolvePass(ctx, batch, parsed, schemaInvalid, dispositions)
+		changed, err := p.resolvePass(ctx, batch, parsed, schemaInvalid, visibilityInvalid, dispositions)
 		if err != nil {
 			return err // DLQ 硬停 fatal：停 worker（不静默越过毒丸）
 		}
@@ -169,25 +191,38 @@ func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) er
 
 // resolvePass 对仍为 dispTransient 的条目跑一轮 bulk + DLQ 路由，就地更新 dispositions。
 // 返回 changed=是否有条目从 transient 转为终态（OK/DLQResolved）；error 仅当 DLQ 硬停逃逸（fatal）。
-func (p *Processor) resolvePass(ctx context.Context, batch []fetchedMessage, parsed []searchmsg.Message, schemaInvalid []bool, dispositions []itemDisposition) (bool, error) {
+func (p *Processor) resolvePass(ctx context.Context, batch []fetchedMessage, parsed []searchmsg.Message, schemaInvalid []bool, visibilityInvalid []bool, dispositions []itemDisposition) (bool, error) {
 	changed := false
 	// schema 非法的毒丸：直接送 DLQ（不进 bulk）。
 	for i := range batch {
 		if dispositions[i] != dispTransient || !schemaInvalid[i] {
 			continue
 		}
-		if err := p.routePoison(ctx, batch[i], esindex.BulkItemResult{Status: 0}, true); err != nil {
+		if err := p.routePoison(ctx, batch[i], esindex.BulkItemResult{Status: 0}, reasonSchemaInvalid); err != nil {
 			return changed, err
 		}
 		dispositions[i] = dispDLQResolved
 		changed = true
 	}
 
-	// 收集仍 transient 且 schema 合法的条目走 bulk。
+	// 🔴 visibility 失败的毒丸（§3.4）：bulk 之前剔出 + 落 DLQ(visibility_untrusted, status=0)，
+	// 绝不进 bulk、绝不写空 visibles。幂等卫与 schemaInvalid 毒丸块同构（重试每轮重跑，已终态跳过）。
+	for i := range batch {
+		if dispositions[i] != dispTransient || !visibilityInvalid[i] {
+			continue
+		}
+		if err := p.routePoison(ctx, batch[i], esindex.BulkItemResult{Status: 0}, reasonVisibilityUntrusted); err != nil {
+			return changed, err
+		}
+		dispositions[i] = dispDLQResolved
+		changed = true
+	}
+
+	// 收集仍 transient 且非毒丸（schema 合法 + visibility 通过）的条目走 bulk。
 	var toBulk []searchmsg.Message
 	bulkIdx := make([]int, 0, len(batch))
 	for i := range batch {
-		if dispositions[i] == dispTransient && !schemaInvalid[i] {
+		if dispositions[i] == dispTransient && !schemaInvalid[i] && !visibilityInvalid[i] {
 			toBulk = append(toBulk, parsed[i])
 			bulkIdx = append(bulkIdx, i)
 		}
@@ -213,7 +248,7 @@ func (p *Processor) resolvePass(ctx context.Context, batch []fetchedMessage, par
 			dispositions[idx] = dispOK
 			changed = true
 		case permanent:
-			if err := p.routePoison(ctx, batch[idx], res, false); err != nil {
+			if err := p.routePoison(ctx, batch[idx], res, reasonPermanent4xx); err != nil {
 				return changed, err
 			}
 			dispositions[idx] = dispDLQResolved
@@ -226,8 +261,8 @@ func (p *Processor) resolvePass(ctx context.Context, batch []fetchedMessage, par
 }
 
 // routePoison 把一条毒丸送 DLQ。DLQ 终态成功 → nil；硬停逃逸 → 返回 fatal error。
-func (p *Processor) routePoison(ctx context.Context, m fetchedMessage, res esindex.BulkItemResult, schemaInvalid bool) error {
-	rec := buildDLQRecord(schemaInvalid, m, res)
+func (p *Processor) routePoison(ctx context.Context, m fetchedMessage, res esindex.BulkItemResult, reason dlqReason) error {
+	rec := buildDLQRecord(reason, m, res)
 	if err := p.dlq.Send(ctx, rec); err != nil {
 		p.alert.Alert("dlq_hard_stop", fmt.Sprintf("offset=%d: %v", m.Offset, err))
 		return fmt.Errorf("consumer: DLQ terminal escape hard-stop at offset %d: %w", m.Offset, err)
@@ -246,6 +281,32 @@ func (p *Processor) commitPrefixes(ctx context.Context, batch []fetchedMessage, 
 	return nil
 }
 
+// dlqReason 是 consumer 侧毒丸落 DLQ 的机器可读原因（§3.4 把原 schemaInvalid bool 泛化为枚举，
+// 表达第三类「bulk 前 visibility 预检失败」）。
+type dlqReason int
+
+const (
+	reasonSchemaInvalid dlqReason = iota
+	reasonPermanent4xx
+	// reasonVisibilityUntrusted：bulk 前 visibility 预检失败（payload 非对象 / visibles
+	// present-but-empty / 不可信）。是**数据完整性/解析**失败，**不是** HTTP 4xx → status=0
+	// （与 schema-invalid 同档）。命名用 visibility_untrusted（无 producer_ 前缀，与 producer 腿
+	// 的 producer_visibility_untrusted 有意区分来源腿，非笔误）。
+	reasonVisibilityUntrusted
+)
+
+// reasonString 返回 dlqReason 的线格字符串（写进 dlqRecord.Reason）。
+func (r dlqReason) reasonString() string {
+	switch r {
+	case reasonSchemaInvalid:
+		return "unknown_schema_version"
+	case reasonVisibilityUntrusted:
+		return "visibility_untrusted"
+	default:
+		return "permanent_4xx"
+	}
+}
+
 // decodeAndValidate 解析消息字节并做 schema_version 校验（C4：未知版本 → 毒丸进 DLQ，不静默吃）。
 // 返回 (msg, true) 表示通过；(zero, false) 表示 schema 非法。
 func decodeAndValidate(value []byte) (searchmsg.Message, bool) {
@@ -259,19 +320,26 @@ func decodeAndValidate(value []byte) (searchmsg.Message, bool) {
 	return msg, true
 }
 
-// buildDLQRecord 构造一条 DLQ 记录（保留原始字节供回灌）。
-func buildDLQRecord(schemaInvalid bool, m fetchedMessage, res esindex.BulkItemResult) dlqRecord {
-	reason := "permanent_4xx"
+// buildDLQRecord 构造一条 DLQ 记录。
+//
+// 🔴 信封超限对称截断（§4.4.3 B-5）：DLQ 实际写出的是 json.Marshal(dlqRecord)，Go 把
+// Value []byte 编成 base64(~1.33x 膨胀) + 信封字段开销。一条带大 RawPayload 的消息落 consumer DLQ
+// 时，原样保留整条字节会触发 DLQ topic 超限连锁卡死（与 producer 腿同构）。故当原始 Value 体积
+// 超阈值（按预留 base64 余量的原始字节判，见 maxDLQRawValueBytes）时**截断 Value**，只留截断占位
+// + 标记 payload_truncated=true，保证 DLQ 写入必成功（回灌须从源 message 表按 messageId 重取）。
+func buildDLQRecord(reason dlqReason, m fetchedMessage, res esindex.BulkItemResult) dlqRecord {
 	detail := ""
 	status := res.Status
-	if schemaInvalid {
-		reason = "unknown_schema_version"
+	switch reason {
+	case reasonSchemaInvalid, reasonVisibilityUntrusted:
 		status = 0
-	} else if res.Err != nil {
-		detail = res.Err.Error()
+	default:
+		if res.Err != nil {
+			detail = res.Err.Error()
+		}
 	}
-	return dlqRecord{
-		Reason:    reason,
+	rec := dlqRecord{
+		Reason:    reason.reasonString(),
 		Topic:     m.Topic,
 		Partition: m.Partition,
 		Offset:    m.Offset,
@@ -280,4 +348,15 @@ func buildDLQRecord(schemaInvalid bool, m fetchedMessage, res esindex.BulkItemRe
 		Status:    status,
 		Detail:    detail,
 	}
+	// 超限对称截断（§4.4.3）：按 marshal 后 base64 膨胀预留余量的原始字节阈值判。
+	if len(m.Value) > maxDLQRawValueBytes {
+		rec.Value = nil
+		rec.PayloadTruncated = true
+		if rec.Detail != "" {
+			rec.Detail += "; "
+		}
+		rec.Detail += fmt.Sprintf("payload truncated (orig %d bytes > %d); replay must re-fetch from source by messageId(=key)",
+			len(m.Value), maxDLQRawValueBytes)
+	}
+	return rec
 }

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -51,6 +51,7 @@ type fakeWriter struct {
 	// 让原地重试循环能收敛）。0 表示不自愈（持续按 statusByID）。
 	healAfter map[string]int
 	bulkCalls int
+	lastBulk  []searchmsg.Message // 最近一次 Bulk 调用的入参（断言 visibility 回填用）
 	mu        sync.Mutex
 }
 
@@ -58,6 +59,7 @@ func (w *fakeWriter) Bulk(ctx context.Context, msgs []searchmsg.Message) ([]esin
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.bulkCalls++
+	w.lastBulk = msgs
 	out := make([]esindex.BulkItemResult, len(msgs))
 	for i := range msgs {
 		if w.batchErr != nil {
@@ -92,6 +94,8 @@ func (w *fakeWriter) Bulk(ctx context.Context, msgs []searchmsg.Message) ([]esin
 func (w *fakeWriter) Close() error { return nil }
 
 func (w *fakeWriter) EnsureIndex(ctx context.Context) error { return nil }
+
+func (w *fakeWriter) AssertLiveMappingCompatible(ctx context.Context) error { return nil }
 
 // BulkDocs 不被 consumer 路径调用（consumer 走 Bulk(msgs)）；提供空实现满足接口。
 func (w *fakeWriter) BulkDocs(ctx context.Context, docs []esindex.Doc) ([]esindex.BulkItemResult, error) {

--- a/internal/consumer/dlq.go
+++ b/internal/consumer/dlq.go
@@ -24,16 +24,30 @@ type alerter interface {
 
 // dlqRecord 是落 DLQ 的记录载荷：原始消息 + 进 DLQ 的原因（便于排查/回灌）。
 type dlqRecord struct {
-	Reason    string `json:"reason"`     // permanent_4xx / unknown_schema_version / ...
+	Reason    string `json:"reason"`     // permanent_4xx / unknown_schema_version / visibility_untrusted
 	Topic     string `json:"topic"`      // 源 topic
 	Partition int    `json:"partition"`  // 源分区
 	Offset    int64  `json:"offset"`     // 源 offset
 	Key       []byte `json:"key"`        // 原始 Kafka key（= message_id）
-	Value     []byte `json:"value"`      // 原始消息字节（原样保留供回灌）
-	Status    int    `json:"status"`     // bulk per-item HTTP 状态（schema 错误为 0）
+	Value     []byte `json:"value"`      // 原始消息字节（原样保留供回灌；超限时截断置 nil，见 PayloadTruncated）
+	Status    int    `json:"status"`     // bulk per-item HTTP 状态（schema/visibility 错误为 0）
 	Detail    string `json:"detail"`     // 失败详情
 	SpilledAt int64  `json:"spilled_at"` // 仅本地 spill 文件记录写入时间（纪元秒）
+	// PayloadTruncated 标记 Value 因超限被截断（§4.4.3 B-5）：带大 RawPayload 的毒丸落 DLQ 时，
+	// 原样保留整条字节经 base64 膨胀会触发 DLQ topic 超限连锁卡死，故截断 Value 保证写入必成功。
+	// 回灌工具读到 true 时须从源 message 表按 messageId(=Key) 重取，而非依赖 DLQ 内字节。
+	PayloadTruncated bool `json:"payload_truncated,omitempty"`
 }
+
+// maxDLQRawValueBytes 是 consumer DLQ 信封里原始消息字节（Value）的截断阈值（§4.4.3 B-5）。
+//
+// 🔴 必须按「marshal 后信封体积」判，不能按原始字节直接拿 1MiB 判：DLQ 实际写出的是
+// json.Marshal(dlqRecord)，Go 把 Value []byte 编成 base64(~1.33x 膨胀) + 信封字段开销。若按
+// len(Value)>1048576 判，则 Value 落在 ~786KB–1MiB 区间时过不了原始字节判定 → 原样保留 →
+// base64 后 JSON 信封 >1MiB（broker message.max.bytes 硬限）→ DLQ 写失败 → 分区卡死。
+// 故取**预留 base64 余量的原始字节阈值** 700KB（700KB×1.33≈931KB + 信封 < 1MiB，留足头部余量）。
+// 与 producer 腿（internal/producer/dlq.go maxDLQRawPayloadBytes）同口径。
+const maxDLQRawValueBytes = 700_000
 
 // dlqConfig 配置 DLQ 投递的有界重试 + 终态逃逸（C4 硬条件）。
 type dlqConfig struct {

--- a/internal/consumer/service.go
+++ b/internal/consumer/service.go
@@ -93,23 +93,32 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	return &Service{proc: proc, source: source, dlqSink: dlqSink, writer: writer}, nil
 }
 
-// Run 运行消费循环直到 ctx 取消。启动时先幂等确保目标索引存在（带 mapping/中文分词）。
+// Run 运行消费循环直到 ctx 取消。启动时先幂等确保目标索引存在（带 mapping/中文分词），
+// 再做 mapping-compat fail-closed 断言（§6.4）。
 //
-// 🔴 安全闸（V3b fail-OPEN 防护）：实时 consumer 写出的 doc 的 spaceId/visibles/messageSeq
-// 来自 Kafka 契约 searchmsg.Message，而当前契约（SchemaVersion 1）不带这三字段。若放行，
-// reader 对空 visibles 会 fail-OPEN（普通成员搜出群管才可见的系统消息）。故契约未携带安全
-// 字段前，实时写入**拒启动**（fail-closed），不静默灌 fail-open doc。存量经 backfill 富化。
-// 契约升到 SafetyFieldsSchemaVersion（octo-lib bump + producer 富化，阶段 9 前置）后自动解封。
+// 🔴 实时写入安全闸（§3.6 语义重定义）：本 gate（LiveContractCarriesSafetyFields）仅校验
+// **Kafka 契约版本 ≥ v2**（带 RawPayload 投影能力的最低契约版本，当前 searchmsg.SchemaVersion 已 ==2，
+// gate 恒 true）。**方案 B 后，实时写入的 visibility fail-closed 安全保证来自消费侧 processBatch
+// 预检调 searchmsg.ExtractVisibility（§3.4），不再来自「契约是否带 visibles」。** 故本 gate 不是
+// visibility 安全的充分条件，仅是契约版本下限闸；安全充分性由预检负责。不 bump SchemaVersion
+// （consumer 严格相等校验，bump=在飞 v2 消息全进 DLQ 风暴）。
 func (s *Service) Run(ctx context.Context) error {
 	if !esindex.LiveContractCarriesSafetyFields() {
 		return fmt.Errorf("consumer: live ingestion refused — Kafka contract (searchmsg.SchemaVersion=%d) "+
-			"does not carry reader safety fields (spaceId/visibles/messageSeq); writing now would fail-OPEN "+
-			"the reader's visibles gate. Bump octo-lib to SchemaVersion>=%d + enrich the producer (phase 9) "+
-			"before enabling live ingestion. Backfill enriches existing docs from MySQL meanwhile",
+			"is below the minimum version %d that carries RawPayload projection capability; bump octo-lib "+
+			"before enabling live ingestion (visibility fail-closed safety itself comes from the consumer-side "+
+			"ExtractVisibility pre-check, not from this gate)",
 			searchmsg.SchemaVersion, esindex.SafetyFieldsSchemaVersion)
 	}
 	if err := s.writer.EnsureIndex(ctx); err != nil {
 		return fmt.Errorf("consumer: ensure index: %w", err)
+	}
+	// 🔴 mapping-compat fail-closed 断言（§6.4）：方案 B 新增 payloadRaw / richText /
+	// mergeForward.msgs.{from,timestamp}，dynamic:strict 下若漏迁这些字段会启动后每条 bulk 4xx
+	// 静默全量塌。启动期校验 live mapping 含本期所有新字段路径，缺则**拒启动**（loud crash），
+	// 不静默灌 4xx。与 EnsureIndex 的存在性幂等独立（存在仍幂等容忍，字段缺失才拒启动）。
+	if err := s.writer.AssertLiveMappingCompatible(ctx); err != nil {
+		return fmt.Errorf("consumer: mapping-compat assertion: %w", err)
 	}
 	return s.proc.Run(ctx)
 }

--- a/internal/consumer/visibility_consumer_test.go
+++ b/internal/consumer/visibility_consumer_test.go
@@ -1,0 +1,262 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+// branchAMsgBytes 构造一条方案 B 分支 A 消息字节（非加密新形态，带 RawPayload 整包，不预填 visibles）。
+//
+// rawPayload 必须本身是合法 JSON（才能内联进 Message.raw_payload 并通过 decodeAndValidate 的整体
+// json.Unmarshal）。**结构性损坏的 payload（非合法 JSON）在线格上根本无法作为合法 Message 的
+// raw_payload 到达消费侧——它会让整条消息 json.Unmarshal 失败 → 走 schema-invalid 毒丸路径**，
+// 故不属于 visibility 预检的输入域。返回 ok=false 表示该向量不可作为 RawPayload 注入（跳过）。
+func branchAMsgBytes(t *testing.T, id, rawPayload string) ([]byte, bool) {
+	t.Helper()
+	if !json.Valid([]byte(rawPayload)) {
+		return nil, false
+	}
+	b, err := json.Marshal(searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     id,
+		ChannelID:     "g_1",
+		ChannelType:   2,
+		FromUID:       "u_1",
+		Source:        searchmsg.SourceETLMessageTable,
+		RawPayload:    json.RawMessage(rawPayload),
+	})
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+// decodeDLQ 解析 fakeDLQSink 记录的一条 DLQ 信封。
+func decodeDLQ(t *testing.T, b []byte) dlqRecord {
+	t.Helper()
+	var rec dlqRecord
+	if err := json.Unmarshal(b, &rec); err != nil {
+		t.Fatalf("decode dlq record: %v", err)
+	}
+	return rec
+}
+
+// mustBranchA 是 branchAMsgBytes 的「rawPayload 必为合法 JSON」便捷封装（断言用例）。
+func mustBranchA(t *testing.T, id, rawPayload string) []byte {
+	t.Helper()
+	b, ok := branchAMsgBytes(t, id, rawPayload)
+	if !ok {
+		t.Fatalf("rawPayload must be valid JSON for branch A: %s", rawPayload)
+	}
+	return b
+}
+
+// TestProcessBatch_S1_SharedVisibilityVectors 🔴 §3.7 S1（升级为 STOP）：消费侧遍历 octo-lib 共享
+// 向量 FailClosedVisibilityVectors()（仅取本身是合法 JSON、能作为 RawPayload 到达消费侧的子集；
+// 非合法 JSON 的向量在线格上走 schema-invalid，不属 visibility 预检输入域）。WantErr 向量
+// （valid-but-empty 等结构性损坏）→ 该条进 DLQ(reason=visibility_untrusted)、doc 不写（不进 bulk）；
+// 放行向量 → 进 bulk、不进 DLQ。
+func TestProcessBatch_S1_SharedVisibilityVectors(t *testing.T) {
+	covered := 0
+	for _, vec := range searchmsg.FailClosedVisibilityVectors() {
+		t.Run(vec.Name, func(t *testing.T) {
+			value, ok := branchAMsgBytes(t, "100", string(vec.Payload))
+			if !ok {
+				t.Skipf("payload not valid JSON; arrives as schema-invalid, not a visibility-precheck input")
+			}
+			covered++
+			src := &fakeSource{}
+			w := &fakeWriter{}
+			sink := &fakeDLQSink{}
+			alert := &recordAlerter{}
+			p := newProc(t, src, w, sink, alert, "")
+			batch := []fetchedMessage{fm(0, value)}
+			if err := p.processBatch(context.Background(), batch); err != nil {
+				t.Fatalf("processBatch: %v", err)
+			}
+			if vec.WantErr {
+				// fail-closed：进 DLQ，绝不进 bulk。
+				if w.bulkCalls != 0 {
+					t.Fatalf("[%s] fail-closed vector must NOT reach bulk (doc must not be written)", vec.Name)
+				}
+				if len(sink.records) != 1 {
+					t.Fatalf("[%s] fail-closed vector must produce exactly 1 DLQ record, got %d", vec.Name, len(sink.records))
+				}
+				rec := decodeDLQ(t, sink.records[0])
+				if rec.Reason != "visibility_untrusted" {
+					t.Fatalf("[%s] DLQ reason = %q, want visibility_untrusted", vec.Name, rec.Reason)
+				}
+				if rec.Status != 0 {
+					t.Fatalf("[%s] visibility DLQ status must be 0 (not 4xx), got %d", vec.Name, rec.Status)
+				}
+			} else {
+				// 放行：进 bulk，不进 DLQ。
+				if len(sink.records) != 0 {
+					t.Fatalf("[%s] passing vector must NOT produce a DLQ record, got %d", vec.Name, len(sink.records))
+				}
+				if w.bulkCalls == 0 {
+					t.Fatalf("[%s] passing vector must reach bulk", vec.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestProcessBatch_S2_BranchA_VisiblesParsedFromRaw 分支 A：合法 visibles → 进 bulk，且解析值
+// 来自 ExtractVisibility(RawPayload)（消费侧不盲信契约）。
+func TestProcessBatch_S2_BranchA_ValidVisibles(t *testing.T) {
+	src := &fakeSource{}
+	w := &fakeWriter{}
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	p := newProc(t, src, w, sink, alert, "")
+	raw := `{"type":1,"content":"hi","visibles":["u_admin"]}`
+	batch := []fetchedMessage{fm(0, mustBranchA(t, "100", raw))}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if len(sink.records) != 0 {
+		t.Fatalf("valid visibles must not DLQ")
+	}
+	if len(w.lastBulk) != 1 || len(w.lastBulk[0].Visibles) != 1 || w.lastBulk[0].Visibles[0] != "u_admin" {
+		t.Fatalf("branch A must backfill visibles from ExtractVisibility(RawPayload): %+v", w.lastBulk)
+	}
+}
+
+// TestProcessBatch_S2_BranchA_EmptyVisiblesDLQ 分支 A：visibles=[] (valid-but-empty) → 落 DLQ、
+// 不写空 visibles（核心 fail-closed 回归）。
+func TestProcessBatch_S2_BranchA_EmptyVisiblesDLQ(t *testing.T) {
+	src := &fakeSource{}
+	w := &fakeWriter{}
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	p := newProc(t, src, w, sink, alert, "")
+	raw := `{"type":1,"content":"hi","visibles":[]}`
+	batch := []fetchedMessage{fm(0, mustBranchA(t, "100", raw))}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if w.bulkCalls != 0 {
+		t.Fatalf("empty visibles must NOT reach bulk (no empty-visibles doc written)")
+	}
+	if len(sink.records) != 1 || decodeDLQ(t, sink.records[0]).Reason != "visibility_untrusted" {
+		t.Fatalf("empty visibles must DLQ with visibility_untrusted: %v", sink.records)
+	}
+}
+
+// TestProcessBatch_S2_BranchA_UnknownTypeGroupStillParsesVisibility 🔴 P0-B 核心回归：非加密未知
+// type 群消息（RawPayload>0 + 投不出 typed 子对象）**仍解析 visibility**（不因 RawExcluded 走跳过
+// 分支）。合法 visibles → 进 bulk 且 visibles 来自解析；空 visibles → DLQ。这堵住 fail-OPEN 空洞。
+func TestProcessBatch_S2_BranchA_UnknownTypeGroupVisibility(t *testing.T) {
+	src := &fakeSource{}
+	w := &fakeWriter{}
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	p := newProc(t, src, w, sink, alert, "")
+	// type=99 未知 type（投不出 typed 子对象 → doc.RawExcluded=true），但带 visibles 白名单。
+	raw := `{"type":99,"content":"群定向系统消息","visibles":["u_admin"]}`
+	batch := []fetchedMessage{fm(0, mustBranchA(t, "100", raw))}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if len(sink.records) != 0 {
+		t.Fatalf("unknown-type group msg with valid visibles must not DLQ")
+	}
+	if len(w.lastBulk) != 1 || len(w.lastBulk[0].Visibles) != 1 || w.lastBulk[0].Visibles[0] != "u_admin" {
+		t.Fatalf("P0-B regression: unknown-type group msg must STILL parse visibility (not skipped via RawExcluded): %+v", w.lastBulk)
+	}
+}
+
+// TestProcessBatch_BranchB_EncryptedSkipsVisibility 分支 B：加密 DM（RawPayload 缺 + RawExcluded=true）
+// → 不调 ExtractVisibility、不进 DLQ、进 bulk、visibles 留空。
+func TestProcessBatch_BranchB_EncryptedSkips(t *testing.T) {
+	src := &fakeSource{}
+	w := &fakeWriter{}
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	p := newProc(t, src, w, sink, alert, "")
+	enc := mustJSON(searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     "100",
+		ChannelID:     "uidA@uidB",
+		ChannelType:   1,
+		RawExcluded:   true, // 加密：无 RawPayload
+	})
+	batch := []fetchedMessage{fm(0, enc)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if len(sink.records) != 0 {
+		t.Fatalf("encrypted DM must not DLQ (ciphertext not fed to parser)")
+	}
+	if len(w.lastBulk) != 1 || len(w.lastBulk[0].Visibles) != 0 {
+		t.Fatalf("encrypted DM must leave visibles empty (reader fail-closed safe): %+v", w.lastBulk)
+	}
+}
+
+// TestProcessBatch_BranchC_LegacyTrustsContract 分支 C：在飞老 v2（无 RawPayload、非加密）→ 信契约
+// visibles，进 bulk（不重解析、不 DLQ）。
+func TestProcessBatch_BranchC_LegacyTrustsContract(t *testing.T) {
+	src := &fakeSource{}
+	w := &fakeWriter{}
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	p := newProc(t, src, w, sink, alert, "")
+	c := "hi"
+	legacy := mustJSON(searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     "100",
+		ChannelID:     "g_1",
+		ChannelType:   2,
+		Content:       &c,
+		ContentType:   1,
+		Visibles:      []string{"u_admin"}, // producer 富化的契约 visibles
+	})
+	batch := []fetchedMessage{fm(0, legacy)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if len(sink.records) != 0 {
+		t.Fatalf("legacy v2 must not DLQ")
+	}
+	if len(w.lastBulk) != 1 || len(w.lastBulk[0].Visibles) != 1 || w.lastBulk[0].Visibles[0] != "u_admin" {
+		t.Fatalf("branch C must trust contract visibles: %+v", w.lastBulk)
+	}
+}
+
+// TestBuildDLQRecord_B5_ConsumerEnvelopeTruncation 🔴 §4.4.3 B-5：带大 RawPayload 的毒丸落 consumer
+// DLQ 时，Value 被截断（payload_truncated=true、不含完整字节），保证 DLQ 写入不超限卡死。
+func TestBuildDLQRecord_B5_ConsumerEnvelopeTruncation(t *testing.T) {
+	big := make([]byte, maxDLQRawValueBytes+1)
+	for i := range big {
+		big[i] = 'x'
+	}
+	m := fetchedMessage{Topic: "t", Partition: 0, Offset: 5, Key: []byte("100"), Value: big}
+	rec := buildDLQRecord(reasonVisibilityUntrusted, m, esindex.BulkItemResult{})
+	if !rec.PayloadTruncated {
+		t.Fatalf("oversized consumer DLQ envelope must set PayloadTruncated=true")
+	}
+	if rec.Value != nil {
+		t.Fatalf("oversized consumer DLQ envelope must drop Value bytes, got %d", len(rec.Value))
+	}
+	if !strings.Contains(rec.Detail, "truncated") {
+		t.Fatalf("truncation marker must be in Detail: %q", rec.Detail)
+	}
+	// marshal 后体积必须远低于 1MiB（不会触发 broker 硬限）。
+	b := mustJSON(rec)
+	if len(b) > 100_000 {
+		t.Fatalf("truncated DLQ record must be small, got %d bytes", len(b))
+	}
+
+	// 对照：小 Value 不截断。
+	small := fetchedMessage{Topic: "t", Offset: 1, Key: []byte("1"), Value: []byte(`{"x":1}`)}
+	rec2 := buildDLQRecord(reasonSchemaInvalid, small, esindex.BulkItemResult{})
+	if rec2.PayloadTruncated || rec2.Value == nil {
+		t.Fatalf("small DLQ record must retain Value verbatim")
+	}
+}

--- a/internal/esindex/buildraw.go
+++ b/internal/esindex/buildraw.go
@@ -1,0 +1,428 @@
+package esindex
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// 本文件是方案 B（CDC 式写入）正文投影的核心：照搬 CDC 蓝本
+// wukongim-message-indexer/internal/transform/doc.go::ToDoc 的全类型投影（text=1/image=2/
+// gif=3/voice=4/video=5/file=8/mergeForward=11/richText=14），命名校准到 reader 契约
+// （camelCase + mergeForward.msgs[].from，非 CDC fromUid）。
+//
+// 🔴 与蓝本的唯一例外（§3.4/§3.5 钉死）：CDC ToDoc 从 raw **直读** visibles/space_id 写进 doc、
+// **无 fail-closed**（fail-OPEN）。本文件**绝不照搬**那两段——buildPayloadFromRaw 是**纯正文
+// 投影**函数，签名里不含也不返回 spaceId/visibles，函数体内不出现 ExtractVisibility、不读
+// raw["visibles"]/raw["space_id"]。visibility 的唯一权威解析落点在 consumer.processBatch 预检
+// （实时路径）/ backfill docFromRow（存量路径），见 §3。
+//
+// 🔴 雪花精度（§5.3 U-3）：解析 RawPayload 及嵌套 mergeForward.msgs[].messageId 必须用
+// json.Decoder + UseNumber()，否则默认 float64 会截断 >2^53 的雪花 id。
+
+// payload.type 常量，语义对齐 octo-lib common/msg.go ContentType（与 reader source.go 一致）。
+const (
+	payloadTypeImage        = 2
+	payloadTypeGIF          = 3
+	payloadTypeVoice        = 4
+	payloadTypeVideo        = 5
+	payloadTypeFile         = 8
+	payloadTypeMergeForward = 11
+	payloadTypeRichText     = 14
+)
+
+// channelTypePerson 是 p2p 频道类型（reversePeer 反解对端 To 用），语义对齐 octo-lib
+// common.ChannelType Person。
+const channelTypePerson uint32 = 1
+
+// videoExtensions 是「文件消息(type=8)按文件名后缀识别为视频」的后缀白名单（照搬蓝本）。
+// 命中后投成 video(type=5) 只填 url（对齐原 video 业务协议）；payloadRaw 仍存原始 type=8 对象。
+var videoExtensions = map[string]bool{
+	"mp4": true, "avi": true, "mov": true, "mkv": true,
+	"m4v": true, "flv": true, "wmv": true, "webm": true, "3gp": true, "ts": true,
+}
+
+// buildPayloadFromRaw 把原始 payload 整包投影成 reader 可读的 Payload + 留底 rawForStore。
+//
+// 返回：
+//   - payload：typed 投影（type + text/image/gif/voice/video/file/mergeForward/richText 子对象）。
+//     payload 非合法 JSON 对象时为 nil（visibility 预检已对非对象 fail-closed 落 DLQ，不会走到这；
+//     此处为防御性兜底）。
+//   - rawForStore：原始 payload 整包（仅当顶层是 JSON 对象时写，否则 nil；§6.1 形态约束）。
+//   - projected：是否产出了至少一个 typed 可搜子对象（RawExcluded 重定义依据，§5.5）。
+//
+// ⚠️ 本函数是**纯正文投影**：不解析 visibility、不读 visibles/space_id、不产出 To（见文件头）。
+func buildPayloadFromRaw(rawPayload json.RawMessage) (payload *Payload, rawForStore json.RawMessage, projected bool) {
+	if len(rawPayload) == 0 {
+		return nil, nil, false
+	}
+	raw, ok := decodeObjectUseNumber(rawPayload)
+	if !ok {
+		// 顶层非 JSON 对象（数组/标量/损坏）：不写 payloadRaw（object mapping 装不下），不投影。
+		return nil, nil, false
+	}
+	// 顶层是对象 → 原样留底（json.RawMessage 内联存储，不索引：mapping payloadRaw enabled:false）。
+	rawForStore = rawPayload
+
+	t, ok := extractType(raw)
+	if !ok {
+		// 合法对象但缺 type：payloadRaw 已留底，Payload 不挂（保持「至少抽到 type 才挂 Payload」语义）。
+		return nil, rawForStore, false
+	}
+	parsed := &Payload{Type: &t}
+	switch t {
+	case payloadTypeText:
+		p := &TextPayload{}
+		if c, ok := raw["content"].(string); ok {
+			p.Content = c
+		}
+		parsed.Text = p
+	case payloadTypeImage:
+		p := &ImagePayload{}
+		if u, ok := raw["url"].(string); ok {
+			p.URL = u
+		}
+		if c, ok := raw["caption"].(string); ok {
+			p.Caption = c
+		}
+		if n, ok := raw["name"].(string); ok {
+			p.Name = n
+		}
+		if w, ok := extractInt(raw, "width"); ok {
+			p.Width = w
+		}
+		if h, ok := extractInt(raw, "height"); ok {
+			p.Height = h
+		}
+		parsed.Image = p
+	case payloadTypeGIF:
+		p := &GifPayload{}
+		if u, ok := raw["url"].(string); ok {
+			p.URL = u
+		}
+		parsed.Gif = p
+	case payloadTypeVoice:
+		p := &VoicePayload{}
+		if u, ok := raw["url"].(string); ok {
+			p.URL = u
+		}
+		parsed.Voice = p
+	case payloadTypeVideo:
+		p := &VideoPayload{}
+		if u, ok := raw["url"].(string); ok {
+			p.URL = u
+		}
+		if c, ok := raw["cover"].(string); ok {
+			p.Cover = c
+		}
+		if w, ok := extractInt(raw, "width"); ok {
+			p.Width = w
+		}
+		if h, ok := extractInt(raw, "height"); ok {
+			p.Height = h
+		}
+		if s, ok := extractInt(raw, "second"); ok {
+			p.Second = s
+		}
+		parsed.Video = p
+	case payloadTypeFile:
+		// 文件名/extension 后缀命中视频白名单 → 改写成 video(type=5) 只填 url；payloadRaw 不动。
+		extName, _ := raw["name"].(string)
+		extRaw, _ := raw["extension"].(string)
+		if videoExtensions[fileExt(extRaw, extName)] {
+			vt := payloadTypeVideo
+			parsed.Type = &vt
+			v := &VideoPayload{}
+			if u, ok := raw["url"].(string); ok {
+				v.URL = u
+			}
+			parsed.Video = v
+			break
+		}
+		p := &FilePayload{}
+		if u, ok := raw["url"].(string); ok {
+			p.URL = u
+		}
+		if n, ok := raw["name"].(string); ok {
+			p.Name = n
+		}
+		if c, ok := raw["caption"].(string); ok {
+			p.Caption = c
+		}
+		if sz, ok := extractInt64(raw, "size"); ok {
+			p.Size = sz
+		}
+		if ext, ok := raw["extension"].(string); ok {
+			p.Extension = ext
+		}
+		parsed.File = p
+	case payloadTypeMergeForward:
+		parsed.MergeForward = buildMergeForward(raw)
+	case payloadTypeRichText:
+		parsed.RichText = buildRichText(raw)
+	}
+	// projected = 产出了至少一个 typed 可搜子对象（除了 type 本身）。已知 type 但无子对象
+	// （如 gif/voice 仅 url、或未知 type case 未命中）仍按是否挂了子对象判定。
+	projected = parsed.hasTypedSubObject()
+	return parsed, rawForStore, projected
+}
+
+// hasTypedSubObject 报告 Payload 是否挂了至少一个 typed 子对象（用于 RawExcluded 重定义）。
+func (p *Payload) hasTypedSubObject() bool {
+	if p == nil {
+		return false
+	}
+	return p.Text != nil || p.Image != nil || p.Gif != nil || p.Voice != nil ||
+		p.Video != nil || p.File != nil || p.MergeForward != nil || p.RichText != nil
+}
+
+// decodeObjectUseNumber 把 payload 字节解成顶层 map[string]any，数字走 json.Number（UseNumber，
+// 防雪花精度截断，§5.3）。顶层不是对象（数组/标量/null/损坏）→ ok=false。
+func decodeObjectUseNumber(b []byte) (map[string]any, bool) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var raw map[string]any
+	if err := dec.Decode(&raw); err != nil || raw == nil {
+		return nil, false
+	}
+	return raw, true
+}
+
+// buildMergeForward 把 type=11 raw 里的 msgs([]any) 收敛成 MergeForwardPayload。
+// 每条内嵌 msg 取 message_id(snake_case) + from(锚 reader `from`) + timestamp + type + searchText。
+// 命名校准：发送人字段写 reader 契约的 from（非 CDC fromUid），但**读取**仍兼容子消息原生
+// from_uid（octo payload 内嵌字段名）。元素非 object / 缺字段 → 静默跳过该字段（zero）。
+// raw 缺 msgs 或为空 → nil（omitempty 不输出）。
+func buildMergeForward(raw map[string]any) *MergeForwardPayload {
+	arr, ok := raw["msgs"].([]any)
+	if !ok || len(arr) == 0 {
+		return nil
+	}
+	msgs := make([]MergeForwardMsg, 0, len(arr))
+	for _, item := range arr {
+		sub, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		m := MergeForwardMsg{}
+		if id, ok := extractInt64(sub, "message_id"); ok {
+			m.MessageID = id
+		}
+		// 发送人：payload 内嵌原生字段名是 from_uid（octo-web MergeforwardContent schema），
+		// 投影到 reader 契约字段名 from（PR#425）。
+		if v, ok := sub["from_uid"].(string); ok {
+			m.From = v
+		}
+		if ts, ok := extractInt64(sub, "timestamp"); ok {
+			m.Timestamp = ts
+		}
+		subPayload, _ := sub["payload"].(map[string]any)
+		if subPayload != nil {
+			if t, ok := extractType(subPayload); ok {
+				m.Type = t
+				m.SearchText = buildSearchText(subPayload, t)
+			}
+		}
+		msgs = append(msgs, m)
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+	return &MergeForwardPayload{ChildCount: len(msgs), Msgs: msgs}
+}
+
+// searchableTextFields 严格对齐外层 payload.<X> 子对象里 type:text + ik 分词字段，让
+// mergeForward 内嵌 msgs[i].searchText 与外层可搜文本字段集一致（照搬蓝本 SearchableTextFields）。
+var searchableTextFields = map[int][]string{
+	payloadTypeText:  {"content"},
+	payloadTypeImage: {"caption", "name"},
+	payloadTypeFile:  {"name", "caption"},
+}
+
+// buildSearchText 按 searchableTextFields 取字段拼接（空格连接，跳空）。type=14 走
+// richTextSearchText 特判（与顶层 buildRichText 同源）。
+func buildSearchText(payload map[string]any, t int) string {
+	if t == payloadTypeRichText {
+		return richTextSearchText(payload)
+	}
+	keys, ok := searchableTextFields[t]
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if v, ok := payload[k].(string); ok && v != "" {
+			parts = append(parts, v)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// richText 占位符与 octo-web / octo-lib 严格对齐（wire-format 不可本地化）。
+const (
+	richTextImagePlaceholder = "[图片]"
+	richTextFilePlaceholder  = "[文件]"
+)
+
+// richTextSearchText 是 type=14 可搜文本的单源计算（顶层 buildRichText 与合并转发内嵌共用）：
+// plain（优先 raw["plain"]，缺则现场 buildRichTextPlain 回填）+ 各 image/file block 的 name/caption。
+func richTextSearchText(raw map[string]any) string {
+	blocks := richTextBlocks(raw["content"])
+	plain, _ := raw["plain"].(string)
+	if strings.TrimSpace(plain) == "" {
+		plain = buildRichTextPlain(blocks)
+	}
+	parts := make([]string, 0, len(blocks)+1)
+	if plain != "" {
+		parts = append(parts, plain)
+	}
+	for _, blk := range blocks {
+		if blk["type"] == "image" || blk["type"] == "file" {
+			if n, ok := blk["name"].(string); ok && n != "" {
+				parts = append(parts, n)
+			}
+			if c, ok := blk["caption"].(string); ok && c != "" {
+				parts = append(parts, c)
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildRichText 把 type=14 raw 收敛成 RichTextPayload；searchText 为空 → nil（omitempty 不输出）。
+func buildRichText(raw map[string]any) *RichTextPayload {
+	searchText := richTextSearchText(raw)
+	if searchText == "" {
+		return nil
+	}
+	return &RichTextPayload{SearchText: searchText}
+}
+
+// richTextBlocks 归一 content 为 block 数组（[]any 只留 map；string 向后兼容归一为单 text block）。
+func richTextBlocks(content any) []map[string]any {
+	switch v := content.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			if blk, ok := item.(map[string]any); ok {
+				out = append(out, blk)
+			}
+		}
+		return out
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []map[string]any{{"type": "text", "text": v}}
+	}
+	return nil
+}
+
+// buildRichTextPlain 遍历 blocks 生成纯文本（text 取 text；image 注 [图片]；file 注 [文件]+名）。
+// 仅在 server plain 缺失时回填（server 是 plain 权威源）。
+func buildRichTextPlain(blocks []map[string]any) string {
+	var sb strings.Builder
+	for _, blk := range blocks {
+		t, _ := blk["type"].(string)
+		text, _ := blk["text"].(string)
+		switch t {
+		case "image":
+			sb.WriteString(richTextImagePlaceholder)
+		case "file":
+			if name, ok := blk["name"].(string); ok && name != "" {
+				sb.WriteString(richTextFilePlaceholder + " " + name)
+			} else {
+				sb.WriteString(richTextFilePlaceholder)
+			}
+		case "text":
+			sb.WriteString(text)
+		default:
+			sb.WriteString(text) // 未知 type：有 text 取 text，无则空串
+		}
+	}
+	return sb.String()
+}
+
+// reversePeer 从 fakeChannelId("uidA@uidB"，hash 排序) 反解对端 uid。拆不出两段 → 空串。
+// 入参取自**契约** ChannelID/From（非 payloadRaw），防恶意 payloadRaw 篡改 To（§5.2 U-2）。
+func reversePeer(channelID, from string) string {
+	parts := strings.SplitN(channelID, "@", 3)
+	if len(parts) != 2 {
+		return ""
+	}
+	a, b := parts[0], parts[1]
+	if from == a {
+		return b
+	}
+	return a
+}
+
+// fileExt 从文件消息提取小写后缀（照搬蓝本，对齐 octo-web getExtension）：优先 name 取后缀
+// （排除 dotfile 前导点 / 尾点），fallback extension 字段。
+func fileExt(extension, name string) string {
+	if name != "" {
+		if dot := strings.LastIndex(name, "."); dot > 0 && dot < len(name)-1 {
+			return strings.ToLower(name[dot+1:])
+		}
+	}
+	return strings.ToLower(extension)
+}
+
+// extractType 从 payload map 抽 type（兼容 float64/int/json.Number）。
+func extractType(payload map[string]any) (int, bool) {
+	return extractInt(payload, "type")
+}
+
+// extractInt 按 key 抽 int，兼容 JSON 默认 float64 / json.Number / int*。
+func extractInt(m map[string]any, key string) (int, bool) {
+	v, ok := m[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(i), true
+	}
+	return 0, false
+}
+
+// extractInt64 按 key 抽 int64，兼容 float64 / json.Number / int* / string。string 分支处理
+// 内嵌 msgs[].message_id 在原始 JSON 里是字符串（雪花 ID）的情形。
+func extractInt64(m map[string]any, key string) (int64, bool) {
+	v, ok := m[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	case string:
+		i, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	}
+	return 0, false
+}

--- a/internal/esindex/buildraw_test.go
+++ b/internal/esindex/buildraw_test.go
@@ -1,0 +1,232 @@
+package esindex
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// readerProjDoc 镜像 octo-server reader source.go::Doc 的全 payload 投影（驱动「写入→reader 反序列化」
+// 契约断言）。用 reader 的 json tag 反序列化 indexer 写出的 doc。
+type readerProjDoc struct {
+	MessageID   int64  `json:"messageId"`
+	To          string `json:"to"`
+	RawExcluded bool   `json:"rawExcluded"`
+	Payload     *struct {
+		Type  *int                      `json:"type"`
+		Text  *struct{ Content string } `json:"text"`
+		Image *struct {
+			URL, Caption, Name string
+			Width, Height      int
+		} `json:"image"`
+		Gif   *struct{ URL string } `json:"gif"`
+		Voice *struct{ URL string } `json:"voice"`
+		Video *struct {
+			URL, Cover            string
+			Width, Height, Second int
+		} `json:"video"`
+		File *struct {
+			URL, Name, Caption, Extension string
+			Size                          int64
+		} `json:"file"`
+		MergeForward *struct {
+			ChildCount int `json:"childCount"`
+			Msgs       []struct {
+				MessageID  int64  `json:"messageId"`
+				Type       int    `json:"type"`
+				SearchText string `json:"searchText"`
+				From       string `json:"from"`
+				Timestamp  int64  `json:"timestamp"`
+			} `json:"msgs"`
+		} `json:"mergeForward"`
+		RichText *struct {
+			SearchText string `json:"searchText"`
+		} `json:"richText"`
+	} `json:"payload"`
+	PayloadRaw json.RawMessage `json:"payloadRaw"`
+}
+
+// projectViaDoc 走完整 DocFromMessage（分支 A）拿到 reader 可读 doc。
+func projectViaDoc(t *testing.T, raw string) readerProjDoc {
+	t.Helper()
+	d, err := DocFromMessage(branchAMsg("100", raw))
+	if err != nil {
+		t.Fatalf("DocFromMessage: %v", err)
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var rd readerProjDoc
+	if err := json.Unmarshal(b, &rd); err != nil {
+		t.Fatalf("reader unmarshal: %v", err)
+	}
+	return rd
+}
+
+// TestProject_Text type=1 文本投影 payload.text.content。
+func TestProject_Text(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":1,"content":"你好 world"}`)
+	if rd.Payload == nil || rd.Payload.Text == nil || rd.Payload.Text.Content != "你好 world" {
+		t.Fatalf("text.content not projected: %+v", rd.Payload)
+	}
+	if rd.RawExcluded {
+		t.Fatalf("text must not be rawExcluded")
+	}
+	if len(rd.PayloadRaw) == 0 {
+		t.Fatalf("payloadRaw must be retained")
+	}
+}
+
+// TestProject_Image type=2 image.{caption,name}+url/宽高。
+func TestProject_Image(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":2,"name":"合同.png","caption":"季度合同","url":"https://x/y.png","width":800,"height":600}`)
+	img := rd.Payload.Image
+	if img == nil || img.Name != "合同.png" || img.Caption != "季度合同" || img.URL != "https://x/y.png" || img.Width != 800 || img.Height != 600 {
+		t.Fatalf("image not fully projected: %+v", img)
+	}
+	if rd.RawExcluded {
+		t.Fatalf("image must not be rawExcluded (searchable)")
+	}
+}
+
+// TestProject_GIF type=3 留底 gif.url。
+func TestProject_GIF(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":3,"url":"https://x/a.gif"}`)
+	if rd.Payload.Gif == nil || rd.Payload.Gif.URL != "https://x/a.gif" {
+		t.Fatalf("gif.url not projected: %+v", rd.Payload.Gif)
+	}
+}
+
+// TestProject_Voice type=4 留底 voice.url。
+func TestProject_Voice(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":4,"url":"https://x/a.mp3"}`)
+	if rd.Payload.Voice == nil || rd.Payload.Voice.URL != "https://x/a.mp3" {
+		t.Fatalf("voice.url not projected: %+v", rd.Payload.Voice)
+	}
+}
+
+// TestProject_Video type=5 video.*。
+func TestProject_Video(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":5,"url":"https://x/v.mp4","cover":"https://x/c.jpg","width":1920,"height":1080,"second":42}`)
+	v := rd.Payload.Video
+	if v == nil || v.URL != "https://x/v.mp4" || v.Cover != "https://x/c.jpg" || v.Width != 1920 || v.Height != 1080 || v.Second != 42 {
+		t.Fatalf("video not fully projected: %+v", v)
+	}
+}
+
+// TestProject_File type=8 file.{name,caption,extension}+url/size。
+func TestProject_File(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":8,"name":"年报.pdf","caption":"2025 年报","url":"https://x/f.pdf","size":123456,"extension":"pdf"}`)
+	f := rd.Payload.File
+	if f == nil || f.Name != "年报.pdf" || f.Caption != "2025 年报" || f.Extension != "pdf" || f.URL != "https://x/f.pdf" || f.Size != 123456 {
+		t.Fatalf("file not fully projected: %+v", f)
+	}
+}
+
+// TestProject_FileToVideo type=8 文件名后缀命中视频白名单 → 投成 video(type=5) 只填 url；payloadRaw 仍存原 type=8。
+func TestProject_FileToVideo(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":8,"name":"clip.mp4","url":"https://x/clip.mp4","size":999,"extension":"mp4"}`)
+	if rd.Payload.Type == nil || *rd.Payload.Type != payloadTypeVideo {
+		t.Fatalf("file→video must rewrite payload.type to 5, got %+v", rd.Payload.Type)
+	}
+	if rd.Payload.Video == nil || rd.Payload.Video.URL != "https://x/clip.mp4" {
+		t.Fatalf("file→video must project video.url: %+v", rd.Payload.Video)
+	}
+	if rd.Payload.File != nil {
+		t.Fatalf("file→video must not also project file: %+v", rd.Payload.File)
+	}
+	// payloadRaw 仍是原始 type=8 对象。
+	var raw map[string]any
+	if err := json.Unmarshal(rd.PayloadRaw, &raw); err != nil {
+		t.Fatalf("payloadRaw parse: %v", err)
+	}
+	if tp, _ := extractInt(raw, "type"); tp != payloadTypeFile {
+		t.Fatalf("payloadRaw must retain original type=8, got %v", raw["type"])
+	}
+}
+
+// TestProject_MergeForward type=11 msgs[].{searchText,from,timestamp,messageId}，from 锚 reader（非 fromUid）。
+func TestProject_MergeForward(t *testing.T) {
+	raw := `{"type":11,"msgs":[
+		{"message_id":"9007199254740993","from_uid":"u_sender","timestamp":1700000000,"payload":{"type":1,"content":"季度总结"}},
+		{"message_id":123,"from_uid":"u_b","timestamp":1700000001,"payload":{"type":8,"name":"附件.docx"}}
+	]}`
+	rd := projectViaDoc(t, raw)
+	mf := rd.Payload.MergeForward
+	if mf == nil || mf.ChildCount != 2 || len(mf.Msgs) != 2 {
+		t.Fatalf("mergeForward not projected: %+v", mf)
+	}
+	m0 := mf.Msgs[0]
+	if m0.From != "u_sender" {
+		t.Fatalf("mergeForward msgs[].from must anchor reader `from` (not fromUid): %+v", m0)
+	}
+	if m0.MessageID != 9007199254740993 {
+		t.Fatalf("snowflake precision lost in nested messageId: got %d", m0.MessageID)
+	}
+	if m0.Timestamp != 1700000000 {
+		t.Fatalf("mergeForward msgs[].timestamp missing: %+v", m0)
+	}
+	if m0.SearchText != "季度总结" {
+		t.Fatalf("mergeForward inner text searchText missing: %q", m0.SearchText)
+	}
+	if mf.Msgs[1].SearchText != "附件.docx" {
+		t.Fatalf("mergeForward inner file name searchText missing: %q", mf.Msgs[1].SearchText)
+	}
+}
+
+// TestProject_RichText type=14 richText.searchText（前瞻）。
+func TestProject_RichText(t *testing.T) {
+	raw := `{"type":14,"content":[{"type":"text","text":"看这张"},{"type":"image","name":"图.png"}]}`
+	rd := projectViaDoc(t, raw)
+	if rd.Payload.RichText == nil || rd.Payload.RichText.SearchText == "" {
+		t.Fatalf("richText.searchText not projected: %+v", rd.Payload.RichText)
+	}
+	// plain 回填应含文本 + 图片占位 + 附件名。
+	if !containsSub(rd.Payload.RichText.SearchText, "看这张") || !containsSub(rd.Payload.RichText.SearchText, "图.png") {
+		t.Fatalf("richText searchText incomplete: %q", rd.Payload.RichText.SearchText)
+	}
+}
+
+// TestProject_PayloadRawRetained payloadRaw 整包原样留底（_source 备查）。
+func TestProject_PayloadRawRetained(t *testing.T) {
+	raw := `{"type":2,"name":"x.png","custom_field":"keep_me","nested":{"a":1}}`
+	rd := projectViaDoc(t, raw)
+	var got map[string]any
+	if err := json.Unmarshal(rd.PayloadRaw, &got); err != nil {
+		t.Fatalf("payloadRaw parse: %v", err)
+	}
+	if got["custom_field"] != "keep_me" {
+		t.Fatalf("payloadRaw must retain unprojected fields verbatim: %+v", got)
+	}
+}
+
+// TestProject_SnowflakePrecision 顶层 + 嵌套 messageId 雪花精度（2^53+1）不被 float64 截断。
+func TestProject_SnowflakePrecision(t *testing.T) {
+	// 嵌套 msgs[].message_id 在 octo payload 里是 string（避 JS 精度丢失）；extractInt64 string 分支处理。
+	raw := `{"type":11,"msgs":[{"message_id":"9007199254740993","from_uid":"u","payload":{"type":1,"content":"x"}}]}`
+	rd := projectViaDoc(t, raw)
+	if rd.Payload.MergeForward.Msgs[0].MessageID != 9007199254740993 {
+		t.Fatalf("nested snowflake messageId truncated: %d", rd.Payload.MergeForward.Msgs[0].MessageID)
+	}
+}
+
+// TestProject_UnknownTypeRawExcluded 未知 type（投不出任何 typed 子对象）→ RawExcluded=true，但
+// 仍写 payloadRaw（留底）。
+func TestProject_UnknownTypeRawExcluded(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":99,"content":"系统通知"}`)
+	if !rd.RawExcluded {
+		t.Fatalf("unknown type with no typed sub-object must be rawExcluded=true")
+	}
+	if len(rd.PayloadRaw) == 0 {
+		t.Fatalf("unknown type must still retain payloadRaw")
+	}
+}
+
+// TestProject_NonObjectPayloadNoRaw payload 顶层非对象（数组）→ 不写 payloadRaw、不投影（visibility
+// 预检在上游已对此 fail-closed；此处防御性兜底）。
+func TestProject_NonObjectPayload(t *testing.T) {
+	p, raw, projected := buildPayloadFromRaw(json.RawMessage(`["a","b"]`))
+	if p != nil || raw != nil || projected {
+		t.Fatalf("non-object payload must yield nil payload/raw and projected=false: p=%v raw=%s", p, raw)
+	}
+}

--- a/internal/esindex/doc.go
+++ b/internal/esindex/doc.go
@@ -1,6 +1,7 @@
 package esindex
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -8,18 +9,24 @@ import (
 )
 
 // Doc 是写入 OpenSearch 的文档形态 —— **逐字段对齐 octo-server reader**
-// (`modules/messages_search/source.go::Doc`，PR#385)。这是分叉 B 收敛的核心：
+// (`modules/messages_search/source.go::Doc`，PR#385/PR#425)。这是分叉 B 收敛的核心：
 // 索引契约的单一真源是 reader 读的形态，indexer 写成它能读的样子（reader 不动）。
 //
 // 与旧 flat snake_case 契约（message_id/content/...）的差异（全量收敛）：
 //   - 字段名 camelCase + payload 嵌套（messageId/channelId/payload.text.content）。
 //   - messageId 用 **long**（数值，全精度）——snowflake id 不可被 float64 截断，
 //     reader 从 typed _source 读 int64 做 cursor tiebreaker（dsl.go::lastHitMessageID）。
-//   - 新增 reader 必读的 **spaceId**(keyword) / **visibles**(keyword[]) / **messageSeq**(long)：
+//   - reader 必读的 **spaceId**(keyword) / **visibles**(keyword[]) / **messageSeq**(long)：
 //     · spaceId：p2p (DM) space 召回过滤，缺则同 space 也 0 命中（reader fail-closed）。
 //     · visibles：群系统消息「仅管理员可见」白名单 gate，缺则 reader fail-OPEN（V3b）。
 //     · messageSeq：reader channel_offset「清空会话」gate（visibility.go），缺则保守隐藏。
 //   - 排序字段 timestamp + messageId 与 reader cursor sort 口径一致。
+//
+// 方案 B（CDC 式写入）新增：
+//   - **payloadRaw**：原始 payload 整包（json.RawMessage 原样存进 _source，mapping
+//     enabled:false → 不索引、不建倒排）。以后 reader 加任何字段本地 reindex 即可，不回源 backfill。
+//   - **payload.<type>.<field>** 全类型投影（text/image/gif/voice/video/file/mergeForward/richText），
+//     照搬 CDC 蓝本 ToDoc，但 **visibility 不走 raw 直读**（见 buildPayloadFromRaw 与 §3 落点）。
 //
 // 字段标签与 reader Doc 完全一致（含 omitempty），保证 reader 反序列化无歧义。
 type Doc struct {
@@ -37,19 +44,92 @@ type Doc struct {
 	RawExcluded   bool     `json:"rawExcluded,omitempty"`
 	Source        string   `json:"source,omitempty"`
 	Payload       *Payload `json:"payload,omitempty"`
+	// PayloadRaw 是原始 payload 整包，原样留底（mapping payloadRaw enabled:false → 存 _source
+	// 不索引）。仅当 payload 顶层是 JSON 对象时写（非对象在 visibility 预检即 fail-closed 落 DLQ，
+	// 不会走到这里）。用 json.RawMessage 内联存原始字节（不二次转义）。
+	PayloadRaw json.RawMessage `json:"payloadRaw,omitempty"`
 }
 
-// Payload 是结构化正文投影（镜像 reader Doc.Payload）。当前 indexer 只抽取文本正文
-// （路线甲 + 与 producer/backfill payload 抽取口径一致：非文本 raw_excluded）；媒体子对象
-// mapping 已就位但本期不填，待后续阶段细化（CONSTRAINTS v1.10 follow-up）。
+// Payload 是结构化正文投影（镜像 reader Doc.Payload + RichText 前瞻）。方案 B 后照搬 CDC
+// 蓝本 ToDoc 投全 8 类 type（text=1/image=2/gif=3/voice=4/video=5/file=8/mergeForward=11/
+// richText=14）；payloadRaw 兜底未投字段。
 type Payload struct {
-	Type *int         `json:"type,omitempty"`
-	Text *TextPayload `json:"text,omitempty"`
+	Type         *int                 `json:"type,omitempty"`
+	Text         *TextPayload         `json:"text,omitempty"`         // type=1
+	Image        *ImagePayload        `json:"image,omitempty"`        // type=2
+	Gif          *GifPayload          `json:"gif,omitempty"`          // type=3
+	Voice        *VoicePayload        `json:"voice,omitempty"`        // type=4
+	Video        *VideoPayload        `json:"video,omitempty"`        // type=5
+	File         *FilePayload         `json:"file,omitempty"`         // type=8
+	MergeForward *MergeForwardPayload `json:"mergeForward,omitempty"` // type=11
+	RichText     *RichTextPayload     `json:"richText,omitempty"`     // type=14（前瞻，reader 暂未查）
 }
 
 // TextPayload 镜像 reader Doc.Payload.Text（IK 分词字段 payload.text.content）。
 type TextPayload struct {
 	Content string `json:"content,omitempty"`
+}
+
+// ImagePayload 镜像 reader Doc.Payload.Image（payload.image.{caption,name} 可搜 + url/宽高投影）。
+type ImagePayload struct {
+	URL     string `json:"url,omitempty"`
+	Caption string `json:"caption,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Width   int    `json:"width,omitempty"`
+	Height  int    `json:"height,omitempty"`
+}
+
+// GifPayload 镜像 reader Doc.Payload.Gif（留底 url；reader 暂未查）。
+type GifPayload struct {
+	URL string `json:"url,omitempty"`
+}
+
+// VoicePayload 镜像 reader Doc.Payload.Voice（留底 url；reader 暂未查）。
+type VoicePayload struct {
+	URL string `json:"url,omitempty"`
+}
+
+// VideoPayload 镜像 reader Doc.Payload.Video（search_media 按 type=5 过滤）。
+type VideoPayload struct {
+	URL    string `json:"url,omitempty"`
+	Cover  string `json:"cover,omitempty"`
+	Width  int    `json:"width,omitempty"`
+	Height int    `json:"height,omitempty"`
+	Second int    `json:"second,omitempty"`
+}
+
+// FilePayload 镜像 reader Doc.Payload.File（payload.file.{caption,name,extension} 可搜 + url/size）。
+type FilePayload struct {
+	URL       string `json:"url,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Caption   string `json:"caption,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	Extension string `json:"extension,omitempty"`
+}
+
+// MergeForwardPayload 镜像 reader Doc.Payload.MergeForward（合并转发，type=11）。
+type MergeForwardPayload struct {
+	ChildCount int               `json:"childCount,omitempty"`
+	Msgs       []MergeForwardMsg `json:"msgs,omitempty"`
+}
+
+// MergeForwardMsg 镜像 reader Doc.Payload.MergeForward.Msgs（PR#425）。
+//
+// 🔴 命名校准（§5.2）：发送人字段锚 reader 契约的 **From `json:"from"`**（PR#425），
+// **不是** CDC 蓝本的 `fromUid`。timestamp 与 reader 一致（秒级 epoch）。
+type MergeForwardMsg struct {
+	MessageID  int64  `json:"messageId,omitempty"`
+	Type       int    `json:"type,omitempty"`
+	SearchText string `json:"searchText,omitempty"`
+	From       string `json:"from,omitempty"`      // 发送人 UID（锚 reader PR#425 `from`，非 CDC fromUid）
+	Timestamp  int64  `json:"timestamp,omitempty"` // 发送时间（秒级 epoch，与顶层 timestamp 同单位）
+}
+
+// RichTextPayload 镜像 reader 前瞻字段（type=14 图文混排，content 数组收敛为单 searchText）。
+// reader main 与 PR#425 的 Payload struct **暂无** RichText，DSL 也未查——本期前瞻投影 + mapping
+// 就位，待 reader 加查询时无需再动 indexer。CI 防漂移门当前不覆盖本字段（§8.4）。
+type RichTextPayload struct {
+	SearchText string `json:"searchText,omitempty"`
 }
 
 // idString 返回 ES `_id`（= 规范化 message_id）。messageId 为数值 snowflake，
@@ -69,17 +149,24 @@ func parseMessageID(messageID string) (int64, error) {
 	return id, nil
 }
 
-// DocFromMessage 把 Kafka 契约消息（searchmsg.Message）转成 reader 可读 Doc（实时 consumer 路径）。
+// DocFromMessage 把 Kafka 契约消息（searchmsg.Message）转成 reader 可读 Doc。
 //
-// ✅ 契约已升到 v2（SchemaVersion=2）：searchmsg.Message 携带 reader 必读的安全/正确性字段
-// SpaceID / Visibles / MessageSeq（octo-server searchetl producer 富化后填全）。DocFromMessage
-// 把这三字段从契约逐字段 copy 进 Doc —— 这正是 TestV2Gate_DocFromMessageWiresSafetyFields 钉死
-// 的「v2 bump 必须同步接线」：若解了实时安全闸（LiveContractCarriesSafetyFields）却不接线，
-// 实时路径会写出空 visibles 的 doc → reader fail-OPEN（普通成员搜出群管才可见的系统消息）。
+// 方案 B（CDC 式写入）三分支分流（§3.2，按 RawPayload 优先判，自上而下短路）：
 //
-// 注意：producer 是否对每条消息填非空 visibles 是 producer 侧 fail-closed（空 visibles → DLQ，
-// 不进 Kafka）的职责（票2）；indexer 侧只负责忠实搬运契约已带的字段。存量数据的这三字段由
-// backfill 路径（读原始 MySQL payload + searchmsg.ExtractVisibility）自源填全。
+//	分支 A  len(msg.RawPayload) > 0（非加密新形态——无论正文能否投影）
+//	   · visibility：**不在此解析**。由调用方（实时路径 = consumer.processBatch 预检；
+//	     backfill = docFromRow）先调 searchmsg.ExtractVisibility fail-closed 并把结果回填进
+//	     msg.SpaceID/msg.Visibles，DocFromMessage **只消费**回填值（唯一权威解析落点见 §3.4/§3.5）。
+//	   · 正文：buildPayloadFromRaw(RawPayload)（纯投影，不碰 visibility）。能投则投；
+//	     投不出任何 typed 子对象的未知 type → doc.RawExcluded=true（§5.5），但 visibility 已设、非 fail-OPEN。
+//	   · payloadRaw 整包留底。
+//	分支 B  len(msg.RawPayload) == 0 且 msg.RawExcluded == true（加密 DM：RawPayload=nil + RawExcluded=true）
+//	   · 跳过解析（绝不把密文喂 parser）；spaceId/visibles 留空（加密 DM reader fail-closed 安全方向）；不投影。
+//	分支 C  else（在飞老 v2：无 RawPayload、非加密、RawExcluded=false）
+//	   · 过渡期信契约 msg.SpaceID/msg.Visibles（producer 富化仍在线，§3.3）；正文走旧 buildPayload。
+//	   · 迁移窗 backfill 会用 ExtractVisibility 重解析覆盖重写本类 doc，故过渡期信契约是有限过渡、非永久信任洞。
+//
+// 🔴 DocFromMessage 函数体内**绝不出现** ExtractVisibility（唯一权威解析落点在调用方预检，§3.5）。
 func DocFromMessage(msg searchmsg.Message) (Doc, error) {
 	id, err := parseMessageID(msg.MessageID)
 	if err != nil {
@@ -92,19 +179,41 @@ func DocFromMessage(msg searchmsg.Message) (Doc, error) {
 		From:          msg.FromUID,
 		ChannelID:     msg.ChannelID,
 		ChannelType:   uint32(msg.ChannelType),
-		SpaceID:       msg.SpaceID,
-		Visibles:      msg.Visibles,
-		Timestamp:     msg.MsgTimestamp,
-		CreatedAt:     msg.CreatedAt,
-		RawExcluded:   msg.RawExcluded,
-		Source:        msg.Source,
+		// spaceId/visibles：分支 A 消费调用方预检回填值；分支 C 信契约；分支 B 留空。
+		SpaceID:     msg.SpaceID,
+		Visibles:    msg.Visibles,
+		Timestamp:   msg.MsgTimestamp,
+		CreatedAt:   msg.CreatedAt,
+		RawExcluded: msg.RawExcluded,
+		Source:      msg.Source,
 	}
-	d.Payload = buildPayload(msg.ContentType, msg.Content)
+
+	switch {
+	case len(msg.RawPayload) > 0:
+		// 分支 A：非加密新形态。纯正文投影 + payloadRaw 留底。
+		payload, rawForStore, projected := buildPayloadFromRaw(msg.RawPayload)
+		d.Payload = payload
+		d.PayloadRaw = rawForStore
+		// To 投影沿用蓝本 reversePeer 模式，入参取**契约** ChannelID/From（不从 payloadRaw 读，
+		// 防恶意 payloadRaw 篡改 To，§5.2 U-2）；buildPayloadFromRaw 不产出 To。
+		if d.ChannelType == channelTypePerson {
+			d.To = reversePeer(d.ChannelID, d.From)
+		}
+		// RawExcluded 重定义（§5.5）：产出了 typed 可搜子对象 → false；未知 type 投不出 → true。
+		d.RawExcluded = !projected
+	case msg.RawExcluded:
+		// 分支 B：加密 DM（RawPayload=nil + RawExcluded=true）。跳过解析、不投影、visibles 留空。
+		d.Payload = nil
+		d.RawExcluded = true
+	default:
+		// 分支 C：在飞老 v2（无 RawPayload、非加密）。信契约 visibles + 旧正文投影。
+		d.Payload = buildPayload(msg.ContentType, msg.Content)
+	}
 	return d, nil
 }
 
-// buildPayload 构造 reader 可读的 payload 投影。payload.type 始终带（reader _search_all
-// 据此分流）；仅文本且 content 非空时填 payload.text.content（IK 分词）。
+// buildPayload 构造 reader 可读的 payload 投影（**旧路径**：在飞老 v2 分支 C 用）。payload.type
+// 始终带（reader _search_all 据此分流）；仅文本且 content 非空时填 payload.text.content（IK 分词）。
 func buildPayload(contentType int, content *string) *Payload {
 	ct := contentType
 	p := &Payload{Type: &ct}
@@ -118,19 +227,23 @@ func buildPayload(contentType int, content *string) *Payload {
 // payloadTypeText / producer extract 口径一致。
 const payloadTypeText = 1
 
-// SafetyFieldsSchemaVersion 是 Kafka 契约（searchmsg.Message）开始携带 reader 必读的
-// 安全/正确性字段（SpaceID + Visibles + MessageSeq）的最小 SchemaVersion。
+// SafetyFieldsSchemaVersion 是 Kafka 契约（searchmsg.Message）携带 reader 必读的安全/正确性
+// 字段（SpaceID + Visibles + MessageSeq）的最小 SchemaVersion。当前契约 searchmsg.SchemaVersion
+// **已 ==2**，故本 gate 恒 true、实时写入解封。
 //
-// 当前契约 searchmsg.SchemaVersion==1 **不带**这三字段（producer 只抽 content），故实时
-// consumer 路径写出的 doc 这三字段为空——reader 对空 visibles 是 **fail-OPEN**（群系统消息
-// 普通成员能搜出群管才可见消息），对空 spaceId(p2p) fail-closed，对 messageSeq=0 保守隐藏。
-// 把这三字段灌进 Kafka 契约需 octo-lib 升 SchemaVersion 1→2 + octo-server producer 富化
-// （阶段 9 上线前置）。届时 indexer 重 pin 到带这些字段的 octo-lib，SchemaVersion 升到本值，
-// LiveContractCarriesSafetyFields() 自动转 true，实时路径解除写入封锁。
+// 🔴 方案 B 语义重定义（§3.6）：本常量 + 下方 gate 仅保证「Kafka 契约 ≥ v2（带 RawPayload 投影
+// 能力的最低契约版本）」。**方案 B 后，实时写入的 visibility fail-closed 安全保证来自消费侧
+// consumer.processBatch 预检调 searchmsg.ExtractVisibility（§3.4），不再来自『契约是否带 visibles』。**
+// 故此 gate 不再是 visibility 安全的充分条件，仅是契约版本下限闸；安全充分性由 §3.4 预检保证。
+// 不 bump SchemaVersion（consumer 严格相等校验，bump=在飞 v2 消息全进 DLQ 风暴）。改 SchemaVersion 前必读本注释。
 const SafetyFieldsSchemaVersion = 2
 
-// LiveContractCarriesSafetyFields 报告当前编译进二进制的 Kafka 契约是否已携带 reader 必读的
-// 安全字段（SpaceID/Visibles/MessageSeq）。consumer 据此决定是否允许实时写入（防 V3b fail-OPEN）。
+// LiveContractCarriesSafetyFields 报告当前编译进二进制的 Kafka 契约版本是否 ≥ v2。
+//
+// 🔴 方案 B 语义重定义（§3.6）：本 gate 仅是**契约版本下限闸**（≥ v2 即带 RawPayload 投影能力）。
+// 实时写入的 visibility fail-closed 安全**不再**由本 gate 保证，而由消费侧 processBatch 预检调
+// ExtractVisibility（§3.4）保证。consumer 据本 gate 决定是否允许实时写入（契约版本前置），但安全
+// 充分性由预检负责，二者不可混淆。
 func LiveContractCarriesSafetyFields() bool {
 	return searchmsg.SchemaVersion >= SafetyFieldsSchemaVersion
 }

--- a/internal/esindex/doc_test.go
+++ b/internal/esindex/doc_test.go
@@ -26,6 +26,22 @@ type readerDoc struct {
 	} `json:"payload"`
 }
 
+// branchAMsg 构造一条方案 B 分支 A 消息（非加密新形态，带 RawPayload 整包）。visibility 由
+// 上游预检回填，这里直接给定（投影测试只关心正文投影；visibility 三分支另有专测）。
+func branchAMsg(id, rawPayload string) searchmsg.Message {
+	return searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     id,
+		ChannelID:     "g_1",
+		ChannelType:   2,
+		FromUID:       "u_1",
+		MsgTimestamp:  1700000000,
+		CreatedAt:     1700000001,
+		Source:        searchmsg.SourceETLMessageTable,
+		RawPayload:    json.RawMessage(rawPayload),
+	}
+}
+
 func textMsg(id string) searchmsg.Message {
 	c := "你好 world"
 	return searchmsg.Message{
@@ -104,18 +120,20 @@ func TestDocFromMessage_NonNumericIsError(t *testing.T) {
 	}
 }
 
-// TestDocFromMessage_RawExcludedNoText raw_excluded（非文本/加密）→ 无 payload.text，但仍占一个 doc。
+// TestDocFromMessage_RawExcludedNoText raw_excluded（无 RawPayload，加密/老形态）→ 走分支 B：
+// 不投影正文（Payload nil），但仍占一个 doc 且 rawExcluded 标志保留。
 func TestDocFromMessage_RawExcludedNoText(t *testing.T) {
 	m := textMsg("42")
 	m.RawExcluded = true
 	m.Content = nil
 	m.ContentType = 2 // image
+	// 无 RawPayload → 分支 B（加密 DM 形态）：不解析、不投影。
 	d, err := DocFromMessage(m)
 	if err != nil {
 		t.Fatalf("DocFromMessage: %v", err)
 	}
-	if d.Payload == nil || d.Payload.Text != nil {
-		t.Fatalf("raw_excluded must not carry payload.text: %+v", d.Payload)
+	if d.Payload != nil {
+		t.Fatalf("raw_excluded without RawPayload (branch B) must not carry a payload projection: %+v", d.Payload)
 	}
 	if !d.RawExcluded {
 		t.Fatalf("rawExcluded flag must round-trip")

--- a/internal/esindex/drift_gate_test.go
+++ b/internal/esindex/drift_gate_test.go
@@ -1,0 +1,74 @@
+package esindex
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// 本文件是方案 B §8 CI 防漂移门（indexer 侧 + STOP-8 单仓 fallback）：断言 reader 实查的 OS doc
+// 字段集 ⊆ indexer 写出（mapping 可索引）字段集，违则红。防止 reader 加字段而 indexer 漏写，
+// 重蹈写读不对称覆辙。
+//
+// 跨仓同步（STOP-8）：理想是 indexer CI 用 gh api 拉 octo-server reader_fields.json diff 本仓副本；
+// 无跨仓 CI 凭证时降级为本仓 checked-in 快照 testdata/reader_fields.json（人工维护 + 文件头互相注释
+// 同步纪律）。本测试在单仓内有效（mapping ⊇ 快照）；跨仓自动同步是 follow-up。
+//
+// ⚠️ richText 前瞻字段（§8.4）：reader 当前未查 richText，故 reader_fields.json 不含它，本门对
+// richText **天然不覆盖**（reader 空集）。依赖人工在 reader 加 richText 查询时同步加 indexer 投影/
+// mapping。不要因为本门绿就认为 richText 投影被保护。
+
+// TestDriftGate_ReaderFieldsSubsetOfMapping 断言 reader_fields.json ⊆ mapping 可索引字段集
+// （拍平 mapping，跳过 enabled:false 的 payloadRaw）。任一 reader 字段缺失 → 红。
+func TestDriftGate_ReaderFieldsSubsetOfMapping(t *testing.T) {
+	mappingFields, err := MappingIndexableFieldPaths()
+	if err != nil {
+		t.Fatalf("MappingIndexableFieldPaths: %v", err)
+	}
+	b, err := os.ReadFile("testdata/reader_fields.json")
+	if err != nil {
+		t.Fatalf("read reader_fields.json: %v", err)
+	}
+	var readerFields []string
+	if err := json.Unmarshal(b, &readerFields); err != nil {
+		t.Fatalf("parse reader_fields.json: %v", err)
+	}
+	if len(readerFields) == 0 {
+		t.Fatal("reader_fields.json is empty — the drift gate would be vacuously green")
+	}
+	for _, f := range readerFields {
+		if !mappingFields[f] {
+			t.Fatalf("DRIFT: reader field %q is NOT in the indexer mapping (write-read asymmetry). "+
+				"Add it to mapping/octo-message.json + the projection, or update reader_fields.json if reader dropped it.", f)
+		}
+	}
+}
+
+// TestDriftGate_PayloadRawNotIndexable payloadRaw 是 enabled:false BLOB，**不应**出现在可索引字段
+// 集里（拍平须跳过 enabled:false 子树）——否则 drift 门会错误地要求 reader 查它。
+func TestDriftGate_PayloadRawNotIndexable(t *testing.T) {
+	mappingFields, err := MappingIndexableFieldPaths()
+	if err != nil {
+		t.Fatalf("MappingIndexableFieldPaths: %v", err)
+	}
+	for f := range mappingFields {
+		if f == "payloadRaw" || len(f) >= 11 && f[:11] == "payloadRaw." {
+			t.Fatalf("payloadRaw (enabled:false) must be excluded from indexable fields, found %q", f)
+		}
+	}
+}
+
+// TestDriftGate_RequiredNewFieldsInMapping 断言本期新增字段在 mapping 可索引集（mergeForward
+// from/timestamp + richText.searchText），这与启动期 mapping-compat 断言（requiredMappingFieldPaths）
+// 同源，确保两道门口径一致。
+func TestDriftGate_RequiredNewFieldsInMapping(t *testing.T) {
+	mappingFields, err := MappingIndexableFieldPaths()
+	if err != nil {
+		t.Fatalf("MappingIndexableFieldPaths: %v", err)
+	}
+	for _, f := range requiredMappingFieldPaths {
+		if !mappingFields[f] {
+			t.Fatalf("required Plan B field %q missing from embedded mapping", f)
+		}
+	}
+}

--- a/internal/esindex/mapping/octo-message.json
+++ b/internal/esindex/mapping/octo-message.json
@@ -87,13 +87,22 @@
                 "properties": {
                   "messageId":  { "type": "long" },
                   "type":       { "type": "integer" },
-                  "searchText": { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" }
+                  "searchText": { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+                  "from":       { "type": "keyword", "ignore_above": 256 },
+                  "timestamp":  { "type": "date", "format": "epoch_second" }
                 }
               }
             }
+          },
+          "richText": {
+            "type": "object",
+            "properties": {
+              "searchText": { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" }
+            }
           }
         }
-      }
+      },
+      "payloadRaw": { "type": "object", "enabled": false }
     }
   }
 }

--- a/internal/esindex/mapping_compat.go
+++ b/internal/esindex/mapping_compat.go
@@ -1,0 +1,166 @@
+package esindex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// 本文件实现两件互相关联的事，单一真源都是内嵌 mapping octo-message.json：
+//   1. flattenMappingFields：把一棵 OS mapping properties 树拍平成「可索引叶子字段的点号
+//      全路径集合」，**跳过 enabled:false 子树**（payloadRaw 不索引 → 不入集）。drift 防漂移门
+//      （drift_gate_test）与启动期 mapping-compat 断言共用此拍平逻辑，口径一处不漂。
+//   2. AssertLiveMappingCompatible：启动期 fail-closed 断言——GET 目标索引 live mapping，
+//      校验本期所有新字段路径齐备；缺则**拒启动**（loud crash），不静默灌 dynamic:strict 4xx。
+
+// requiredMappingFieldPaths 是方案 B 后 indexer 写出的、**必须**在 live mapping 里声明的字段
+// 路径（dynamic:strict 下未声明即 bulk 4xx 静默全量塌）。从内嵌 mapping 派生 + 本期新增三类：
+//   - payload.mergeForward.msgs.from / .timestamp（PR#425 锚）
+//   - payload.richText.searchText（前瞻）
+//   - payloadRaw（enabled:false，不在 flatten 集里，单独断言其声明存在 §6.4）
+//
+// 之所以钉一份显式清单而非「整张 embed mapping ⊆ live」：embed 与 live 可能因历史
+// migrate-forward 有良性差异；这里只断言**本期变更引入的新字段**齐备，命中 §6.4 的部署竞态
+// （漏迁新字段 → 启动即每条 bulk 4xx）。
+var requiredMappingFieldPaths = []string{
+	"payload.mergeForward.msgs.from",
+	"payload.mergeForward.msgs.timestamp",
+	"payload.richText.searchText",
+}
+
+// requiredDisabledObjectPaths 是必须以 enabled:false object 形态存在的留底字段（payloadRaw）。
+// 它不在 flatten 的可索引叶子集里（enabled:false 子树被跳过），故单独按「顶层 properties 里
+// 存在该键且 enabled==false」断言。
+var requiredDisabledObjectPaths = []string{"payloadRaw"}
+
+// AssertLiveMappingCompatible 启动期 fail-closed 断言：GET 目标索引 live mapping，校验本期所有
+// 新字段路径齐备（可索引字段 + payloadRaw enabled:false object）。缺任一 → 返回 error，调用方
+// 据此拒启动（loud crash），绝不静默向 dynamic:strict 索引灌 4xx。
+//
+// 🔴 与 EnsureIndex 的存在性幂等**互相独立、不打架**（eng-review §4 额外发现）：EnsureIndex 把
+// resource_already_exists 当成功以防 CrashLoop（索引存在即放行）；本断言只校验**字段路径齐备**，
+// 缺字段才 loud crash。即「索引存在」仍幂等容忍，「字段缺失」才拒启动——二者方向不冲突。
+func (w *osWriter) AssertLiveMappingCompatible(ctx context.Context) error {
+	return assertLiveMappingCompatible(ctx, w.client, w.index)
+}
+
+func assertLiveMappingCompatible(ctx context.Context, client *opensearchapi.Client, index string) error {
+	resp, err := client.Indices.Mapping.Get(ctx, &opensearchapi.MappingGetReq{Indices: []string{index}})
+	if err != nil {
+		return fmt.Errorf("esindex: mapping-compat get live mapping for %q failed: %w", index, err)
+	}
+	entry, ok := resp.Indices[index]
+	if !ok {
+		// alias / 单索引：GET 返回的 key 可能是底层具体索引名而非传入名。取唯一一个兜底。
+		if len(resp.Indices) == 1 {
+			for _, v := range resp.Indices {
+				entry = v
+				ok = true
+				break
+			}
+		}
+	}
+	if !ok {
+		return fmt.Errorf("esindex: mapping-compat live mapping for %q not found in response (got %d index entries)",
+			index, len(resp.Indices))
+	}
+
+	var root mappingNode
+	if err := json.Unmarshal(entry.Mappings, &root); err != nil {
+		return fmt.Errorf("esindex: mapping-compat parse live mapping for %q failed: %w", index, err)
+	}
+
+	indexable := flattenMappingNode(root)
+	var missing []string
+	for _, p := range requiredMappingFieldPaths {
+		if !indexable[p] {
+			missing = append(missing, p)
+		}
+	}
+	for _, p := range requiredDisabledObjectPaths {
+		if !disabledObjectPresent(root, p) {
+			missing = append(missing, p+" (enabled:false object)")
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("esindex: mapping-compat FAILED for index %q — live mapping is missing required field paths %v; "+
+			"run `make migrate-forward` to add them before starting (refusing to ingest into a dynamic:strict index that "+
+			"would 4xx every bulk item)", index, missing)
+	}
+	return nil
+}
+
+// mappingNode 是 OS mapping 树的最小递归形态：一个节点可能有 properties（子字段）、
+// enabled（object 是否索引）、type。
+type mappingNode struct {
+	Enabled    *bool                  `json:"enabled,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	Properties map[string]mappingNode `json:"properties,omitempty"`
+}
+
+// MappingIndexableFieldPaths 返回内嵌规范 mapping（octo-message.json）里所有**可索引**叶子
+// 字段的点号全路径集合（跳过 enabled:false 子树，即 payloadRaw）。drift 防漂移门用它断言
+// reader 字段 ⊆ 本集。
+func MappingIndexableFieldPaths() (map[string]bool, error) {
+	var top struct {
+		Mappings mappingNode `json:"mappings"`
+	}
+	if err := json.Unmarshal(mappingJSON, &top); err != nil {
+		return nil, fmt.Errorf("esindex: parse embedded mapping: %w", err)
+	}
+	return flattenMappingNode(top.Mappings), nil
+}
+
+// flattenMappingNode 递归遍历 mapping 节点，收集所有可索引叶子字段的点号全路径。
+// 规则：
+//   - enabled==false 的 object 子树整体跳过（不索引，payloadRaw）。
+//   - 有 properties 的节点是中间对象，递归下钻（自身不作叶子，除非它同时是某叶子——OS 里
+//     object 容器本身不可作 multi_match 字段，故只收叶子）。
+//   - 无 properties 的节点是叶子字段 → 收其全路径。
+func flattenMappingNode(root mappingNode) map[string]bool {
+	out := make(map[string]bool)
+	var walk func(prefix string, n mappingNode)
+	walk = func(prefix string, n mappingNode) {
+		if n.Enabled != nil && !*n.Enabled {
+			return // enabled:false 子树跳过（不索引）
+		}
+		if len(n.Properties) == 0 {
+			if prefix != "" {
+				out[prefix] = true
+			}
+			return
+		}
+		for name, child := range n.Properties {
+			next := name
+			if prefix != "" {
+				next = prefix + "." + name
+			}
+			walk(next, child)
+		}
+	}
+	walk("", root)
+	return out
+}
+
+// disabledObjectPresent 报告 root.properties 链路上 dotted path 处存在一个 enabled:false 的 object。
+// 当前只用于顶层 payloadRaw（path 无点号）；保留 dotted 解析以备将来。
+func disabledObjectPresent(root mappingNode, path string) bool {
+	segs := strings.Split(path, ".")
+	n := root
+	for i, seg := range segs {
+		child, ok := n.Properties[seg]
+		if !ok {
+			return false
+		}
+		if i == len(segs)-1 {
+			return child.Enabled != nil && !*child.Enabled
+		}
+		n = child
+	}
+	return false
+}

--- a/internal/esindex/mapping_compat_test.go
+++ b/internal/esindex/mapping_compat_test.go
@@ -1,0 +1,117 @@
+package esindex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// mappingTransport 模拟 GET <index>/_mapping，返回注入的 live mapping body。
+type mappingTransport struct {
+	body string
+}
+
+func (m *mappingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "_mapping") {
+		return mkResp(200, m.body), nil
+	}
+	return mkResp(200, "{}"), nil
+}
+
+func mappingWriter(t *testing.T, rt http.RoundTripper) *osWriter {
+	t.Helper()
+	w, err := NewWriter(Config{Addresses: []string{"http://os.test:9200"}, Index: "octo-message", Transport: rt})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	return w.(*osWriter)
+}
+
+// liveMappingBody 包装 properties 成 GET _mapping 的应答形态。
+func liveMappingBody(propsJSON string) string {
+	return `{"octo-message":{"mappings":{"dynamic":"strict","properties":` + propsJSON + `}}}`
+}
+
+// TestMappingCompat_FullEmbeddedMappingPasses 用内嵌规范 mapping 当 live mapping → 断言通过
+// （本期所有新字段路径齐备 + payloadRaw enabled:false）。
+func TestMappingCompat_FullEmbeddedMappingPasses(t *testing.T) {
+	var embedded struct {
+		Mappings struct {
+			Properties json.RawMessage `json:"properties"`
+		} `json:"mappings"`
+	}
+	if err := json.Unmarshal(IndexMappingJSON(), &embedded); err != nil {
+		t.Fatalf("parse embedded mapping: %v", err)
+	}
+	rt := &mappingTransport{body: liveMappingBody(string(embedded.Mappings.Properties))}
+	w := mappingWriter(t, rt)
+	if err := w.AssertLiveMappingCompatible(context.Background()); err != nil {
+		t.Fatalf("full embedded mapping must pass compat assertion, got %v", err)
+	}
+}
+
+// TestMappingCompat_MissingPayloadRawFails 🔴 §9 S7：live mapping 缺 payloadRaw → 断言失败
+// （调用方据此拒启动，不静默向 dynamic:strict 灌 4xx）。
+func TestMappingCompat_MissingPayloadRawFails(t *testing.T) {
+	// 含 mergeForward.from/timestamp + richText，但**无** payloadRaw。
+	props := `{
+		"messageId":{"type":"long"},
+		"payload":{"type":"object","properties":{
+			"type":{"type":"integer"},
+			"mergeForward":{"type":"object","properties":{"msgs":{"type":"object","properties":{
+				"from":{"type":"keyword"},"timestamp":{"type":"date","format":"epoch_second"}}}}},
+			"richText":{"type":"object","properties":{"searchText":{"type":"text"}}}
+		}}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil {
+		t.Fatal("missing payloadRaw must FAIL the compat assertion (refuse to start)")
+	}
+	if !strings.Contains(err.Error(), "payloadRaw") {
+		t.Fatalf("error must name payloadRaw, got %v", err)
+	}
+}
+
+// TestMappingCompat_MissingMergeForwardFromFails live mapping 缺 mergeForward.msgs.from → 失败。
+func TestMappingCompat_MissingMergeForwardFromFails(t *testing.T) {
+	props := `{
+		"messageId":{"type":"long"},
+		"payload":{"type":"object","properties":{
+			"type":{"type":"integer"},
+			"mergeForward":{"type":"object","properties":{"msgs":{"type":"object","properties":{
+				"timestamp":{"type":"date","format":"epoch_second"}}}}},
+			"richText":{"type":"object","properties":{"searchText":{"type":"text"}}}
+		}},
+		"payloadRaw":{"type":"object","enabled":false}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "payload.mergeForward.msgs.from") {
+		t.Fatalf("missing mergeForward.msgs.from must fail naming the path, got %v", err)
+	}
+}
+
+// TestMappingCompat_PayloadRawMustBeDisabled payloadRaw 若被声明为普通 object（enabled 非 false）
+// → 视为缺失（必须是 enabled:false BLOB 才不会让任意子键触发 dynamic:strict 4xx）。
+func TestMappingCompat_PayloadRawMustBeDisabled(t *testing.T) {
+	props := `{
+		"messageId":{"type":"long"},
+		"payload":{"type":"object","properties":{
+			"type":{"type":"integer"},
+			"mergeForward":{"type":"object","properties":{"msgs":{"type":"object","properties":{
+				"from":{"type":"keyword"},"timestamp":{"type":"date","format":"epoch_second"}}}}},
+			"richText":{"type":"object","properties":{"searchText":{"type":"text"}}}
+		}},
+		"payloadRaw":{"type":"object"}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	if err := w.AssertLiveMappingCompatible(context.Background()); err == nil {
+		t.Fatal("payloadRaw declared as an enabled object must FAIL (must be enabled:false BLOB)")
+	}
+}

--- a/internal/esindex/safetygate_test.go
+++ b/internal/esindex/safetygate_test.go
@@ -6,16 +6,17 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
 )
 
-// TestLiveContractSafetyGate 钉住实时写入安全闸的口径：当前 Kafka 契约（SchemaVersion=1）
-// 不带 spaceId/visibles/messageSeq，故实时路径必须封锁（防 reader visibles fail-OPEN）。
-// octo-lib 升到 SafetyFieldsSchemaVersion(=2) + producer 富化后才解封（阶段 9 前置）。
+// TestLiveContractSafetyGate 钉住实时写入安全闸的口径（§3.6 语义重定义后）：本 gate 仅是
+// **契约版本下限闸**——契约 SchemaVersion ≥ SafetyFieldsSchemaVersion(=2，带 RawPayload 投影能力)
+// 即放行实时写入。当前契约已 ==2 → gate 恒 true。**visibility fail-closed 安全本身来自消费侧
+// processBatch 预检调 ExtractVisibility（§3.4），不由本 gate 保证。** 不 bump SchemaVersion。
 func TestLiveContractSafetyGate(t *testing.T) {
 	want := searchmsg.SchemaVersion >= SafetyFieldsSchemaVersion
 	if got := LiveContractCarriesSafetyFields(); got != want {
 		t.Fatalf("LiveContractCarriesSafetyFields()=%v want %v", got, want)
 	}
-	// 本期断言：契约尚未携带安全字段（若 octo-lib 已 bump，此处会提示更新 pin / 解封实时路径）。
+	// 当前契约已携带版本下限（SchemaVersion>=2），gate 应放行。
 	if searchmsg.SchemaVersion < SafetyFieldsSchemaVersion && LiveContractCarriesSafetyFields() {
-		t.Fatalf("guard must stay closed while contract lacks safety fields")
+		t.Fatalf("gate must stay closed while contract is below the v2 floor")
 	}
 }

--- a/internal/esindex/testdata/reader_fields.json
+++ b/internal/esindex/testdata/reader_fields.json
@@ -1,0 +1,21 @@
+[
+  "messageId",
+  "messageSeq",
+  "channelId",
+  "channelType",
+  "from",
+  "to",
+  "spaceId",
+  "visibles",
+  "timestamp",
+  "payload.type",
+  "payload.text.content",
+  "payload.image.caption",
+  "payload.image.name",
+  "payload.file.caption",
+  "payload.file.name",
+  "payload.file.extension",
+  "payload.mergeForward.msgs.searchText",
+  "payload.mergeForward.msgs.from",
+  "payload.mergeForward.msgs.timestamp"
+]

--- a/internal/esindex/v2gate_test.go
+++ b/internal/esindex/v2gate_test.go
@@ -20,26 +20,25 @@ var safetyFieldNames = []struct {
 
 // TestV2Gate_DocFromMessageWiresSafetyFields 🔴 v2-gate latent fail-open 防回归门（Jerry 两轮点名）。
 //
-// 背景：实时安全闸（consumer.Run / LiveContractCarriesSafetyFields）只看 searchmsg.SchemaVersion>=2
-// 就解封实时写入。但 DocFromMessage 当前**不 copy** spaceId/visibles/messageSeq（v1 契约根本没这仨
-// 字段）。隐患：将来有人把 octo-lib bump 到 v2（加字段 + 升 SchemaVersion）解了闸，却忘了同步给
-// DocFromMessage 接线 —— 实时路径就会写出**空** visibles 的 doc，reader 直接 fail-OPEN（普通成员
-// 搜出群管才可见的系统消息）。安全闸开了，但数据是 fail-open 的，比闸关着更危险。
+// 背景（方案 B 后语义，§3）：契约已是 v2（SchemaVersion=2）。DocFromMessage 对**分支 C**（在飞
+// 老 v2 消息：无 RawPayload、非加密）信任契约带的 spaceId/visibles/messageSeq 并 copy 进 Doc。
+// 隐患：若有人删了 DocFromMessage 对这三字段的 copy，分支 C 就会写出**空** visibles 的 doc，
+// reader 直接 fail-OPEN（普通成员搜出群管才可见的系统消息）。本门钉死分支 C 的接线。
 //
-// 本测试用**反射**实现，故在 v1（字段尚不存在）下能正常编译/通过；一旦契约升到 v2：
-//   - 若 searchmsg.Message 没有这三字段 → 报错（契约 bump 不完整）。
-//   - 若有字段但 DocFromMessage 没把它们 copy 进 Doc → 断言失败转红（这正是要拦的 latent fail-open）。
+// 注意区分：**分支 A**（带 RawPayload 的新形态）的 visibility 来自消费侧 processBatch 预检
+// （ExtractVisibility 回填进 msg），DocFromMessage 同样只是 copy 已回填值——本测试不带 RawPayload，
+// 故走分支 C，验证「契约带的安全字段被忠实搬运」。
 //
-// 即「v2 bump 不接线就过不了 CI」。接线（DocFromMessage 填全三字段）后本测试自动转绿。
+// 本测试用**反射**写哨兵值（历史上为兼容 v1 契约无字段而用反射，现 v2 字段已在，反射仍可用）。
 func TestV2Gate_DocFromMessageWiresSafetyFields(t *testing.T) {
 	if !LiveContractCarriesSafetyFields() {
-		// 契约仍是 v1（SchemaVersion<2）：这三字段尚未进 Kafka 契约，实时闸保持关闭（由
-		// TestLiveContractSafetyGate 钉死），此 latent 隐患尚未被激活。本门在 v2 bump 时自动生效。
-		t.Skipf("contract still v1 (SchemaVersion=%d < %d); v2-gate inactive until contract bump",
+		// 契约版本低于 v2 下限（理论上不应发生，当前 SchemaVersion 已 ==2）：实时闸保持关闭
+		// （由 TestLiveContractSafetyGate 钉死）。本门在契约 ≥ v2 时生效。
+		t.Skipf("contract below v2 floor (SchemaVersion=%d < %d); v2-gate inactive",
 			searchmsg.SchemaVersion, SafetyFieldsSchemaVersion)
 	}
 
-	// ── 契约已升到 v2：强制要求 DocFromMessage 把三个安全字段从契约 copy 进 Doc ──
+	// ── 分支 C（无 RawPayload）：强制要求 DocFromMessage 把三个安全字段从契约 copy 进 Doc ──
 	msg := searchmsg.Message{
 		SchemaVersion: searchmsg.SchemaVersion,
 		MessageID:     "123456789012345678",
@@ -47,7 +46,7 @@ func TestV2Gate_DocFromMessageWiresSafetyFields(t *testing.T) {
 		ChannelType:   2,
 	}
 
-	// 反射写入三个安全字段的哨兵值（字段在 v2 契约里才存在，故用反射，避免 v1 下编译失败）。
+	// 反射写入三个安全字段的哨兵值。
 	mv := reflect.ValueOf(&msg).Elem()
 	const (
 		sentSpace = "space-sentinel"
@@ -57,8 +56,7 @@ func TestV2Gate_DocFromMessageWiresSafetyFields(t *testing.T) {
 	for _, f := range safetyFieldNames {
 		fv := mv.FieldByName(f.msgField)
 		if !fv.IsValid() {
-			t.Fatalf("contract bumped to v2 (SchemaVersion=%d) but searchmsg.Message lacks field %q; "+
-				"a v2 bump must add SpaceID/Visibles/MessageSeq to the contract", searchmsg.SchemaVersion, f.msgField)
+			t.Fatalf("v2 contract must carry field %q (SpaceID/Visibles/MessageSeq)", f.msgField)
 		}
 		setSentinel(t, fv, f.msgField, sentSpace, sentVis, sentSeq)
 	}

--- a/internal/esindex/visibility_landing_test.go
+++ b/internal/esindex/visibility_landing_test.go
@@ -1,0 +1,79 @@
+package esindex
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// 本文件是方案 B §3.5（visibility 唯一权威解析落点）+ §3.6（gate 语义重定义防漂移）的静态守门，
+// 防止弱执行者把 visibility 直读 / fail-OPEN 回归 / stale 注释漂移悄悄带回。
+
+// readSrc 读取本包某源文件正文（去掉 _test.go 自身，避免测试断言串匹配到测试代码）。
+func readSrc(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// funcBody 粗粒度抽取一个顶层函数体（从 "func <name>(" 到下一个顶层 "\nfunc " 或文件末尾）。
+func funcBody(src, fnSig string) string {
+	idx := strings.Index(src, fnSig)
+	if idx < 0 {
+		return ""
+	}
+	rest := src[idx+len(fnSig):]
+	if next := strings.Index(rest, "\nfunc "); next >= 0 {
+		return rest[:next]
+	}
+	return rest
+}
+
+// TestBuildPayloadFromRaw_NoVisibilityRead 🔴 §3.5 STOP-2 静态守：buildPayloadFromRaw 是纯正文
+// 投影，函数体内**绝不**出现 ExtractVisibility / 直读 "visibles" / "space_id"。出现 = fail-OPEN 回归。
+func TestBuildPayloadFromRaw_NoVisibilityRead(t *testing.T) {
+	body := funcBody(readSrc(t, "buildraw.go"), "func buildPayloadFromRaw(")
+	if body == "" {
+		t.Fatal("buildPayloadFromRaw not found in buildraw.go")
+	}
+	for _, banned := range []string{"ExtractVisibility", `"visibles"`, `"space_id"`} {
+		if strings.Contains(body, banned) {
+			t.Fatalf("§3.5 STOP-2 regression: buildPayloadFromRaw must not reference %q (visibility is parsed only in the consumer/backfill pre-check; this func is pure body projection)", banned)
+		}
+	}
+}
+
+// TestDocFromMessage_NoVisibilityParse 🔴 §3.5：DocFromMessage 只消费回填值，函数体内**不**出现
+// ExtractVisibility（唯一权威解析落点在 consumer.processBatch 预检 / backfill docFromRow）。
+func TestDocFromMessage_NoVisibilityParse(t *testing.T) {
+	body := funcBody(readSrc(t, "doc.go"), "func DocFromMessage(")
+	if body == "" {
+		t.Fatal("DocFromMessage not found in doc.go")
+	}
+	if strings.Contains(body, "ExtractVisibility") {
+		t.Fatal("§3.5 regression: DocFromMessage must not call ExtractVisibility (single authoritative parse landing point is the consumer pre-check / backfill, not here)")
+	}
+}
+
+// TestGateComments_NoStaleSchemaV1 🔴 §3.6 S-gate lint（必跑门）：本包源文件不得再出现「契约是 v1 /
+// SchemaVersion==1 / 契约仍是 v1」这类 stale 误导注释；且 doc.go 必须出现「安全来自消费侧」语义关键字。
+func TestGateComments_NoStaleSchemaV1(t *testing.T) {
+	// stale 锚点：宣称契约 v1 / SchemaVersion==1 不带安全字段（误导后人改 schema）。
+	staleRe := regexp.MustCompile(`SchemaVersion *== *1|SchemaVersion 1|契约是 v1|契约仍是 v1`)
+	// §3.6 点名的 stale 锚点宿主文件（doc.go const/函数注释 + 两个 test 文件）。
+	for _, f := range []string{"doc.go", "v2gate_test.go", "safetygate_test.go"} {
+		src := readSrc(t, f)
+		if loc := staleRe.FindString(src); loc != "" {
+			t.Fatalf("§3.6 stale gate comment found in %s (%q): the contract is v2; rewrite to 'safety comes from the consumer-side pre-check'", f, loc)
+		}
+	}
+	// doc.go 必须出现重定义后的语义关键字（安全来自消费侧预检）。
+	docSrc := readSrc(t, "doc.go")
+	if !strings.Contains(docSrc, "消费侧") || !strings.Contains(docSrc, "ExtractVisibility") {
+		t.Fatal("§3.6 gate comment in doc.go must state the visibility safety now comes from the consumer-side ExtractVisibility pre-check")
+	}
+}

--- a/internal/esindex/writer.go
+++ b/internal/esindex/writer.go
@@ -270,7 +270,11 @@ func (w *osWriter) bulkOnce(ctx context.Context, docs []Doc) ([]BulkItemResult, 
 
 	body, err := encodeBulkBody(docs)
 	if err != nil {
-		return nil, err
+		// 编码失败也是批级失败：必须返回与 docs 等长、位置对齐的结果切片（batchFailure），
+		// 绝不返回 nil。否则 BulkDocs 的 out 会比 sub 短，上层 Bulk() 按位 docRes[j]↔docIdx[j]
+		// 归属时整体错位 → 一条编码失败 doc 可能被贴上另一条的 success → 误判已索引、既不进 DLQ
+		// 也搜不到（静默丢消息）。标 transient(Status=0) 让调用方整批退避重试。
+		return batchFailure(docs, err), fmt.Errorf("esindex: encode bulk body failed: %w", err)
 	}
 
 	resp, err := w.client.Bulk(ctx, opensearchapi.BulkReq{

--- a/internal/esindex/writer.go
+++ b/internal/esindex/writer.go
@@ -36,6 +36,11 @@ type Writer interface {
 	// EnsureIndex 幂等创建目标索引（不存在则用内嵌 mapping 创建，已存在则不动）。
 	// 供服务启动与 backfill job 复用同一套 mapping bootstrap。
 	EnsureIndex(ctx context.Context) error
+	// AssertLiveMappingCompatible 启动期 fail-closed 断言：GET 目标索引 live mapping，校验本期
+	// 所有新字段路径齐备（payload.mergeForward.msgs.{from,timestamp} / payload.richText.searchText /
+	// payloadRaw enabled:false）。缺则返回 error，调用方拒启动（loud crash），不静默向
+	// dynamic:strict 索引灌 4xx（§6.4 部署竞态防护）。与 EnsureIndex 存在性幂等互相独立。
+	AssertLiveMappingCompatible(ctx context.Context) error
 	// Bulk 幂等写入一批 Kafka 契约消息（实时 consumer 路径）。内部转 reader 可读 Doc 后
 	// bulk upsert；契约 message_id 非数值（无法对齐 reader long messageId）的条目按
 	// **永久错误（4xx 语义，Status=400）**回报，由 consumer 路由 DLQ，绝不静默落 0。
@@ -184,9 +189,81 @@ func (w *osWriter) Bulk(ctx context.Context, msgs []searchmsg.Message) ([]BulkIt
 	return out, nil
 }
 
+// maxBulkBodyBytes 是单次 _bulk 请求体的字节上限（软阈值，留足余量低于 OpenSearch 默认
+// http.max_content_length=100MB）。方案 B 后每条 branch-A doc 内嵌 payloadRaw（可达 ~1MB），
+// 仅按条数批（如 500 条）会让 _bulk body 远超限 → 整批非 2xx → 被当 transient 无限重试 → 卡死
+// ingestion。故按**编码字节**再切子批，每子批独立 _bulk，结果按序拼接，per-item 契约不变。
+// 取 50MB（远低于 100MB 默认 + 余量），足以摊薄大 payloadRaw 又不至于子批过多。
+const maxBulkBodyBytes = 50 << 20 // 50 MiB
+
 // BulkDocs 把一批 reader 可读 Doc 以 _bulk 幂等写入 ES（backfill 富化路径直接调用）。
 // doc _id = 规范化 messageId，与实时 consumer 路径同 _id → 重叠运行幂等去重。
+//
+// 🔴 按字节切子批（codex 补）：payloadRaw 内嵌后单批体积可能远超 http.max_content_length，
+// 整批失败被当 transient 无限重试卡死。故先按 maxBulkBodyBytes 把 docs 切成多个子批，逐子批
+// _bulk，结果按入参顺序拼接返回。任一子批批级失败 → 该子批条目标 transient + 返回 error（与
+// 原单批语义一致：调用方整批退避重试；下一轮同 _id 幂等覆盖已成功子批，无重复 doc）。
 func (w *osWriter) BulkDocs(ctx context.Context, docs []Doc) ([]BulkItemResult, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	out := make([]BulkItemResult, 0, len(docs))
+	var firstErr error
+	for start := 0; start < len(docs); {
+		end := subBatchEnd(docs, start)
+		sub := docs[start:end]
+		// 🔴 单条 doc 自身就超限（end==start+1 且其编码 > 阈值）：发出去会被 ES 在批级 413 拒绝，
+		// 映射成 Status=0(transient) → consumer/backfill 无限重试卡死。改判为 **permanent(413)**，
+		// 让调用方把这条毒丸路由 DLQ（不重试）。实时路径已被 producer 1MB guard 拦下，本兜底主要
+		// 防 backfill 读到异常大的历史 payloadRaw 行。
+		if len(sub) == 1 && encodedDocSize(sub[0]) > maxBulkBodyBytes {
+			out = append(out, BulkItemResult{
+				MessageID: sub[0].idString(),
+				OK:        false,
+				Status:    http.StatusRequestEntityTooLarge, // 413 → Permanent()
+				Err:       fmt.Errorf("esindex: doc %s encoded size exceeds max bulk body %d bytes (poison, routed to DLQ not retried)", sub[0].idString(), maxBulkBodyBytes),
+			})
+			start = end
+			continue
+		}
+		res, err := w.bulkOnce(ctx, sub)
+		out = append(out, res...)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		start = end
+	}
+	return out, firstErr
+}
+
+// subBatchEnd 返回从 start 起、累计编码字节不超过 maxBulkBodyBytes 的子批结束下标（半开区间）。
+// 至少含 1 条（即便单条 >阈值也单独成批——交给 ES 报错走 per-item，不在此死循环）。
+func subBatchEnd(docs []Doc, start int) int {
+	size := 0
+	for i := start; i < len(docs); i++ {
+		ds := encodedDocSize(docs[i])
+		if i > start && size+ds > maxBulkBodyBytes {
+			return i
+		}
+		size += ds
+	}
+	return len(docs)
+}
+
+// encodedDocSize 估算一条 doc 在 _bulk body 里占的字节（动作行 + 文档行 + 两个换行）。
+// marshal 失败时返回 0（该条会在 bulkOnce 编码时再次失败并按 per-item 处理）。
+func encodedDocSize(d Doc) int {
+	docJSON, err := json.Marshal(d)
+	if err != nil {
+		return 0
+	}
+	// 动作行约 ~40 字节（{"index":{"_id":"<id>"}}）+ 文档行 + 2 换行；动作行用 id 长度近似。
+	return len(docJSON) + len(d.idString()) + 24 + 2
+}
+
+// bulkOnce 执行单次 _bulk（原 BulkDocs 主体），用于 BulkDocs 的按字节子批切分。
+func (w *osWriter) bulkOnce(ctx context.Context, docs []Doc) ([]BulkItemResult, error) {
 	if len(docs) == 0 {
 		return nil, nil
 	}

--- a/internal/esindex/writer_test.go
+++ b/internal/esindex/writer_test.go
@@ -375,6 +375,79 @@ func TestBulkDocs_SplitsByByteSize(t *testing.T) {
 	}
 }
 
+// TestBulkDocs_SubBatchEncodeFailureKeepsAlignment 🔴 (返工 R1)：子批 encodeBulkBody 失败时，
+// bulkOnce 必须返回与子批等长、位置对齐的 batchFailure，绝不返回 nil。否则 BulkDocs 的 out
+// 会比 docs 短，上层 Bulk() 按位 docRes[j]↔docIdx[j] 归属时整体错位 → 一条编码失败 doc 被贴上
+// 另一条的 success → 误判已索引、既不进 DLQ 也搜不到（静默丢消息）。
+//
+// 构造：doc0 大且合法（独占第一子批，成功）；doc1 大且合法 + doc2 非法 payloadRaw（同处第二
+// 子批，encode 失败）。断言结果切片长度与入参对齐、失败条目按入参顺序正确归属、且失败子批不打 ES。
+func TestBulkDocs_SubBatchEncodeFailureKeepsAlignment(t *testing.T) {
+	bulkCalls := 0
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body := readAll(r.Body)
+		n := strings.Count(body, `{"index":`)
+		bulkCalls++
+		var sb strings.Builder
+		sb.WriteString(`{"took":1,"errors":false,"items":[`)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(`{"index":{"status":201}}`)
+		}
+		sb.WriteString(`]}`)
+		return jsonResp(200, sb.String()), nil
+	})
+	w := osWriterFor(t, rt)
+
+	// doc0/doc1 各 ~30MB 合法 → 二者相加 >50MB 阈值 → doc0 独占第一子批。
+	big := make([]byte, 30<<20)
+	for i := range big {
+		big[i] = 'x'
+	}
+	rawBig := mustRawObject(big)
+	// doc2 携带非法 JSON payloadRaw → json.Marshal 失败 → encodeBulkBody 失败；
+	// encodedDocSize 对其返回 0，故它落在 doc1 所在的第二子批里，使该子批整体编码失败。
+	docs := []Doc{
+		{MessageID: 1001, ChannelID: "g", ChannelType: 2, PayloadRaw: rawBig},
+		{MessageID: 1002, ChannelID: "g", ChannelType: 2, PayloadRaw: rawBig},
+		{MessageID: 1003, ChannelID: "g", ChannelType: 2, PayloadRaw: json.RawMessage([]byte("{not valid json"))},
+	}
+
+	res, err := w.BulkDocs(context.Background(), docs)
+	if err == nil {
+		t.Fatalf("expected a batch error from the encode-failing sub-batch, got nil")
+	}
+	// 核心回归守卫：结果切片长度必须与入参对齐（修复前会比 docs 短 → 上层错位丢消息）。
+	if len(res) != len(docs) {
+		t.Fatalf("result slice length must align with input (regression: encode-fail returned nil); got %d want %d", len(res), len(docs))
+	}
+	// 失败条目正确归属：每条结果的 MessageID 必须对应同下标的入参 doc。
+	for i := range docs {
+		if res[i].MessageID != docs[i].idString() {
+			t.Fatalf("result[%d] misattributed: MessageID=%q want %q", i, res[i].MessageID, docs[i].idString())
+		}
+	}
+	// doc0 成功（独占第一子批，已打 ES）。
+	if !res[0].OK {
+		t.Fatalf("doc0 expected OK, got %+v", res[0])
+	}
+	// doc1/doc2 同处编码失败子批 → 全部 transient(Status=0, OK=false)，让调用方整批退避重试。
+	for _, i := range []int{1, 2} {
+		if res[i].OK || res[i].Status != 0 || res[i].Err == nil {
+			t.Fatalf("doc%d expected transient failure (OK=false, Status=0, Err!=nil), got %+v", i, res[i])
+		}
+		if res[i].Permanent() {
+			t.Fatalf("doc%d encode-failure must be transient, not permanent", i)
+		}
+	}
+	// 第二子批在 encode 阶段失败，绝不应打到 ES（只有 doc0 那一次成功请求）。
+	if bulkCalls != 1 {
+		t.Fatalf("encode-failing sub-batch must not hit ES; expected exactly 1 bulk call (doc0), got %d", bulkCalls)
+	}
+}
+
 // mustRawObject 把一段大字节塞进一个合法 JSON 对象的字段值（用于构造大 payloadRaw）。
 func mustRawObject(filler []byte) []byte {
 	// {"type":2,"blob":"<filler>"}

--- a/internal/esindex/writer_test.go
+++ b/internal/esindex/writer_test.go
@@ -324,3 +324,93 @@ func TestBulk_AllNonNumericNoESCall(t *testing.T) {
 		}
 	}
 }
+
+// TestBulkDocs_SplitsByByteSize 🔴 §4.4（codex 补）：payloadRaw 内嵌后，按字节切子批，避免单次
+// _bulk body 超 http.max_content_length 被当 transient 无限重试卡死。构造多条大 payloadRaw doc，
+// 断言 BulkDocs 拆成多次 _bulk 请求，且 per-item 结果按入参顺序齐全。
+func TestBulkDocs_SplitsByByteSize(t *testing.T) {
+	bulkCalls := 0
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body := readAll(r.Body)
+		// 数请求里的动作行条数（每条一行 {"index":...}），按数生成等量成功 items。
+		n := strings.Count(body, `{"index":`)
+		bulkCalls++
+		var sb strings.Builder
+		sb.WriteString(`{"took":1,"errors":false,"items":[`)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(`{"index":{"status":201}}`)
+		}
+		sb.WriteString(`]}`)
+		return jsonResp(200, sb.String()), nil
+	})
+	w := osWriterFor(t, rt)
+
+	// 每条 doc 带 ~20MB payloadRaw → 3 条 = ~60MB > 50MB 阈值 → 至少切 2 个子批。
+	big := make([]byte, 20<<20)
+	for i := range big {
+		big[i] = 'x'
+	}
+	rawBig := mustRawObject(big)
+	docs := make([]Doc, 3)
+	for i := range docs {
+		docs[i] = Doc{MessageID: int64(1000 + i), ChannelID: "g", ChannelType: 2, PayloadRaw: rawBig}
+	}
+	res, err := w.BulkDocs(context.Background(), docs)
+	if err != nil {
+		t.Fatalf("BulkDocs: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 per-item results in input order, got %d", len(res))
+	}
+	for i := range res {
+		if !res[i].OK {
+			t.Fatalf("doc %d expected OK, got %+v", i, res[i])
+		}
+	}
+	if bulkCalls < 2 {
+		t.Fatalf("oversized total must be split into >=2 _bulk requests, got %d", bulkCalls)
+	}
+}
+
+// mustRawObject 把一段大字节塞进一个合法 JSON 对象的字段值（用于构造大 payloadRaw）。
+func mustRawObject(filler []byte) []byte {
+	// {"type":2,"blob":"<filler>"}
+	b := make([]byte, 0, len(filler)+32)
+	b = append(b, []byte(`{"type":2,"blob":"`)...)
+	b = append(b, filler...)
+	b = append(b, []byte(`"}`)...)
+	return b
+}
+
+// TestBulkDocs_SingleOversizedDocIsPermanent §4.4（codex P2 补）：单条 doc 编码自身超 _bulk 上限
+// → 不发 ES、直接判 permanent(413)，让 consumer/backfill 路由 DLQ 而非无限 transient 重试。
+func TestBulkDocs_SingleOversizedDocIsPermanent(t *testing.T) {
+	bulkCalls := 0
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		bulkCalls++
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"status":201}}]}`), nil
+	})
+	w := osWriterFor(t, rt)
+	// 一条 doc 的 payloadRaw 超过 maxBulkBodyBytes 自身。
+	huge := make([]byte, maxBulkBodyBytes+1024)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	docs := []Doc{{MessageID: 1, ChannelID: "g", ChannelType: 2, PayloadRaw: mustRawObject(huge)}}
+	res, err := w.BulkDocs(context.Background(), docs)
+	if err != nil {
+		t.Fatalf("BulkDocs must not return a batch error for a poison doc (it's per-item permanent): %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res))
+	}
+	if res[0].OK || !res[0].Permanent() {
+		t.Fatalf("oversized single doc must be permanent (DLQ-routed), got OK=%v status=%d", res[0].OK, res[0].Status)
+	}
+	if bulkCalls != 0 {
+		t.Fatalf("oversized single doc must NOT hit ES (would 413), got %d bulk calls", bulkCalls)
+	}
+}

--- a/internal/producer/chunk.go
+++ b/internal/producer/chunk.go
@@ -1,6 +1,16 @@
 package producer
 
-import "github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+import (
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// maxKafkaMessageBytes 是单条 Kafka 消息体的体积上限（留头部余量低于 broker
+// message.max.bytes 默认 1MiB=1048576）。方案 B 让 producer 发原始 payload 整包，单条体积可能
+// 逼近硬限；segmentio kafka-go 写侧超限 WriteMessages 失败 → cursor 不前进 → 死循环卡 partition
+// （注：consumer fetch 侧已 10MB，本风险是写侧/broker 侧）。故组装时按本阈值降级。
+const maxKafkaMessageBytes = 1_000_000
 
 // chunkPlan is the delivery plan produced from one batch of read source rows
 // after the stability gate + payload extraction (a pure-function product, no IO).
@@ -46,7 +56,16 @@ func planChunk(table string, rows []*srcMessageRow, cutoff int64) chunkPlan {
 		case outcomeDLQ:
 			plan.dlq = append(plan.dlq, newDLQEnvelope(table, row, reason))
 		default: // outcomeOK / outcomeRawExcluded both go to the body stream
-			plan.main = append(plan.main, msg)
+			// 🔴 Plan B oversize guard (§4.4): the raw payload整包 can push a single
+			// contract message past the Kafka write-side hard limit. Degrade (drop
+			// RawPayload, keep text-only) rather than discard; if still oversized
+			// (rare: plaintext itself >1MB) dead-letter with a TRUNCATED envelope so
+			// the DLQ write cannot itself blow the limit and wedge the partition.
+			if degraded, oversized := degradeIfOversized(msg); oversized {
+				plan.dlq = append(plan.dlq, newOversizeDLQEnvelope(table, row))
+			} else {
+				plan.main = append(plan.main, degraded)
+			}
 		}
 	}
 	plan.maxID = stable[len(stable)-1].ID
@@ -72,6 +91,41 @@ func stablePrefix(rows []*srcMessageRow, cutoff int64) []*srcMessageRow {
 		}
 	}
 	return rows
+}
+
+// degradeIfOversized applies the Plan B oversize guard (§4.4) to one body message
+// before it joins the produce batch:
+//   - fits under maxKafkaMessageBytes → return unchanged (oversized=false).
+//   - else DEGRADE not discard: drop RawPayload and re-check — keeps the text-only
+//     body searchable (avoids the v0 "discard → plaintext also unsearchable"
+//     regression). Now fits → return the degraded message (oversized=false).
+//   - STILL overflows (rare: plaintext content itself >1MB) → oversized=true; the
+//     caller dead-letters it with a truncated envelope so the DLQ write itself
+//     cannot blow the limit and wedge the partition.
+//
+// Pure function (json.Marshal only, no IO/clock) so planChunk stays deterministic.
+func degradeIfOversized(msg searchmsg.Message) (searchmsg.Message, bool) {
+	if marshaledSize(msg) <= maxKafkaMessageBytes {
+		return msg, false
+	}
+	// Degrade: drop the raw payload整包, keep the text-only body. RawExcluded stays
+	// as extractMessage set it.
+	msg.RawPayload = nil
+	if marshaledSize(msg) <= maxKafkaMessageBytes {
+		return msg, false
+	}
+	return msg, true
+}
+
+// marshaledSize returns the JSON wire size of a contract message (the exact bytes
+// produced for Kafka). On a marshal error (encoding bug, should not happen) it
+// returns over-the-limit so the guard degrades/dead-letters conservatively.
+func marshaledSize(msg searchmsg.Message) int {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return maxKafkaMessageBytes + 1
+	}
+	return len(b)
 }
 
 // firstNonAscendingByID returns the index of the first row not strictly ascending

--- a/internal/producer/chunk_oversize_test.go
+++ b/internal/producer/chunk_oversize_test.go
@@ -1,0 +1,112 @@
+package producer
+
+import (
+	"strings"
+	"testing"
+)
+
+// bigPayload 构造一个总体 >maxKafkaMessageBytes 的合法 JSON payload，content 字段可控大小。
+func bigPayload(contentType int, contentSize int) []byte {
+	filler := strings.Repeat("x", contentSize)
+	if contentType == contentTypeText {
+		return []byte(`{"type":1,"content":"` + filler + `"}`)
+	}
+	// 非文本（媒体）：把巨量放在一个非可搜字段，content 为空（degrade 后正文很小）。
+	return []byte(`{"type":2,"name":"a.png","blob":"` + filler + `"}`)
+}
+
+// TestOversize_DegradeMediaToTextOnly §4.4：大 RawPayload + 小/无正文（媒体）→ degrade：清空
+// RawPayload 发 text-only，进 main、不进 DLQ（cursor 仍前进）。
+func TestOversize_DegradeMediaKeepsBody(t *testing.T) {
+	// 媒体消息，RawPayload 巨大但 Content 为 nil（media raw_excluded）。
+	row := &srcMessageRow{
+		ID: 1, MessageID: "1", ChannelType: 2, CreatedUnix: 100,
+		Payload: bigPayload(2, maxKafkaMessageBytes+50_000),
+	}
+	plan := planChunk("message", []*srcMessageRow{row}, 1_000_000_000)
+	if len(plan.dlq) != 0 {
+		t.Fatalf("media oversize must DEGRADE not DLQ, got %d dlq", len(plan.dlq))
+	}
+	if len(plan.main) != 1 {
+		t.Fatalf("media oversize must still produce a body message, got %d", len(plan.main))
+	}
+	if len(plan.main[0].RawPayload) != 0 {
+		t.Fatalf("degraded message must have RawPayload dropped, got %d bytes", len(plan.main[0].RawPayload))
+	}
+	if marshaledSize(plan.main[0]) > maxKafkaMessageBytes {
+		t.Fatalf("degraded message must be under the Kafka limit, got %d", marshaledSize(plan.main[0]))
+	}
+}
+
+// TestOversize_TextOnlyStillOversizeToDLQ §4.4：纯文本本身 >1MB（degrade 后仍超限）→ 落 DLQ，
+// 且 DLQ 信封截断（RawPayload 抛弃、Detail 带截断标记），保证 DLQ 写入不超限。
+func TestOversize_HugePlaintextToTruncatedDLQ(t *testing.T) {
+	row := &srcMessageRow{
+		ID: 1, MessageID: "1", ChannelType: 2, CreatedUnix: 100,
+		Payload: bigPayload(contentTypeText, maxKafkaMessageBytes+50_000),
+	}
+	plan := planChunk("message", []*srcMessageRow{row}, 1_000_000_000)
+	if len(plan.main) != 0 {
+		t.Fatalf("huge plaintext must NOT go to body topic, got %d main", len(plan.main))
+	}
+	if len(plan.dlq) != 1 {
+		t.Fatalf("huge plaintext must DLQ, got %d", len(plan.dlq))
+	}
+	env := plan.dlq[0]
+	if env.Reason != dlqReasonOversize {
+		t.Fatalf("oversize DLQ reason = %q, want %q", env.Reason, dlqReasonOversize)
+	}
+	if len(env.RawPayload) != 0 {
+		t.Fatalf("oversize DLQ envelope must TRUNCATE RawPayload (else DLQ write blows the limit), got %d bytes", len(env.RawPayload))
+	}
+	if !strings.Contains(env.Detail, "payload_truncated") {
+		t.Fatalf("oversize DLQ must carry truncation marker in Detail: %q", env.Detail)
+	}
+	// 源定位齐备（回灌从源表重取）。
+	if env.ShardTable != "message" || env.SourceID != 1 || env.MessageID != "1" {
+		t.Fatalf("oversize DLQ must keep source locator for replay: %+v", env)
+	}
+}
+
+// TestOversize_NormalMessageUnchanged 正常小消息不受影响：RawPayload 保留、进 main。
+func TestOversize_NormalKeepsRawPayload(t *testing.T) {
+	row := &srcMessageRow{
+		ID: 1, MessageID: "1", ChannelType: 2, CreatedUnix: 100,
+		Payload: []byte(`{"type":1,"content":"小消息"}`),
+	}
+	plan := planChunk("message", []*srcMessageRow{row}, 1_000_000_000)
+	if len(plan.main) != 1 || len(plan.dlq) != 0 {
+		t.Fatalf("normal message must go to body unchanged: main=%d dlq=%d", len(plan.main), len(plan.dlq))
+	}
+	if len(plan.main[0].RawPayload) == 0 {
+		t.Fatalf("normal message must retain RawPayload (Plan B)")
+	}
+}
+
+// TestNewDLQEnvelope_OrdinaryOversizeTruncates §4.4（codex 补）：普通毒丸（visibility/parse 失败）
+// 若源 payload 很大，普通 DLQ 信封也必须截断 RawPayload（否则 base64 膨胀过 1MiB → DLQ 写 wedge）。
+func TestNewDLQEnvelope_OrdinaryOversizeTruncates(t *testing.T) {
+	big := make([]byte, maxDLQRawPayloadBytes+1)
+	for i := range big {
+		big[i] = 'x'
+	}
+	row := &srcMessageRow{ID: 7, MessageID: "7", ChannelType: 2, Payload: big}
+	env := newDLQEnvelope("message", row, dlqReasonVisibilityUntrusted)
+	if len(env.RawPayload) != 0 {
+		t.Fatalf("ordinary DLQ envelope with oversized payload must truncate RawPayload, got %d bytes", len(env.RawPayload))
+	}
+	if !strings.Contains(env.Detail, "payload_truncated") {
+		t.Fatalf("truncation marker must be in Detail: %q", env.Detail)
+	}
+	// 源定位仍齐备（回灌从源表重取）。
+	if env.ShardTable != "message" || env.SourceID != 7 {
+		t.Fatalf("truncated DLQ must keep source locator: %+v", env)
+	}
+
+	// 对照：小 payload 不截断。
+	small := &srcMessageRow{ID: 1, MessageID: "1", ChannelType: 2, Payload: []byte(`{"type":1}`)}
+	env2 := newDLQEnvelope("message", small, dlqReasonPayloadUnparseable)
+	if len(env2.RawPayload) == 0 {
+		t.Fatalf("small payload DLQ must retain RawPayload verbatim")
+	}
+}

--- a/internal/producer/dlq.go
+++ b/internal/producer/dlq.go
@@ -43,7 +43,16 @@ type DLQEnvelope struct {
 	// ── forensic payload (triage: see what could not be parsed) ──────────────
 	// RawPayload is the original source payload bytes, preserved verbatim so a
 	// replay/triage tool can re-attempt extraction or inspect the anomaly.
-	RawPayload []byte `json:"raw_payload"`
+	//
+	// 🔴 Plan B (§4.4): for the oversize-truncated reason this is intentionally
+	// omitted (nil) so the DLQ record itself cannot blow the Kafka write limit and
+	// wedge the partition. Detail then carries payloadTruncatedNote and replay must
+	// re-fetch the row from the source table by {ShardTable, SourceID}.
+	RawPayload []byte `json:"raw_payload,omitempty"`
+
+	// Detail is a human-readable note (e.g. the oversize-truncation marker). Empty
+	// for ordinary parse/visibility dead-letters whose RawPayload is preserved.
+	Detail string `json:"detail,omitempty"`
 
 	// ── timestamps ───────────────────────────────────────────────────────────
 	// CreatedAt is the source row created_at (epoch seconds) — windowed triage.
@@ -70,13 +79,40 @@ const (
 	// (fail-closed #1124 guard) — the row is dead-lettered rather than written
 	// with empty visibles (which the reader would treat as fail-OPEN).
 	dlqReasonVisibilityUntrusted = "producer_visibility_untrusted"
+	// dlqReasonOversize: even after dropping RawPayload the body is still over the
+	// Kafka write-side limit (rare: plaintext content itself >1MB). Dead-lettered
+	// with a TRUNCATED envelope (RawPayload omitted) so the DLQ write cannot itself
+	// blow the limit and wedge the partition (§4.4). Replay must re-fetch the row
+	// from the source message table by {ShardTable, SourceID}.
+	dlqReasonOversize = "producer_oversize_truncated"
 )
+
+// payloadTruncatedNote marks an oversize DLQ envelope whose RawPayload was dropped
+// to keep the DLQ write under the broker limit. Stamped into Detail so a triage /
+// replay tool knows it must re-read the source row instead of trusting RawPayload.
+const payloadTruncatedNote = "payload_truncated:true (oversize; replay must re-fetch from source by shard_table+source_id)"
+
+// maxDLQRawPayloadBytes is the truncation threshold for the raw payload retained
+// in a producer DLQ envelope (§4.4). It MUST account for json.Marshal base64-
+// expanding the []byte RawPayload (~1.33x) plus envelope overhead: if a poison
+// row's payload is large, the ordinary DLQ envelope (visibility_untrusted /
+// payload_unparseable, not just the oversize case) base64-expands past the Kafka
+// 1MiB write limit → ProduceDLQ fails → cursor wedges. 700KB × 1.33 ≈ 931KB +
+// envelope < 1MiB, with head-room. Same口径 as the consumer leg
+// (internal/consumer/dlq.go maxDLQRawValueBytes).
+const maxDLQRawPayloadBytes = 700_000
 
 // newDLQEnvelope builds a dead-letter envelope from a source row + reason. It is
 // a pure function (no clock): ProducedAt is stamped later, at produce time, by
 // the Kafka sink — keeping planChunk deterministic and unit-testable.
+//
+// 🔴 Oversize truncation (§4.4): when the source payload itself is large, even a
+// non-oversize dead-letter (visibility/parse failure) would embed it verbatim and
+// the base64-expanded envelope could exceed the Kafka limit → DLQ write wedge. So
+// any payload over maxDLQRawPayloadBytes is dropped here too (Detail marks it;
+// replay re-fetches from the source table by {ShardTable, SourceID}).
 func newDLQEnvelope(table string, row *srcMessageRow, reason string) DLQEnvelope {
-	return DLQEnvelope{
+	env := DLQEnvelope{
 		SchemaVersion: dlqSchemaVersion,
 		Reason:        reason,
 		ShardTable:    table,
@@ -85,6 +121,31 @@ func newDLQEnvelope(table string, row *srcMessageRow, reason string) DLQEnvelope
 		ChannelID:     row.ChannelID,
 		ChannelType:   int(row.ChannelType),
 		RawPayload:    row.Payload,
+		CreatedAt:     row.CreatedUnix,
+		MsgTimestamp:  row.Timestamp,
+	}
+	if len(row.Payload) > maxDLQRawPayloadBytes {
+		env.RawPayload = nil
+		env.Detail = payloadTruncatedNote
+	}
+	return env
+}
+
+// newOversizeDLQEnvelope builds a TRUNCATED dead-letter envelope (§4.4): RawPayload
+// is intentionally omitted so the DLQ record stays small and the DLQ write cannot
+// itself exceed the Kafka write limit. Replay re-fetches the row from the source
+// table by {ShardTable, SourceID}; Detail carries the truncation marker.
+func newOversizeDLQEnvelope(table string, row *srcMessageRow) DLQEnvelope {
+	return DLQEnvelope{
+		SchemaVersion: dlqSchemaVersion,
+		Reason:        dlqReasonOversize,
+		ShardTable:    table,
+		SourceID:      row.ID,
+		MessageID:     row.MessageID,
+		ChannelID:     row.ChannelID,
+		ChannelType:   int(row.ChannelType),
+		RawPayload:    nil, // truncated — do not embed the oversized payload
+		Detail:        payloadTruncatedNote,
 		CreatedAt:     row.CreatedUnix,
 		MsgTimestamp:  row.Timestamp,
 	}

--- a/internal/producer/extract.go
+++ b/internal/producer/extract.go
@@ -112,9 +112,24 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome, stri
 		return msg, outcomeDLQ, dlqReasonPayloadUnparseable
 	}
 
+	// 🔴 Plan B (CDC-style writes): ship the raw payload整包 so the es-indexer
+	// consumer does the full projection + visibility fail-closed parsing itself.
+	// json.RawMessage inlines the original bytes (zero base64 bloat). Only set for
+	// non-encrypted messages (encrypted DMs keep RawPayload=nil — ciphertext never
+	// leaves; see the isSignalEncrypted branch above).
+	msg.RawPayload = json.RawMessage(row.Payload)
+
 	// 🔴 Fail-closed visibility (access-control ACL): if it cannot be trusted →
 	// the whole row goes to DLQ, never write empty Visibles. A weird space_id JSON
 	// type does not drag down valid visibles (ExtractVisibility isolates that).
+	//
+	// Plan B note: the es-indexer consumer is now the AUTHORITATIVE fail-closed
+	// landing point (it re-parses RawPayload in processBatch pre-check). The
+	// producer keeps enriching during the transition (belt-and-suspenders, §3.3):
+	// both legs run the SAME octo-lib parser + FailClosedVisibilityVectors, so the
+	// kou-jing (口径 / contract) never drifts; a row dead-lettered here never reaches
+	// the body topic, so there is no double-DLQ. Producer enrichment is retired in a
+	// separate ticket after the consumer is verified stable.
 	spaceID, visibles, verr := searchmsg.ExtractVisibility(row.Payload)
 	if verr != nil {
 		return msg, outcomeDLQ, dlqReasonVisibilityUntrusted
@@ -126,8 +141,12 @@ func extractMessage(row *srcMessageRow) (searchmsg.Message, extractOutcome, stri
 	msg.ContentType = contentType
 
 	if !isText {
-		// Non-text (media / system / rich structured content): not indexed this
-		// phase, raw_excluded.
+		// Non-text (media / system / rich structured content): the es-indexer
+		// consumer projects it from RawPayload (Plan B). content stays nil here
+		// (the body text field is text-only); RawExcluded is set conservatively for
+		// the transition contract — the consumer recomputes RawExcluded from the
+		// actual projection (§5.5), so a media row with RawPayload still gets a
+		// searchable doc downstream.
 		msg.RawExcluded = true
 		msg.Content = nil
 		return msg, outcomeRawExcluded, ""


### PR DESCRIPTION
## What

CDC-style write model for the search indexer (root-causes the systemic write/read asymmetry: the reader queries ≥9 payload fields but the indexer only wrote `payload.type` + `payload.text.content`, so image/file names, forward contents, voice/video/richtext were all unsearchable).

- **producer** degrades to shipping the **raw payload verbatim** (`RawPayload`) + metadata.
- **es-indexer consumer** does the full payload projection (ported from the CDC blueprint `ToDoc`, all 8 types: text/image/gif/voice/video/file/mergeForward/richText) + retains `payloadRaw` verbatim (`enabled:false` BLOB → future reader fields need only a local reindex, no re-backfill).
- Collection source stays **poll/SQL** (DB-portable; no binlog/CDC). Only the write shape changes.

## 🔴 P0 — visibility fail-closed moved to the consumer (authoritative)

The visibility ACL (`visibles`/`spaceId`) is now parsed at a **single authoritative landing point**: the consumer `processBatch` pre-check (and the backfill path), via the shared octo-lib `searchmsg.ExtractVisibility`, **fail-closed** — an empty/unparseable `visibles` on a non-encrypted message goes to DLQ (`reason=visibility_untrusted`, `status=0`), it is **never written with empty visibles** (which the reader treats as fail-OPEN). The CDC blueprint's raw `visibles`/`space_id` direct-read (no fail-closed) is deliberately **not** ported. `buildPayloadFromRaw` is pure body projection — it never touches visibility.

Three-branch dispatch in `DocFromMessage` (by `RawPayload` first):
- **A** `len(RawPayload)>0` (non-encrypted new shape, incl. unknown-type group msgs) → projection + consume pre-filled visibility + `payloadRaw`.
- **B** encrypted (`RawPayload=nil` + `RawExcluded`) → skip parse, leave visibles empty (reader fail-closed safe).
- **C** legacy in-flight v2 (no `RawPayload`) → trust contract visibles (transition; backfill rewrites via ExtractVisibility).

## Other safety/correctness

- No `SchemaVersion` bump (consumer strict-equality; a bump would dead-letter all in-flight v2).
- Kafka oversize guard: producer degrades (drop RawPayload → text-only) else truncated DLQ envelope; consumer + producer DLQ envelopes truncate oversized payloads (base64-aware threshold).
- `_bulk` split by encoded byte size (payloadRaw embedded can blow `http.max_content_length`); a single over-limit doc is routed to DLQ (permanent), not retried forever.
- Snowflake int64 precision via `UseNumber` (incl. nested `mergeForward.msgs[].messageId`).
- mapping: `payloadRaw` (enabled:false), `mergeForward.msgs.{from,timestamp}`, `richText.searchText`. Startup mapping-compat fail-closed assertion (consumer + backfill).
- CI drift gate: reader field set ⊆ indexer mapping indexable fields.

## Tests

`go test ./...` → all pass (full-type projection, shared visibility fail-closed vectors on the consumer side, three-branch incl. unknown-type group fail-OPEN regression, snowflake precision, DLQ truncation both legs, byte-split, mapping-compat). `go build` / `go vet` / `golangci-lint` clean.

## ⚠️ Merge order

Depends on: **Mininglamp-OSS/octo-lib#83** (adds `searchmsg.RawPayload`). Merge octo-lib#83 first, then re-pin the `require` line here to the published version. The current pin is a pseudo-version of the octo-lib feature-branch commit.

Reviewed independently (codex, multi-pass) — converged with all P0/P1 findings fixed.



Closes #22
