### PR TITLE
feat(obs): add indexer_message_latency_seconds by stage

### DIFF
--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -259,6 +259,15 @@ func (p *Processor) resolvePass(ctx context.Context, batch []fetchedMessage, par
 		case ok:
 			dispositions[idx] = dispOK
 			p.markDisposition(dispOK)
+			if p.metrics != nil {
+				now := time.Now()
+				if parsed[idx].CreatedAt > 0 {
+					p.metrics.ObserveMessageLatency("e2e", now.Sub(time.Unix(parsed[idx].CreatedAt, 0)))
+				}
+				if parsed[idx].MsgTimestamp > 0 {
+					p.metrics.ObserveMessageLatency("send_to_index", now.Sub(time.Unix(parsed[idx].MsgTimestamp, 0)))
+				}
+			}
 			changed = true
 		case permanent:
 			if err := p.routePoison(ctx, batch[idx], res, reasonPermanent4xx); err != nil {

--- a/internal/consumer/metrics.go
+++ b/internal/consumer/metrics.go
@@ -13,6 +13,10 @@ const metricsNamespace = "indexer"
 // producer leg.
 var latencyBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}
 
+// msgLatencyBuckets bucketizes end-to-end message latency (sub-second up to
+// 30min), too coarse for the IO-op buckets above.
+var msgLatencyBuckets = []float64{0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800}
+
 // Metrics is the es-indexer consumer observability set, backed by the prometheus
 // client_golang SDK on a private registry (no global default registry — the two
 // binaries must never cross-register each other's series).
@@ -36,6 +40,7 @@ type Metrics struct {
 	committed    *prometheus.GaugeVec
 	ioOpDuration *prometheus.HistogramVec
 	ioOpErrors   *prometheus.CounterVec
+	msgLatency   *prometheus.HistogramVec
 }
 
 // NewMetrics constructs a Metrics bound to its own registry.
@@ -84,10 +89,16 @@ func NewMetrics() *Metrics {
 			Name:      "io_op_errors_total",
 			Help:      "IO operation failures by op.",
 		}, []string{"op"}),
+		msgLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "message_latency_seconds",
+			Help:      "Message latency to ES visibility by stage (e2e: from DB created_at; send_to_index: from msg send timestamp).",
+			Buckets:   msgLatencyBuckets,
+		}, []string{"stage"}),
 	}
 	reg.MustRegister(
 		m.disposition, m.dlq, m.dlqHardStop, m.dlqExhausted, m.bulkErrors,
-		m.committed, m.ioOpDuration, m.ioOpErrors,
+		m.committed, m.ioOpDuration, m.ioOpErrors, m.msgLatency,
 	)
 	return m
 }
@@ -129,4 +140,13 @@ func (m *Metrics) ObserveIO(op string, d time.Duration) {
 // MarkIOError records one IO failure by op.
 func (m *Metrics) MarkIOError(op string) {
 	m.ioOpErrors.WithLabelValues(op).Inc()
+}
+
+// ObserveMessageLatency records one message latency sample for stage (e2e or
+// send_to_index). Negative durations (clock skew where now < ts) clamp to 0.
+func (m *Metrics) ObserveMessageLatency(stage string, d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	m.msgLatency.WithLabelValues(stage).Observe(d.Seconds())
 }


### PR DESCRIPTION
Closes #40

## What

在 es-indexer consumer 侧新增单个 Histogram，度量消息到 ES 可见的延迟，用 `stage` label 区分两种：

- `indexer_message_latency_seconds{stage="e2e"}` = `now - created_at`（DB 落库 → ES 可见）
- `indexer_message_latency_seconds{stage="send_to_index"}` = `now - msg_timestamp`（消息发送 → ES 可见）

## Where

埋点在 `resolvePass` 的 `dispOK` 分支（ES bulk 成功那一刻）——此时 `CreatedAt` / `MsgTimestamp`（秒级 epoch）与处理时刻 `now` 同时在手，无需改 Kafka 协议、无需新表。

## Design notes

- 单一指标名 + `stage` label，控制基数。
- 独立延迟 bucket（`[0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800]`，0.5s~30min），与处理耗时 bucket（5ms~5s）分开。
- 负值（时钟漂移 `now < ts`）clamp 到 0；源时间戳为 0 时跳过对应 stage，避免把缺时间戳当成超大延迟。
- 风格对齐现有 `ObserveIO` / `MarkIOError`，无新增文件、无抽象层，最小 diff。

## Test

- `go build ./...` ✅
- `go vet ./internal/consumer/...` ✅
- `go test ./internal/consumer/...` ✅
- 全量 `go test ./...` ✅
