### PR TITLE
fix(es-indexer): clamp image/video width/height to int32 in buildraw path

### DIFF
--- a/internal/esindex/buildraw.go
+++ b/internal/esindex/buildraw.go
@@ -90,10 +90,10 @@ func buildPayloadFromRaw(rawPayload json.RawMessage) (payload *Payload, rawForSt
 			p.Name = n
 		}
 		if w, ok := extractInt(raw, "width"); ok {
-			p.Width = w
+			p.Width = clampInt32(w)
 		}
 		if h, ok := extractInt(raw, "height"); ok {
-			p.Height = h
+			p.Height = clampInt32(h)
 		}
 		parsed.Image = p
 	case payloadTypeGIF:
@@ -117,10 +117,10 @@ func buildPayloadFromRaw(rawPayload json.RawMessage) (payload *Payload, rawForSt
 			p.Cover = c
 		}
 		if w, ok := extractInt(raw, "width"); ok {
-			p.Width = w
+			p.Width = clampInt32(w)
 		}
 		if h, ok := extractInt(raw, "height"); ok {
-			p.Height = h
+			p.Height = clampInt32(h)
 		}
 		if s, ok := extractInt(raw, "second"); ok {
 			p.Second = s

--- a/internal/esindex/buildraw_test.go
+++ b/internal/esindex/buildraw_test.go
@@ -89,6 +89,42 @@ func TestProject_Image(t *testing.T) {
 	}
 }
 
+// TestProject_ImageOverflowClamped type=2 image with width/height exceeding int32 max → clamped to 0 (see #31).
+func TestProject_ImageOverflowClamped(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":2,"name":"x.png","url":"https://x/y.png","width":4293001688,"height":3997107456}`)
+	img := rd.Payload.Image
+	if img == nil {
+		t.Fatal("image payload must not be nil")
+	}
+	if img.Width != 0 {
+		t.Fatalf("image width should be clamped to 0 for int32 overflow, got %d", img.Width)
+	}
+	if img.Height != 0 {
+		t.Fatalf("image height should be clamped to 0 for int32 overflow, got %d", img.Height)
+	}
+	if img.URL != "https://x/y.png" {
+		t.Fatalf("image url must still be projected: %s", img.URL)
+	}
+}
+
+// TestProject_VideoOverflowClamped type=5 video with width/height exceeding int32 max → clamped to 0 (see #31).
+func TestProject_VideoOverflowClamped(t *testing.T) {
+	rd := projectViaDoc(t, `{"type":5,"url":"https://x/v.mp4","width":2424569856,"height":3997107456,"second":30}`)
+	v := rd.Payload.Video
+	if v == nil {
+		t.Fatal("video payload must not be nil")
+	}
+	if v.Width != 0 {
+		t.Fatalf("video width should be clamped to 0 for int32 overflow, got %d", v.Width)
+	}
+	if v.Height != 0 {
+		t.Fatalf("video height should be clamped to 0 for int32 overflow, got %d", v.Height)
+	}
+	if v.Second != 30 {
+		t.Fatalf("video second must still be projected: %d", v.Second)
+	}
+}
+
 // TestProject_GIF type=3 留底 gif.url。
 func TestProject_GIF(t *testing.T) {
 	rd := projectViaDoc(t, `{"type":3,"url":"https://x/a.gif"}`)


### PR DESCRIPTION
## Summary

Fixes #31.

The previous fix (commit 49e8d79) added `clampInt32` only to the richtext derive path (`richtext_derive.go:95-99`), leaving the direct image (type=2) and video (type=5) paths in `buildraw.go` unclamped. When `payload.image.width/height` or `payload.video.width/height` exceed int32 max (2,147,483,647), OpenSearch returns `mapper_parsing_exception` → permanent DLQ entries.

**Prod impact**: 45 messages already in `octo.message.v1.prod.dlq` with `reason=permanent_4xx`.

## Changes

### `internal/esindex/buildraw.go`
- **Image path** (type=2, lines 92-96): wrap `extractInt` results with `clampInt32()` for `Width` and `Height`
- **Video path** (type=5, lines 119-123): same treatment for `Width` and `Height`

### `internal/esindex/buildraw_test.go`
- `TestProject_ImageOverflowClamped`: verifies image with `width=4293001688, height=3997107456` → both clamped to 0, URL preserved
- `TestProject_VideoOverflowClamped`: verifies video with `width=2424569856, height=3997107456` → both clamped to 0, `second` preserved

## Verification

- [x] Full test suite passes (`go test ./...`)
- [x] New overflow regression tests pass
- [x] Existing image/video projection tests unaffected (normal values unchanged)
- [x] Build succeeds

## Risk

Low — `clampInt32` is the same function already used in the richtext path. Out-of-range values are replaced with 0 (→ `omitempty` drops them from ES doc), preserving the "dimensions untrusted → don't write" semantics from PR #26.