### PR TITLE
fix(esindex): fail-fast when target index missing instead of auto-creating (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ binaries distinct from `octo-server`.
 | `cmd/backfill/`       | One-shot historical loader: MySQL shards → OpenSearch, bypassing Kafka |
 | `internal/producer/`  | Producer internals: slow-cursor scheduler, keyset extraction, fail-closed enrich, Kafka sink + DLQ, Redis run-lock, obs server (`config.go` is the env SoT) |
 | `internal/consumer/`  | Kafka consumer: FetchMessage + manual commit, ordered-prefix offset, DLQ routing + terminal escape (C4) |
-| `internal/esindex/`   | Reusable ES bulk writer + index mapping bootstrap (imported by both the service and the backfill job) |
+| `internal/esindex/`   | Reusable ES bulk writer + startup index existence check (index must be pre-created manually; service refuses to start if missing — see issue #29) |
 | `internal/esindex/mapping/` | Canonical `octo-message` index mapping + 中文 analyzer (single source for the octo-deployment change) |
 | `harness/producer/`   | Local docker-compose e2e harness for the producer (see its own `README.md`) |
 

--- a/harness/run-backfill.sh
+++ b/harness/run-backfill.sh
@@ -54,8 +54,23 @@ down() {
   docker rm -f octo-bf-os octo-bf-mysql >/dev/null 2>&1 || true
 }
 
+# create_index pre-creates the target index from the embedded canonical mapping.
+# cmd/backfill no longer auto-creates a missing index (fail-fasts on 404, see
+# issue #29), so the harness provisions it explicitly. Idempotent: tolerate 200
+# (created) and 400 already-exists; anything else fails loud.
+create_index() {
+  echo "[backfill-harness] pre-creating index $ES_INDEX from embedded mapping..."
+  local code
+  code="$(curl -s -o /dev/null -w "%{http_code}" -XPUT "$ES_URL/$ES_INDEX" \
+    -H 'Content-Type: application/json' \
+    -d @"$ROOT/internal/esindex/mapping/octo-message.json")"
+  if [[ "$code" != "200" && "$code" != "400" ]]; then
+    echo "[backfill-harness] FATAL: creating index $ES_INDEX failed (HTTP $code)" >&2
+    exit 1
+  fi
+}
+
 seed() {
-  echo "[backfill-harness] seeding MySQL message shards..."
   BASE_TS="$(date +%s)"
   export BASE_TS
   go run ./harness/backfill -mode seed -mysql-dsn "$MYSQL_DSN" -tables "$TABLES" -base-ts "$BASE_TS"
@@ -86,6 +101,7 @@ case "${1:-all}" in
   all)
     up
     trap 'if [[ "${KEEP_UP:-0}" != "1" ]]; then down; fi' EXIT
+    create_index
     seed
     backfill
     verify

--- a/harness/run.sh
+++ b/harness/run.sh
@@ -164,7 +164,25 @@ down() {
   compose down -v --remove-orphans || true
 }
 
+# create_index pre-creates the target index from the embedded canonical mapping.
+# The indexer no longer auto-creates a missing index (it fail-fasts on 404, see
+# issue #29), so the harness must provision it explicitly — mirroring how a real
+# deployment pre-creates the index with mapping/ISM/shards/aliases. Idempotent:
+# tolerate 200 (created) and a 400 already-exists; anything else fails loud.
+create_index() {
+  echo "[harness] pre-creating index $ES_INDEX from embedded mapping..."
+  local code
+  code="$(curl -s -o /dev/null -w "%{http_code}" -XPUT "$ES_URL/$ES_INDEX" \
+    -H 'Content-Type: application/json' \
+    -d @"$ROOT/internal/esindex/mapping/octo-message.json")"
+  if [[ "$code" != "200" && "$code" != "400" ]]; then
+    echo "[harness] FATAL: creating index $ES_INDEX failed (HTTP $code)" >&2
+    exit 1
+  fi
+}
+
 run_indexer() {
+  create_index
   echo "[harness] starting es-indexer (background)..."
   ( cd "$ROOT" && \
     ES_INDEXER_ENABLED=true \

--- a/internal/backfill/runner.go
+++ b/internal/backfill/runner.go
@@ -72,7 +72,7 @@ func NewRunner(cfg Config, src SourceReader, writer esindex.Writer, cp *Checkpoi
 	}
 }
 
-// Run 执行整个 backfill：先幂等确保索引存在（mapping / 中文分词），再逐分表回灌。
+// Run 执行整个 backfill：先校验索引已存在（mapping / 中文分词），缺失则拒启动（不自动创建，见 issue #29），再逐分表回灌。
 // 返回累计 Stats。任一 fail-closed 条件（DLQ spill 写失败 / checkpoint 持久化失败 /
 // ES 永久错误无法落地）触发即返回错误并 STOP（绝不静默吞行破坏对账）。
 func (r *Runner) Run(ctx context.Context) (Stats, error) {

--- a/internal/consumer/service.go
+++ b/internal/consumer/service.go
@@ -110,13 +110,14 @@ func (s *Service) Run(ctx context.Context) error {
 			"ExtractVisibility pre-check, not from this gate)",
 			searchmsg.SchemaVersion, esindex.SafetyFieldsSchemaVersion)
 	}
+	// 先校验目标索引已存在，缺失则拒启动（不再自动创建，避免裸建丢 ISM/shards/replicas/aliases，见 issue #29）。
 	if err := s.writer.EnsureIndex(ctx); err != nil {
 		return fmt.Errorf("consumer: ensure index: %w", err)
 	}
 	// 🔴 mapping-compat fail-closed 断言（§6.4）：方案 B 新增 payloadRaw / richText /
 	// mergeForward.msgs.{from,timestamp}，dynamic:strict 下若漏迁这些字段会启动后每条 bulk 4xx
 	// 静默全量塌。启动期校验 live mapping 含本期所有新字段路径，缺则**拒启动**（loud crash），
-	// 不静默灌 4xx。与 EnsureIndex 的存在性幂等独立（存在仍幂等容忍，字段缺失才拒启动）。
+	// 不静默灌 4xx。与 EnsureIndex 的存在性校验独立（存在即放行，字段缺失才拒启动）。
 	if err := s.writer.AssertLiveMappingCompatible(ctx); err != nil {
 		return fmt.Errorf("consumer: mapping-compat assertion: %w", err)
 	}

--- a/internal/esindex/ensure_index.go
+++ b/internal/esindex/ensure_index.go
@@ -1,13 +1,10 @@
 package esindex
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 )
@@ -18,10 +15,6 @@ import (
 //go:embed mapping/octo-message.json
 var mappingJSON []byte
 
-// resourceAlreadyExistsType 是 OpenSearch 在「索引已存在」时返回的 error.type（HTTP 400）。
-// 多副本并发启动时抢输的副本 Create 会收到它——必须幂等视为成功，不得冒泡触发 Exit。
-const resourceAlreadyExistsType = "resource_already_exists_exception"
-
 // IndexMappingJSON 返回内嵌的规范 mapping 字节（供 backfill / 部署校验复用）。
 func IndexMappingJSON() []byte {
 	out := make([]byte, len(mappingJSON))
@@ -29,80 +22,28 @@ func IndexMappingJSON() []byte {
 	return out
 }
 
-// EnsureIndex 幂等创建目标索引：若不存在则用内嵌 mapping 创建；已存在则不动（不覆盖既有
-// mapping，避免运行期破坏）。供 es-indexer 启动时与 backfill job 调用。
-//
-// 🔴 并发安全（修 PR#6 P1 TOCTOU）：Exists→Create 非原子。多副本同时启动（replicas≥2 /
-// 滚动更新 / pod 重调度）时，抢输的副本 Create 会收到 400 resource_already_exists_exception。
-// 该错误**幂等视为成功**（索引确已就绪），绝不冒泡到 os.Exit 触发 CrashLoopBackOff。
+// EnsureIndex 校验目标索引**已存在**：存在则放行，缺失（404）则拒启动并报错。
+// 不再自动裸建索引——裸建会丢失 ISM/lifecycle、shards/replicas、aliases 等部署级能力（见 issue #29），
+// 索引须由人工按规范 mapping 预建。供 es-indexer 启动时与 backfill job 调用。
 func (w *osWriter) EnsureIndex(ctx context.Context) error {
 	return ensureIndex(ctx, w.client, w.index)
 }
 
-// ensureIndex 抽出便于测试（注入 mock transport 的 client）。
+// ensureIndex 抽出便于测试（注入 mock transport 的 client）。纯存在性校验，不创建。
 func ensureIndex(ctx context.Context, client *opensearchapi.Client, index string) error {
 	resp, err := client.Indices.Exists(ctx, opensearchapi.IndicesExistsReq{Indices: []string{index}})
 	// Exists 在 404 时返回 (resp, err)；据状态码判定，而非仅看 err。
 	if resp != nil && resp.StatusCode == http.StatusOK {
-		return nil // 已存在，不覆盖
+		return nil // 已存在，放行
 	}
-	if resp != nil && resp.StatusCode != http.StatusNotFound {
-		// 非 200 / 非 404 的异常（如 5xx / 鉴权失败）：上报，不盲目建索引。
-		return fmt.Errorf("esindex: index exists check for %q returned status %d: %w", index, resp.StatusCode, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		// 404 → 索引缺失，拒启动。不自动创建（裸建丢 ISM/shards/replicas/aliases）。
+		return fmt.Errorf("esindex: index %q does not exist; refusing to start — create it manually with the required mapping, ISM/lifecycle policy, shards/replicas and aliases first (auto-create intentionally disabled, see issue #29)", index)
 	}
-
-	// 404（或无 resp 但 err 提示不存在）→ 创建。
-	cresp, cerr := client.Indices.Create(ctx, opensearchapi.IndicesCreateReq{
-		Index: index,
-		Body:  bytes.NewReader(mappingJSON),
-	})
-	if cerr == nil {
-		return nil // 创建成功
+	// 非 200 / 非 404 的异常（如 5xx / 鉴权失败）：上报，不盲目放行。
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
 	}
-	// 🔴 幂等收口：Create 失败时若是「已存在」竞态（另一副本抢先建好）→ 视为成功。
-	// 仅在 HTTP 400 + already-exists 信号时才**权威**判定为已存在（避免 5xx/代理/封装错误恰好
-	// 含该 token 时把真失败误判成功）。其余一律走 existsNow 兜底再确认。
-	if isAlreadyExists(cresp, cerr) {
-		return nil
-	}
-	// 兜底：并发下错误形态可能各异（非 400 / 文本不含 token）。只有此刻索引**确已就绪**才算成功；
-	// 否则（如真 5xx 且索引仍缺失）冒泡报错，不掩盖真问题。
-	if existsNow(ctx, client, index) {
-		return nil
-	}
-	return fmt.Errorf("esindex: create index %q: %w", index, cerr)
-}
-
-// isAlreadyExists 权威判定 Create 失败是否为「索引已存在」竞态——**要求实际 HTTP 响应状态为 400**：
-//   - 先确认真实 HTTP 状态码（cresp.Inspect().Response.StatusCode）== 400；用响应体里的 status 字段
-//     不可靠（代理可能 HTTP 500 却回 body status:400），故只信传输层状态码。
-//   - 再看 already-exists 信号：opensearchapi.Error.Type / root_cause.Type == 该类型，或错误文本含该串。
-//
-// 非 400（5xx/代理/封装错误等）一律返回 false——交由 existsNow 兜底，仅当索引确已就绪才放行，
-// 杜绝真失败被掩盖。
-func isAlreadyExists(cresp *opensearchapi.IndicesCreateResp, cerr error) bool {
-	// 唯一可信的状态来源：实际 HTTP 响应状态码。无响应或非 400 → 不在此判已存在。
-	if cresp == nil || cresp.Inspect().Response == nil ||
-		cresp.Inspect().Response.StatusCode != http.StatusBadRequest {
-		return false
-	}
-	var apiErr opensearchapi.Error
-	if errors.As(cerr, &apiErr) {
-		if apiErr.Err.Type == resourceAlreadyExistsType {
-			return true
-		}
-		for _, rc := range apiErr.Err.RootCause {
-			if rc.Type == resourceAlreadyExistsType {
-				return true
-			}
-		}
-	}
-	return strings.Contains(cerr.Error(), resourceAlreadyExistsType)
-}
-
-// existsNow 重新探测索引是否已就绪（幂等兜底，忽略探测自身错误——404 时 client 会返回 err）。
-func existsNow(ctx context.Context, client *opensearchapi.Client, index string) bool {
-	resp, err := client.Indices.Exists(ctx, opensearchapi.IndicesExistsReq{Indices: []string{index}})
-	_ = err // 探测错误（如 404 携带的 err）不影响判定，仅看状态码
-	return resp != nil && resp.StatusCode == http.StatusOK
+	return fmt.Errorf("esindex: index exists check for %q returned status %d: %w", index, status, err)
 }

--- a/internal/esindex/ensure_index_test.go
+++ b/internal/esindex/ensure_index_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// seqTransport 按请求方法路由到一个可变的响应序列，用于模拟并发 TOCTOU 竞态。
+// seqTransport 按请求方法路由到一个可变的响应序列。
 type seqTransport struct {
 	// existsResponses 是对 HEAD（Exists）的连续应答状态码队列；用尽后取最后一个。
 	existsStatuses []int
@@ -61,72 +61,7 @@ func ensureWriter(t *testing.T, rt http.RoundTripper) *osWriter {
 	return w.(*osWriter)
 }
 
-// alreadyExistsBody 是 OpenSearch 对「索引已存在」返回的 400 错误体。
-const alreadyExistsBody = `{"error":{"root_cause":[{"type":"resource_already_exists_exception","reason":"index [octo-message] already exists","index":"octo-message"}],"type":"resource_already_exists_exception","reason":"index [octo-message] already exists","index":"octo-message"},"status":400}`
-
-// TestEnsureIndex_TOCTOURaceIsIdempotent 🔴 P1 回归：并发竞态路径
-// Exists→404 → Create→400(resource_already_exists_exception) 必须**成功**（视为已就绪），
-// 不得报错/退出（杜绝抢输副本 CrashLoopBackOff）。
-func TestEnsureIndex_TOCTOURaceIsIdempotent(t *testing.T) {
-	rt := &seqTransport{
-		existsStatuses: []int{http.StatusNotFound}, // 首次探测：不存在
-		createStatus:   http.StatusBadRequest,      // 抢输：已存在 400
-		createBody:     alreadyExistsBody,
-	}
-	w := ensureWriter(t, rt)
-	if err := w.EnsureIndex(context.Background()); err != nil {
-		t.Fatalf("TOCTOU race must be idempotent (no error), got %v", err)
-	}
-	if rt.putCalls != 1 {
-		t.Fatalf("expected exactly 1 Create attempt, got %d", rt.putCalls)
-	}
-}
-
-// TestEnsureIndex_RaceFallbackReCheck Create 返回非 already-exists 形态的错误，但兜底 re-check
-// Exists==200（另一副本刚建好）→ 仍视为成功。
-func TestEnsureIndex_RaceFallbackReCheck(t *testing.T) {
-	rt := &seqTransport{
-		// 首次 HEAD 404 → Create 失败（非典型错误体）→ 兜底 HEAD 返回 200。
-		existsStatuses: []int{http.StatusNotFound, http.StatusOK},
-		createStatus:   http.StatusBadRequest,
-		createBody:     `{"error":{"type":"some_other_error","reason":"weird"},"status":400}`,
-	}
-	w := ensureWriter(t, rt)
-	if err := w.EnsureIndex(context.Background()); err != nil {
-		t.Fatalf("fallback re-check (Exists==200) must succeed, got %v", err)
-	}
-	if rt.headCalls < 2 {
-		t.Fatalf("expected a fallback Exists re-check (>=2 HEAD), got %d", rt.headCalls)
-	}
-}
-
-// TestEnsureIndex_RealCreateErrorPropagates Create 真失败（如 5xx）且索引确未就绪 → 报错冒泡
-// （不能把所有 Create 失败都吞掉，否则真问题被掩盖）。
-func TestEnsureIndex_RealCreateErrorPropagates(t *testing.T) {
-	rt := &seqTransport{
-		existsStatuses: []int{http.StatusNotFound, http.StatusNotFound}, // 始终不存在
-		createStatus:   http.StatusInternalServerError,
-		createBody:     `{"error":{"type":"internal","reason":"boom"},"status":500}`,
-	}
-	w := ensureWriter(t, rt)
-	if err := w.EnsureIndex(context.Background()); err == nil {
-		t.Fatalf("a genuine create failure (5xx, index still absent) must propagate")
-	}
-}
-
-// TestEnsureIndex_HTTP500BodyClaims400Propagates 🔴 P1 加固：代理返回真实 HTTP 500，但响应体
-// 谎称 status:400 + already-exists type，索引仍缺失 → 必须报错（只信传输层状态码，不信 body status）。
-func TestEnsureIndex_HTTP500BodyClaims400Propagates(t *testing.T) {
-	rt := &seqTransport{
-		existsStatuses: []int{http.StatusNotFound, http.StatusNotFound},
-		createStatus:   http.StatusInternalServerError, // 真实 HTTP 500
-		createBody:     `{"error":{"root_cause":[{"type":"resource_already_exists_exception","reason":"x"}],"type":"resource_already_exists_exception","reason":"x"},"status":400}`,
-	}
-	w := ensureWriter(t, rt)
-	if err := w.EnsureIndex(context.Background()); err == nil {
-		t.Fatalf("HTTP 500 with body claiming status:400 + already-exists, index absent → must propagate")
-	}
-}
+// TestEnsureIndex_ExistsShortCircuits Exists==200 → 放行，且绝不发 PUT（不再自动创建）。
 func TestEnsureIndex_ExistsShortCircuits(t *testing.T) {
 	rt := &seqTransport{existsStatuses: []int{http.StatusOK}, createStatus: 200}
 	w := ensureWriter(t, rt)
@@ -138,33 +73,31 @@ func TestEnsureIndex_ExistsShortCircuits(t *testing.T) {
 	}
 }
 
-// TestIsAlreadyExists_Only400IsAuthoritative 仅 HTTP 400 + already-exists 信号才权威判已存在；
-// 非 400（即便文本含 token）不在此判成功——避免真失败被掩盖（交 existsNow 兜底）。
-func TestIsAlreadyExists_Only400IsAuthoritative(t *testing.T) {
-	// 无状态/非 400 的纯文本错误：不判已存在。
-	if isAlreadyExists(nil, &textError{s: "create failed: resource_already_exists_exception index [x]"}) {
-		t.Fatalf("non-400 text containing token must NOT be treated as already-exists")
+// TestEnsureIndex_MissingFailsFast Exists==404 → 拒启动报错，绝不发 PUT 自动创建；
+// 错误信息含 "does not exist" 与 "refusing to start"（issue #29 fail-fast）。
+func TestEnsureIndex_MissingFailsFast(t *testing.T) {
+	rt := &seqTransport{existsStatuses: []int{http.StatusNotFound}, createStatus: 200}
+	w := ensureWriter(t, rt)
+	err := w.EnsureIndex(context.Background())
+	if err == nil {
+		t.Fatalf("missing index (404) must fail fast, got nil error")
 	}
-	if isAlreadyExists(nil, &textError{s: "some unrelated error"}) {
-		t.Fatalf("unrelated error must not be treated as already-exists")
+	if rt.putCalls != 0 {
+		t.Fatalf("must not auto-create on 404, got %d PUT", rt.putCalls)
+	}
+	if !strings.Contains(err.Error(), "does not exist") || !strings.Contains(err.Error(), "refusing to start") {
+		t.Fatalf("error must mention the missing index and refusal, got %v", err)
 	}
 }
 
-// TestEnsureIndex_5xxWithTokenStillAbsentPropagates 🔴 P1 加固回归：Create 返回 5xx 且错误文本
-// 恰含 resource_already_exists_exception，但索引仍缺失（兜底 Exists 仍 404）→ 必须报错，不掩盖。
-func TestEnsureIndex_5xxWithTokenStillAbsentPropagates(t *testing.T) {
-	rt := &seqTransport{
-		existsStatuses: []int{http.StatusNotFound, http.StatusNotFound}, // 始终不存在
-		createStatus:   http.StatusInternalServerError,
-		// 5xx 错误体文本恰含 token（代理/封装场景），但 status=500。
-		createBody: `{"error":{"type":"internal_proxy_error","reason":"upstream said resource_already_exists_exception but failed"},"status":500}`,
-	}
+// TestEnsureIndex_5xxPropagates Exists 返回 5xx（如鉴权/集群异常）→ 报错冒泡，绝不放行也不创建。
+func TestEnsureIndex_5xxPropagates(t *testing.T) {
+	rt := &seqTransport{existsStatuses: []int{http.StatusInternalServerError}, createStatus: 200}
 	w := ensureWriter(t, rt)
 	if err := w.EnsureIndex(context.Background()); err == nil {
-		t.Fatalf("5xx create error with index still absent must propagate, even if text contains the token")
+		t.Fatalf("a 5xx exists-check must propagate, got nil error")
+	}
+	if rt.putCalls != 0 {
+		t.Fatalf("must not Create on 5xx, got %d PUT", rt.putCalls)
 	}
 }
-
-type textError struct{ s string }
-
-func (e *textError) Error() string { return e.s }

--- a/internal/esindex/mapping/README.md
+++ b/internal/esindex/mapping/README.md
@@ -1,8 +1,10 @@
 # octo-message index mapping (v1.11 — reader-aligned)
 
 `octo-message.json` is the **canonical index mapping + analyzer** the `es-indexer`
-writes against, embedded into the binary (`//go:embed`) and used by
-`esindex.EnsureIndex` to bootstrap the index idempotently when it does not yet exist.
+writes against, embedded into the binary (`//go:embed`). The index must be
+**pre-created manually** with this mapping (plus ISM/lifecycle policy, shards/replicas
+and aliases) — `esindex.EnsureIndex` only **verifies the index exists** at startup and
+**refuses to start** if it is missing (auto-create intentionally disabled, see issue #29).
 
 ## v1.11 subSeq 排序 tiebreaker（配套 B2 虚拟子文档）
 
@@ -53,7 +55,7 @@ v1.9 收敛索引契约到 **octo-server reader** 读的形态
 - 新增 reader 必读字段：`spaceId`(keyword) / `visibles`(keyword[]) / `messageSeq`(long)。
 - sort 字段 `timestamp`(epoch_second) + `messageId` 与 reader cursor sort 口径一致。
 - reader 读 **alias `wukongim-messages-read`**（pattern `wukongim-messages-*`）。**本 mapping 不再内嵌该
-  alias**（v1.9 R2）：`EnsureIndex` 用本文件裸 PUT 建索引，若内嵌 alias 会让新索引一建好就被 reader
+  alias**（v1.9 R2）：人工预建索引用本文件 PUT，若内嵌 alias 会让新索引一建好就被 reader
   读到（reindex/backfill 完成前的半量数据）。alias 改由迁移脚本步骤③在对账通过后单独原子挂。
 
 完整迁移说明见 `docs/forward-migration-v1.9.md`。

--- a/internal/esindex/mapping_compat.go
+++ b/internal/esindex/mapping_compat.go
@@ -47,9 +47,9 @@ var requiredDisabledObjectPaths = []string{"payloadRaw"}
 // 新字段路径齐备（可索引字段 + payloadRaw enabled:false object）。缺任一 → 返回 error，调用方
 // 据此拒启动（loud crash），绝不静默向 dynamic:strict 索引灌 4xx。
 //
-// 🔴 与 EnsureIndex 的存在性幂等**互相独立、不打架**（eng-review §4 额外发现）：EnsureIndex 把
-// resource_already_exists 当成功以防 CrashLoop（索引存在即放行）；本断言只校验**字段路径齐备**，
-// 缺字段才 loud crash。即「索引存在」仍幂等容忍，「字段缺失」才拒启动——二者方向不冲突。
+// 🔴 与 EnsureIndex 的存在性校验**互相独立、不打架**（eng-review §4 额外发现）：EnsureIndex 只判
+// 索引是否存在（存在即放行，缺失则拒启动）；本断言只校验**字段路径齐备**，缺字段才 loud crash。
+// 即「索引存在」放行，「字段缺失」才拒启动——二者方向不冲突。
 func (w *osWriter) AssertLiveMappingCompatible(ctx context.Context) error {
 	return assertLiveMappingCompatible(ctx, w.client, w.index)
 }

--- a/internal/esindex/writer_test.go
+++ b/internal/esindex/writer_test.go
@@ -218,30 +218,25 @@ func osWriterFor(t *testing.T, rt http.RoundTripper) *osWriter {
 	return w
 }
 
-// TestEnsureIndex_CreatesWhenMissing 索引不存在(404) → 发 PUT 创建，body 为内嵌 mapping。
-func TestEnsureIndex_CreatesWhenMissing(t *testing.T) {
-	var createBody string
-	var createCalled bool
+// TestEnsureIndex_MissingFailsFastNoCreate 索引不存在(404) → 拒启动报错，绝不发 PUT 自动创建（issue #29）。
+func TestEnsureIndex_MissingFailsFastNoCreate(t *testing.T) {
+	createCalled := false
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		if r.Method == http.MethodHead || (r.Method == http.MethodGet) {
+		if r.Method == http.MethodHead || r.Method == http.MethodGet {
 			return jsonResp(404, `{"error":"index_not_found"}`), nil
 		}
 		if r.Method == http.MethodPut {
 			createCalled = true
-			createBody = readAll(r.Body)
 			return jsonResp(200, `{"acknowledged":true}`), nil
 		}
 		return jsonResp(200, `{}`), nil
 	})
 	w := osWriterFor(t, rt)
-	if err := w.EnsureIndex(context.Background()); err != nil {
-		t.Fatalf("EnsureIndex: %v", err)
+	if err := w.EnsureIndex(context.Background()); err == nil {
+		t.Fatalf("missing index (404) must fail fast, got nil error")
 	}
-	if !createCalled {
-		t.Fatalf("expected index create (PUT) when missing")
-	}
-	if !strings.Contains(createBody, "ik_max_word") || !strings.Contains(createBody, `"content"`) {
-		t.Fatalf("create body must carry embedded mapping/analyzer, got: %s", createBody)
+	if createCalled {
+		t.Fatalf("must NOT auto-create a missing index")
 	}
 }
 


### PR DESCRIPTION
## 背景

`EnsureIndex`（`internal/esindex/ensure_index.go`）在启动预检时探测目标索引，404 即用二进制内嵌的 `mapping/octo-message.json` 自动 `Indices.Create` 创建。该路径被两处复用：es-indexer 启动期（`internal/consumer/service.go`）与 backfill job（`internal/backfill/runner.go`）。

## 问题

内嵌 mapping 只覆盖字段映射与分词器，**不包含索引的部署级能力**。索引缺失时由服务自动裸建，会静默丢失：

- **ISM / 生命周期策略**（rollover/retention）—— 自动建出的索引没有任何 ISM policy 绑定。
- **shards / replicas** —— 退化为集群默认值，而非按容量规划设定。
- **aliases**（读/写/rollover 别名）—— 内嵌 mapping 不带 alias，新建索引不进读写别名，读路径可能落空。
- 其他 index settings（codec / slowlog 等）同样丢失。

更严重的是：索引缺失通常意味着尚未由人工/运维按规范预建，本应 loud fail，却被服务自愈式建索引悄悄吞掉，事后才在滚动/容量/检索上暴露。

## 改动

- **`internal/esindex/ensure_index.go`**：`ensureIndex` 改为纯存在性校验 —— 200 放行 / 404 fail-fast 拒启动（错误文案引导人工建索引及其 mapping/ISM/shards/replicas/aliases）/ 其他状态（5xx/鉴权）冒泡。移除 `Indices.Create` 及配套的 `isAlreadyExists`、`existsNow`、`resourceAlreadyExistsType`（无自动创建即无并发竞态需处理）。保留 `mappingJSON` embed 与 `IndexMappingJSON()` —— 仍被 `mapping_compat.go` 的字段兼容性校验复用。
- **`internal/consumer/service.go`、`internal/backfill/runner.go`**：共用同一 `EnsureIndex`，两条启动路径一并 fail-fast；仅同步注释，逻辑不变。
- **`internal/esindex/mapping_compat.go`、`internal/esindex/writer.go`**：更新接口/注释，把旧的「幂等自动创建」表述改为「存在性校验」。
- **测试**（`ensure_index_test.go`、`writer_test.go`）：移除自动创建/TOCTOU 用例，新增 fail-fast 断言（404→报错且 0 次 PUT、5xx→冒泡、200→放行）。
- **harness**（`harness/run.sh`、`harness/run-backfill.sh`）：因 indexer/backfill 不再自动建索引，在启动前用内嵌 mapping 显式预建索引（幂等），模拟真实部署的人工预建。`gaptable-e2e.sh` 本就显式预建，不受影响。
- **文档**（`README.md`、`internal/esindex/mapping/README.md`）：更新为「索引须人工预建，服务只校验存在性、缺失则拒启动」。

## 兼容性（breaking）

升级前现网必须确认目标索引（或写别名实体索引）已存在，否则 es-indexer 与 backfill 均拒启动。CI/本地依赖自动创建的入口已在 harness 内补预建。

## 验证

- `go build ./...` / `go vet ./internal/esindex/...` 通过
- `go test ./internal/esindex/... ./internal/consumer/... ./internal/backfill/...` 全绿
- harness 端到端（`./harness/run.sh all`，gate OPEN 实时链路）：预建索引→启动 indexer→seed→verify 全 PASS（含中文 IK 召回、DLQ 路由、幂等、坏 schema 不入库）

Closes #29
