### PR TITLE
fix(esindex): clamp image/video int32 dims on non-richtext path (#31)

### DIFF
--- a/internal/esindex/buildraw.go
+++ b/internal/esindex/buildraw.go
@@ -89,11 +89,12 @@ func buildPayloadFromRaw(rawPayload json.RawMessage) (payload *Payload, rawForSt
 		if n, ok := raw["name"].(string); ok {
 			p.Name = n
 		}
+		// width/height 钳进 int32（ES `integer`）；异常 payload 超界会触发 _bulk 永久 4xx（见 #26 / #31）。
 		if w, ok := extractInt(raw, "width"); ok {
-			p.Width = w
+			p.Width = clampInt32(w)
 		}
 		if h, ok := extractInt(raw, "height"); ok {
-			p.Height = h
+			p.Height = clampInt32(h)
 		}
 		parsed.Image = p
 	case payloadTypeGIF:
@@ -116,14 +117,15 @@ func buildPayloadFromRaw(rawPayload json.RawMessage) (payload *Payload, rawForSt
 		if c, ok := raw["cover"].(string); ok {
 			p.Cover = c
 		}
+		// width/height/second 均映射为 ES `integer`（int32），异常 payload 超界会触发 _bulk 永久 4xx（见 #31）。
 		if w, ok := extractInt(raw, "width"); ok {
-			p.Width = w
+			p.Width = clampInt32(w)
 		}
 		if h, ok := extractInt(raw, "height"); ok {
-			p.Height = h
+			p.Height = clampInt32(h)
 		}
 		if s, ok := extractInt(raw, "second"); ok {
-			p.Second = s
+			p.Second = clampInt32(s)
 		}
 		parsed.Video = p
 	case payloadTypeFile:

--- a/internal/esindex/buildraw_test.go
+++ b/internal/esindex/buildraw_test.go
@@ -89,6 +89,22 @@ func TestProject_Image(t *testing.T) {
 	}
 }
 
+// TestProject_Image_OverflowDimensionsClamp type=2 普通图片 width/height 超 int32 → 钳为 0（#31）。
+// 复现 DLQ permanent_4xx：payload.image.{width,height} 为历史脏数据（如 4293001688）超 ES `integer`。
+func TestProject_Image_OverflowDimensionsClamp(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":2,"url":"https://x/y.png","width":4293001688,"height":2424569856}`)
+	img := rd.Payload.Image
+	if img == nil {
+		t.Fatalf("image payload missing")
+	}
+	if img.Width != 0 {
+		t.Fatalf("oversize image width must clamp to 0 (int32-safe), got %d", img.Width)
+	}
+	if img.Height != 0 {
+		t.Fatalf("oversize image height must clamp to 0 (int32-safe), got %d", img.Height)
+	}
+}
+
 // TestProject_GIF type=3 留底 gif.url。
 func TestProject_GIF(t *testing.T) {
 	rd := projectViaDoc(t, `{"type":3,"url":"https://x/a.gif"}`)
@@ -111,6 +127,19 @@ func TestProject_Video(t *testing.T) {
 	v := rd.Payload.Video
 	if v == nil || v.URL != "https://x/v.mp4" || v.Cover != "https://x/c.jpg" || v.Width != 1920 || v.Height != 1080 || v.Second != 42 {
 		t.Fatalf("video not fully projected: %+v", v)
+	}
+}
+
+// TestProject_Video_OverflowDimensionsClamp type=5 video width/height/second 超 int32 → 钳为 0（#31）。
+// issue #31 只点名 width/height，但 second 同为 ES `integer`，一并防护。
+func TestProject_Video_OverflowDimensionsClamp(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":5,"url":"https://x/v.mp4","width":4293001688,"height":3997107456,"second":2424569856}`)
+	v := rd.Payload.Video
+	if v == nil {
+		t.Fatalf("video payload missing")
+	}
+	if v.Width != 0 || v.Height != 0 || v.Second != 0 {
+		t.Fatalf("oversize video dims must clamp to 0 (int32-safe), got w=%d h=%d s=%d", v.Width, v.Height, v.Second)
 	}
 }
 


### PR DESCRIPTION
## 背景

Closes #31

prod `octo-search-indexer-prod` 的 DLQ 累计 45 条 `permanent_4xx` `mapper_parsing_exception`：`payload.image.{width,height}` 为历史脏数据（如 `4293001688`、`2424569856`）超出 ES `integer`(int32) 上限，`_bulk` 永久失败 → 消息永远搜不到。

之前的 fix `49e8d79` 只给**富文本派生路径**（`richtext_derive.go`）加了 `clampInt32`，但**普通图片(type=2)和视频(type=5)走的是 `buildraw.go` 另一条解析路径，没有 clamp** —— issue #31 实证 45 条全部 `content_type=2`、`virtual=false`、无 `parentMessageId`，走的就是这条漏网路径。

## 改动

- `buildraw.go`：image `width/height`、video `width/height/second` 五处统一调用 `clampInt32`（同包已有函数，复用，无需 export）
- **`video.second` 同为 ES `integer`，issue 未点名但一并防护**（否则修了宽高仍留溢出尾巴）
- `buildraw_test.go`：补普通 image / video 的 overflow 钳制单测

`payload.file.size` 为 ES `long`(int64)，代码用 `extractInt64` 类型对齐，不会溢出，**不需改**。
`mergeForward.msgs` 子文档不携带任何数值维度，无风险。

## 验证

- `go build ./...` / `go vet ./...` / `go test ./...` 全绿
- **真 OpenSearch 2.17 (analysis-ik) 端到端对照**（canonical mapping，走真 `esindex.Writer.Bulk`，即 prod consumer/backfill 同一路径）：
  - 修复前：超界 image/video 复现逐字一致的 `status=400 mapper_parsing_exception ... value: '4293001688'`
  - 修复后：4 条全部 201 索引成功，超界维度落盘为 0（omitempty，不向 reader 注入假尺寸），含 `video.second`
