### PR TITLE
feat(es-indexer): add ES_TLS_INSECURE_SKIP_VERIFY across indexer/backfill/reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Each binary reads its own env namespace; they share no variables.
 | `ES_ADDRESSES` | — | CSV OpenSearch node list |
 | `ES_INDEX` | `octo-message` | target index |
 | `ES_USERNAME` / `ES_PASSWORD` | — | HTTP basic auth |
+| `ES_TLS_INSECURE_SKIP_VERIFY` | `false` | when `true`, skip TLS cert verification for HTTPS OpenSearch (self-signed certs). Unset/`false` keeps full verification — behavior unchanged |
 | `INDEXER_BATCH_SIZE` | `500` | max docs per bulk |
 | `INDEXER_TRANSIENT_BACKOFF_MS` | `1000` | retry backoff on transient |
 | `INDEXER_DLQ_MAX_RETRIES` | `5` | DLQ write retries before escape |
@@ -182,6 +183,13 @@ gate (inline reads its in-memory spill, standalone reads the same spill dir via
 `-dlq-spill-dir` / `RECON_DLQ_SPILL_DIR`) so they never false-fail as
 `sample_missing`. `make run-recon` is **mandatory** before switching the read
 alias to a freshly backfilled index (see `docs/forward-migration-v1.9.md`).
+
+For a self-signed HTTPS OpenSearch cluster, both jobs accept
+`-es-tls-insecure` (or `BACKFILL_ES_TLS_INSECURE_SKIP_VERIFY` /
+`RECON_ES_TLS_INSECURE_SKIP_VERIFY` = `true`) to skip TLS cert verification,
+mirroring the indexer's `ES_TLS_INSECURE_SKIP_VERIFY`. Default off (full
+verification); enabling it disables CA + hostname checks, so use only on a
+trusted private network.
 
 ## Build
 

--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -31,6 +31,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -61,6 +62,7 @@ func run() error {
 		esIndex    = flag.String("es-index", envOr("BACKFILL_ES_INDEX", "octo-message"), "OpenSearch index")
 		esUser     = flag.String("es-user", os.Getenv("BACKFILL_ES_USER"), "OpenSearch username")
 		esPass     = flag.String("es-pass", os.Getenv("BACKFILL_ES_PASS"), "OpenSearch password")
+		esTLSSkip  = flag.Bool("es-tls-insecure", envBool("BACKFILL_ES_TLS_INSECURE_SKIP_VERIFY"), "skip TLS cert verification for HTTPS OpenSearch (self-signed); default off")
 		spillDir   = flag.String("spill-dir", envOr("BACKFILL_SPILL_DIR", ""), "REQUIRED: local DLQ spill dir for real anomalies / permanent ES rejects")
 		checkpoint = flag.String("checkpoint", envOr("BACKFILL_CHECKPOINT", ""), "checkpoint file path for resumable cursor (empty = in-memory, not resumable)")
 		batch      = flag.Int("batch", envInt("BACKFILL_BATCH", 1000), "keyset batch size")
@@ -107,6 +109,7 @@ func run() error {
 		Index:     *esIndex,
 		Username:  *esUser,
 		Password:  *esPass,
+		Transport: esTLSTransport(*esTLSSkip),
 	})
 	if err != nil {
 		return fmt.Errorf("build ES writer: %w", err)
@@ -149,7 +152,7 @@ func run() error {
 	}
 
 	if *doRecon {
-		return reconcile(ctx, db, splitCSV(*esAddrs), *esUser, *esPass, *esIndex, tables, *fromUnix, *toUnix, *sampleN, *maxDet, dlq)
+		return reconcile(ctx, db, splitCSV(*esAddrs), *esUser, *esPass, *esIndex, tables, *fromUnix, *toUnix, *sampleN, *maxDet, dlq, esTLSTransport(*esTLSSkip))
 	}
 	log.Printf("backfill complete. Run cmd/reconcile (or re-run with -reconcile -from/-to) to gate correctness. Total DLQ count: %d", dlq.Count())
 	return nil
@@ -166,7 +169,7 @@ func run() error {
 // 正是富化 spaceId/visibles/messageSeq 的唯一路径，这些字段错位最该在 backfill 后立即拦住。
 // sampleN<=0 时退回纯 count 门（与 cmd/reconcile -sample 0 同口径）。
 // 对平退出码 0；不对平返回错误（main 退出码 1）作为 STOP 信号。
-func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, index string, tables []string, fromUnix, toUnix int64, sampleN, maxDet int, dlq *backfill.DLQSpill) error {
+func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, index string, tables []string, fromUnix, toUnix int64, sampleN, maxDet int, dlq *backfill.DLQSpill, transport http.RoundTripper) error {
 	to := toUnix
 	if to == 0 {
 		to = time.Now().Unix()
@@ -176,7 +179,7 @@ func reconcile(ctx context.Context, db *sql.DB, esAddrs []string, user, pass, in
 	}
 	dlqCount := dlq.CountInWindow(fromUnix, to)
 	osClient, err := opensearchapi.NewClient(opensearchapi.Config{
-		Client: opensearch.Config{Addresses: esAddrs, Username: user, Password: pass},
+		Client: opensearch.Config{Addresses: esAddrs, Username: user, Password: pass, Transport: transport},
 	})
 	if err != nil {
 		return fmt.Errorf("opensearch client: %w", err)
@@ -243,6 +246,20 @@ func envOr(k, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool 解析布尔型 env（fail-closed：仅 "true"/"TRUE" 等 → true，其余一律 false）。
+func envBool(k string) bool {
+	return strings.EqualFold(os.Getenv(k), "true")
+}
+
+// esTLSTransport 在 skip=true 时返回跳过证书校验的 transport，否则返回 nil
+// （走默认 transport，强校验）。
+func esTLSTransport(skip bool) http.RoundTripper {
+	if !skip {
+		return nil
+	}
+	return esindex.InsecureSkipVerifyTransport()
 }
 
 func envInt(k string, def int) int {

--- a/cmd/es-indexer/main.go
+++ b/cmd/es-indexer/main.go
@@ -72,19 +72,20 @@ func run(ctx context.Context) error {
 // 开通条件：ES_INDEXER_ENABLED=true 且 brokers / ES 地址均已配置。
 func loadConfig() (consumer.ServiceConfig, bool) {
 	cfg := consumer.ServiceConfig{
-		Brokers:          splitCSV(os.Getenv("KAFKA_BROKERS")),
-		Topic:            envOr("KAFKA_TOPIC", "octo.message.v1"),
-		DLQTopic:         envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.dlq"),
-		GroupID:          envOr("KAFKA_GROUP_ID", "octo-search-indexer"),
-		BatchSize:        envInt("INDEXER_BATCH_SIZE", 500),
-		ESAddresses:      splitCSV(os.Getenv("ES_ADDRESSES")),
-		ESIndex:          envOr("ES_INDEX", "octo-message"),
-		ESUsername:       os.Getenv("ES_USERNAME"),
-		ESPassword:       os.Getenv("ES_PASSWORD"),
-		TransientBackoff: time.Duration(envInt("INDEXER_TRANSIENT_BACKOFF_MS", 1000)) * time.Millisecond,
-		DLQMaxRetries:    envInt("INDEXER_DLQ_MAX_RETRIES", 5),
-		DLQRetryBackoff:  time.Duration(envInt("INDEXER_DLQ_RETRY_BACKOFF_MS", 200)) * time.Millisecond,
-		DLQSpillDir:      os.Getenv("INDEXER_DLQ_SPILL_DIR"),
+		Brokers:                 splitCSV(os.Getenv("KAFKA_BROKERS")),
+		Topic:                   envOr("KAFKA_TOPIC", "octo.message.v1"),
+		DLQTopic:                envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.dlq"),
+		GroupID:                 envOr("KAFKA_GROUP_ID", "octo-search-indexer"),
+		BatchSize:               envInt("INDEXER_BATCH_SIZE", 500),
+		ESAddresses:             splitCSV(os.Getenv("ES_ADDRESSES")),
+		ESIndex:                 envOr("ES_INDEX", "octo-message"),
+		ESUsername:              os.Getenv("ES_USERNAME"),
+		ESPassword:              os.Getenv("ES_PASSWORD"),
+		ESTLSInsecureSkipVerify: strings.EqualFold(os.Getenv("ES_TLS_INSECURE_SKIP_VERIFY"), "true"),
+		TransientBackoff:        time.Duration(envInt("INDEXER_TRANSIENT_BACKOFF_MS", 1000)) * time.Millisecond,
+		DLQMaxRetries:           envInt("INDEXER_DLQ_MAX_RETRIES", 5),
+		DLQRetryBackoff:         time.Duration(envInt("INDEXER_DLQ_RETRY_BACKOFF_MS", 200)) * time.Millisecond,
+		DLQSpillDir:             os.Getenv("INDEXER_DLQ_SPILL_DIR"),
 	}
 	enabled := strings.EqualFold(os.Getenv("ES_INDEXER_ENABLED"), "true") &&
 		len(cfg.Brokers) > 0 && len(cfg.ESAddresses) > 0

--- a/cmd/reconcile/main.go
+++ b/cmd/reconcile/main.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/backfill"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 	"github.com/Mininglamp-OSS/octo-search-indexer/internal/recon"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/opensearch-project/opensearch-go/v3"
@@ -47,22 +48,23 @@ func main() {
 
 func run() error {
 	var (
-		fromUnix = flag.Int64("from", 0, "window start (epoch seconds, inclusive)")
-		toUnix   = flag.Int64("to", 0, "window end (epoch seconds, inclusive); 0 = now")
-		mysqlDSN = flag.String("mysql-dsn", os.Getenv("RECON_MYSQL_DSN"), "MySQL DSN (or RECON_MYSQL_DSN)")
-		tablesS  = flag.String("tables", envOr("RECON_TABLES", "message,message1,message2,message3,message4"), "comma-separated message shard tables")
-		esAddrs  = flag.String("es", envOr("RECON_ES", "http://localhost:9200"), "comma-separated OpenSearch addresses")
-		esIndex  = flag.String("es-index", envOr("RECON_ES_INDEX", "octo-message"), "OpenSearch index")
-		esUser   = flag.String("es-user", os.Getenv("RECON_ES_USER"), "OpenSearch username")
-		esPass   = flag.String("es-pass", os.Getenv("RECON_ES_PASS"), "OpenSearch password")
-		dlq      = flag.Int64("dlq", 0, "known DLQ count in window (rows that never reached ES body index)")
-		dlqDir   = flag.String("dlq-spill-dir", os.Getenv("RECON_DLQ_SPILL_DIR"), "optional backfill DLQ spill dir (or RECON_DLQ_SPILL_DIR); its message_ids are excluded from the field-level sample gate so legit DLQ rows don't false-fail as sample_missing")
-		sampleN  = flag.Int("sample", envInt("RECON_SAMPLE", 200), "field-level sample size (0 disables sampling)")
-		maxDet   = flag.Int("sample-max-details", envInt("RECON_SAMPLE_MAX_DETAILS", 50), "cap on mismatch detail entries in the report")
-		jsonOut  = flag.Bool("json", false, "emit the structured FullReport as JSON")
-		pushURL  = flag.String("push-url", os.Getenv("RECON_PUSH_URL"), "optional octo-server ingestion URL to POST the search_recon gauge payload")
-		pushTok  = flag.String("push-token", os.Getenv("RECON_PUSH_TOKEN"), "optional bearer token for -push-url")
-		timeout  = flag.Duration("timeout", 60*time.Second, "overall timeout")
+		fromUnix  = flag.Int64("from", 0, "window start (epoch seconds, inclusive)")
+		toUnix    = flag.Int64("to", 0, "window end (epoch seconds, inclusive); 0 = now")
+		mysqlDSN  = flag.String("mysql-dsn", os.Getenv("RECON_MYSQL_DSN"), "MySQL DSN (or RECON_MYSQL_DSN)")
+		tablesS   = flag.String("tables", envOr("RECON_TABLES", "message,message1,message2,message3,message4"), "comma-separated message shard tables")
+		esAddrs   = flag.String("es", envOr("RECON_ES", "http://localhost:9200"), "comma-separated OpenSearch addresses")
+		esIndex   = flag.String("es-index", envOr("RECON_ES_INDEX", "octo-message"), "OpenSearch index")
+		esUser    = flag.String("es-user", os.Getenv("RECON_ES_USER"), "OpenSearch username")
+		esPass    = flag.String("es-pass", os.Getenv("RECON_ES_PASS"), "OpenSearch password")
+		esTLSSkip = flag.Bool("es-tls-insecure", envBool("RECON_ES_TLS_INSECURE_SKIP_VERIFY"), "skip TLS cert verification for HTTPS OpenSearch (self-signed); default off")
+		dlq       = flag.Int64("dlq", 0, "known DLQ count in window (rows that never reached ES body index)")
+		dlqDir    = flag.String("dlq-spill-dir", os.Getenv("RECON_DLQ_SPILL_DIR"), "optional backfill DLQ spill dir (or RECON_DLQ_SPILL_DIR); its message_ids are excluded from the field-level sample gate so legit DLQ rows don't false-fail as sample_missing")
+		sampleN   = flag.Int("sample", envInt("RECON_SAMPLE", 200), "field-level sample size (0 disables sampling)")
+		maxDet    = flag.Int("sample-max-details", envInt("RECON_SAMPLE_MAX_DETAILS", 50), "cap on mismatch detail entries in the report")
+		jsonOut   = flag.Bool("json", false, "emit the structured FullReport as JSON")
+		pushURL   = flag.String("push-url", os.Getenv("RECON_PUSH_URL"), "optional octo-server ingestion URL to POST the search_recon gauge payload")
+		pushTok   = flag.String("push-token", os.Getenv("RECON_PUSH_TOKEN"), "optional bearer token for -push-url")
+		timeout   = flag.Duration("timeout", 60*time.Second, "overall timeout")
 	)
 	flag.Parse()
 
@@ -93,11 +95,16 @@ func run() error {
 		return fmt.Errorf("ping mysql: %w", err)
 	}
 
+	var esTransport http.RoundTripper
+	if *esTLSSkip {
+		esTransport = esindex.InsecureSkipVerifyTransport()
+	}
 	osClient, err := opensearchapi.NewClient(opensearchapi.Config{
 		Client: opensearch.Config{
 			Addresses: splitCSV(*esAddrs),
 			Username:  *esUser,
 			Password:  *esPass,
+			Transport: esTransport,
 		},
 	})
 	if err != nil {
@@ -222,6 +229,11 @@ func envOr(k, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool 解析布尔型 env（fail-closed：仅 "true"/"TRUE" 等 → true，其余一律 false）。
+func envBool(k string) bool {
+	return strings.EqualFold(os.Getenv(k), "true")
 }
 
 func splitCSV(s string) []string {

--- a/internal/consumer/service.go
+++ b/internal/consumer/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
@@ -30,6 +31,9 @@ type ServiceConfig struct {
 	ESIndex     string
 	ESUsername  string
 	ESPassword  string
+	// ESTLSInsecureSkipVerify 为 true 时跳过 OpenSearch HTTPS 证书校验
+	// （自签证书场景）。默认 false：使用默认 transport，强制校验，行为不变。
+	ESTLSInsecureSkipVerify bool
 
 	TransientBackoff time.Duration
 	DLQMaxRetries    int
@@ -46,11 +50,17 @@ func (logAlerter) Alert(event string, detail string) {
 
 // NewService 装配真实组件（连 Kafka + OpenSearch）。
 func NewService(cfg ServiceConfig) (*Service, error) {
+	var transport http.RoundTripper
+	if cfg.ESTLSInsecureSkipVerify {
+		// 仅在显式开启时跳过证书校验（自签证书场景）。
+		transport = esindex.InsecureSkipVerifyTransport()
+	}
 	writer, err := esindex.NewWriter(esindex.Config{
 		Addresses: cfg.ESAddresses,
 		Index:     cfg.ESIndex,
 		Username:  cfg.ESUsername,
 		Password:  cfg.ESPassword,
+		Transport: transport,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("consumer: build ES writer: %w", err)

--- a/internal/esindex/transport.go
+++ b/internal/esindex/transport.go
@@ -1,0 +1,28 @@
+package esindex
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// InsecureSkipVerifyTransport 返回一个跳过 TLS 证书校验的 http.RoundTripper，
+// 供连接「自签证书 HTTPS OpenSearch」场景使用（由各入口的显式开关控制）。
+//
+// 它克隆 http.DefaultTransport 后仅覆盖 TLSClientConfig，以保留 Proxy /
+// 连接池 / 超时等默认配置；仅当默认 transport 已被替换为非 *http.Transport
+// 时退回到一个带 ProxyFromEnvironment 的新 transport（标准运行时不会发生）。
+//
+// 注意：InsecureSkipVerify 会同时关闭 CA 链与主机名校验，存在 MITM 风险，
+// 仅应在受信任的私网 + 显式 opt-in 下使用。
+func InsecureSkipVerifyTransport() http.RoundTripper {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // 自签证书场景，由调用方显式开关控制
+		}
+	}
+	t := base.Clone()
+	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // 自签证书场景，由调用方显式开关控制
+	return t
+}

--- a/internal/esindex/transport_test.go
+++ b/internal/esindex/transport_test.go
@@ -1,0 +1,23 @@
+package esindex
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestInsecureSkipVerifyTransport 验证 helper 返回的 transport 确实跳过证书校验，
+// 且保留了默认 transport 的 Proxy 配置（克隆而非裸构造）。
+func TestInsecureSkipVerifyTransport(t *testing.T) {
+	rt := InsecureSkipVerifyTransport()
+	tr, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", rt)
+	}
+	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=true, got %+v", tr.TLSClientConfig)
+	}
+	// 克隆默认 transport 应保留 Proxy（裸 &http.Transport{} 会丢）。
+	if def, ok := http.DefaultTransport.(*http.Transport); ok && def.Proxy != nil && tr.Proxy == nil {
+		t.Fatalf("expected cloned transport to preserve Proxy from http.DefaultTransport")
+	}
+}


### PR DESCRIPTION
## What

Add an opt-in TLS skip-verify (`ES_TLS_INSECURE_SKIP_VERIFY` and per-job equivalents) so the whole pipeline can connect to an OpenSearch cluster served over HTTPS with a self-signed certificate.

Refs #27. (Partially addresses #27 — the `ES_CA_FILE` / `RootCAs` option is intentionally deferred to a follow-up; see Scope below.)

## Why

We need to point the indexer at an OpenSearch cluster exposed over HTTPS with a self-signed cert (+ Basic Auth). Basic Auth via `ES_USERNAME`/`ES_PASSWORD` already works; TLS verification was the only blocker, with no override knob.

`esindex.Config` already exposes a `Transport` field that `NewWriter` wires into the client, but no entrypoint populated it — so the default transport always enforced full cert-chain verification.

## How

- **`internal/esindex/transport.go`** (new): shared `InsecureSkipVerifyTransport()` helper. Clones `http.DefaultTransport` and overrides only `TLSClientConfig` (preserves `Proxy: ProxyFromEnvironment`, connection pooling, timeouts), with a comma-ok fallback if `http.DefaultTransport` was ever replaced. `//nolint:gosec` is scoped to it.
- **`internal/consumer/service.go`** (es-indexer): `ServiceConfig.ESTLSInsecureSkipVerify`, fed by `ES_TLS_INSECURE_SKIP_VERIFY`.
- **`cmd/backfill/main.go`**: flag `-es-tls-insecure` / env `BACKFILL_ES_TLS_INSECURE_SKIP_VERIFY`, wired into **both** the writer and the inline `-reconcile` gate.
- **`cmd/reconcile/main.go`**: flag `-es-tls-insecure` / env `RECON_ES_TLS_INSECURE_SKIP_VERIFY`.
- Unit test for the helper; `README.md` documents the new vars + MITM warning.

All three entrypoints are now consistently wired, so an operator enabling skip-verify for a self-signed cluster gets a working consumer **and** working backfill/reconcile against the same cluster (this addresses the partial-coverage concern from the first review round).

## Backward compatibility

Fully backward-compatible. The flag defaults to `false` everywhere → `nil` transport → identical to prior behavior (opensearch-go's own default transport, full verification). `envBool` is fail-closed (only `"true"`/`"TRUE"`/etc. → true).

## Security note

`InsecureSkipVerify: true` disables both CA-chain and hostname verification, so it's gated behind an explicit per-entrypoint opt-in (default off) and documented in the README with an MITM warning. A `//nolint:gosec` justification is on the single helper line. A CA-file (`RootCAs`) path — the option #27 marks as *preferred* — is deferred to a tracked follow-up rather than shipped here.

## Testing

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test -count=1 ./internal/consumer/... ./internal/esindex/... ./cmd/...` — pass
- New `internal/esindex/transport_test.go` asserts `InsecureSkipVerify=true` and Proxy preservation.
