### PR TITLE
feat(obs): add searchetl_producer_source_max_id gauge per shard

### DIFF
--- a/internal/producer/etl.go
+++ b/internal/producer/etl.go
@@ -129,6 +129,15 @@ func (e *ETL) runTick(ctx context.Context, tables []string) error {
 				break
 			}
 		}
+		// source_max_id{shard}: best-effort lag watermark. Observability only —
+		// a query failure must never fail the tick, just log and continue.
+		if e.metrics != nil {
+			if maxID, merr := e.store.MaxID(ctx, table); merr != nil {
+				e.logf("producer: max id query failed (table=%s): %v", table, merr)
+			} else {
+				e.metrics.SetSourceMaxID(table, maxID)
+			}
+		}
 	}
 
 	if e.metrics != nil {

--- a/internal/producer/etl_test.go
+++ b/internal/producer/etl_test.go
@@ -9,7 +9,19 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
+
+// gaugeValue reads the current value of a labelled gauge for assertions.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("gauge write: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
 
 // fakeStore is an in-memory Store: one shard with rows + a cursor, plus a CAS
 // advance. Used to validate the chunk pipeline without a real MySQL.
@@ -20,6 +32,7 @@ type fakeStore struct {
 	cursor   map[string]int64
 	readErr  error
 	advErr   error
+	maxErr   error
 	advCalls int
 }
 
@@ -69,6 +82,21 @@ func (f *fakeStore) AdvanceCursor(_ context.Context, table string, expected, new
 	}
 	f.cursor[table] = newID
 	return true, nil
+}
+
+func (f *fakeStore) MaxID(_ context.Context, table string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.maxErr != nil {
+		return 0, f.maxErr
+	}
+	var max int64
+	for _, r := range f.rows[table] {
+		if r.ID > max {
+			max = r.ID
+		}
+	}
+	return max, nil
 }
 
 // fakeSink records produced batches.
@@ -265,7 +293,7 @@ func (b *blockingSinkT) ProduceBatch(context.Context, []searchmsg.Message) error
 	return nil
 }
 func (b *blockingSinkT) ProduceDLQ(context.Context, []DLQEnvelope) error { return nil }
-func (b *blockingSinkT) Close() error                                          { return nil }
+func (b *blockingSinkT) Close() error                                    { return nil }
 
 // TestPlanChunk_DLQRouting: bad-json row routed to dlq, cursor watermark counts it.
 func TestPlanChunk_DLQRouting(t *testing.T) {
@@ -299,5 +327,52 @@ func TestPlanChunk_DLQRouting(t *testing.T) {
 	}
 	if dl.ProducedAt != 0 {
 		t.Fatalf("planChunk must stay pure (no clock): ProducedAt should be 0, got %d", dl.ProducedAt)
+	}
+}
+
+// TestRunIncremental_SetsSourceMaxID: source_max_id gauge is set to MAX(id).
+func TestRunIncremental_SetsSourceMaxID(t *testing.T) {
+	now := int64(10_000)
+	store := newFakeStore(now)
+	store.rows["message"] = []*srcMessageRow{
+		textRow(1, "a", now-1000), textRow(2, "b", now-1000), textRow(3, "c", now-1000),
+	}
+	metrics := NewMetrics()
+	etl := NewETL(ETLDeps{
+		Store: store, NewSink: func() Sink { return &fakeSink{} },
+		Lock: &fakeLock{acquireOK: true, renewOK: true}, Batch: 100, Lag: 600,
+		RenewInterval: time.Hour, Metrics: metrics,
+	})
+	if err := etl.RunIncremental(context.Background(), []string{"message"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := gaugeValue(t, metrics.sourceMaxID.WithLabelValues("message")); got != 3 {
+		t.Fatalf("source_max_id must be 3, got %v", got)
+	}
+}
+
+// TestRunIncremental_MaxIDFailDoesNotFailTick: MaxID error is logged, the tick
+// still succeeds and the cursor advances.
+func TestRunIncremental_MaxIDFailDoesNotFailTick(t *testing.T) {
+	now := int64(10_000)
+	store := newFakeStore(now)
+	store.maxErr = errors.New("max id boom")
+	store.rows["message"] = []*srcMessageRow{
+		textRow(1, "a", now-1000), textRow(2, "b", now-1000), textRow(3, "c", now-1000),
+	}
+	metrics := NewMetrics()
+	etl := NewETL(ETLDeps{
+		Store: store, NewSink: func() Sink { return &fakeSink{} },
+		Lock: &fakeLock{acquireOK: true, renewOK: true}, Batch: 100, Lag: 600,
+		RenewInterval: time.Hour, Metrics: metrics,
+	})
+	if err := etl.RunIncremental(context.Background(), []string{"message"}); err != nil {
+		t.Fatalf("MaxID failure must not fail the tick, got %v", err)
+	}
+	if store.cursor["message"] != 3 {
+		t.Fatalf("cursor must still advance to 3, got %d", store.cursor["message"])
+	}
+	if got := gaugeValue(t, metrics.sourceMaxID.WithLabelValues("message")); got != 0 {
+		t.Fatalf("source_max_id must stay unset (0) on MaxID failure, got %v", got)
 	}
 }

--- a/internal/producer/metrics.go
+++ b/internal/producer/metrics.go
@@ -21,6 +21,7 @@ var latencyBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}
 // Series (all prefixed searchetl_producer_):
 //   - produced_total{stream}          counter   messages produced by stream (main/dlq)
 //   - cursor_position{shard}          gauge     per-shard cursor watermark (message.id)
+//   - source_max_id{shard}           gauge     per-shard MySQL MAX(id) (lag = source_max_id - cursor_position)
 //   - ticks_total{result}            counter   slow-cursor ticks by result (ok/error)
 //   - tick_duration_seconds          histogram whole-tick latency
 //   - read_batch_duration_seconds    histogram single ReadStableBatchTx latency
@@ -32,6 +33,7 @@ type Metrics struct {
 
 	produced       *prometheus.CounterVec
 	cursor         *prometheus.GaugeVec
+	sourceMaxID    *prometheus.GaugeVec
 	ticks          *prometheus.CounterVec
 	tickDuration   prometheus.Histogram
 	readBatchDur   prometheus.Histogram
@@ -54,6 +56,11 @@ func NewMetrics() *Metrics {
 			Namespace: metricsNamespace,
 			Name:      "cursor_position",
 			Help:      "Per-shard cursor watermark (message.id).",
+		}, []string{"shard"}),
+		sourceMaxID: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "source_max_id",
+			Help:      "Per-shard MySQL MAX(id) (source watermark for lag).",
 		}, []string{"shard"}),
 		ticks: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -89,7 +96,7 @@ func NewMetrics() *Metrics {
 		}),
 	}
 	reg.MustRegister(
-		m.produced, m.cursor, m.ticks, m.tickDuration, m.readBatchDur,
+		m.produced, m.cursor, m.sourceMaxID, m.ticks, m.tickDuration, m.readBatchDur,
 		m.dlq, m.produceErrors, m.lockRenewFails,
 	)
 	return m
@@ -111,6 +118,11 @@ func (m *Metrics) AddProduced(main, dlq int64) {
 // SetCursor records the latest cursor watermark for a shard.
 func (m *Metrics) SetCursor(table string, id int64) {
 	m.cursor.WithLabelValues(table).Set(float64(id))
+}
+
+// SetSourceMaxID records the latest source MAX(id) watermark for a shard.
+func (m *Metrics) SetSourceMaxID(table string, id int64) {
+	m.sourceMaxID.WithLabelValues(table).Set(float64(id))
 }
 
 // MarkTick records a tick outcome (result ∈ {ok, error}).

--- a/internal/producer/source.go
+++ b/internal/producer/source.go
@@ -26,6 +26,9 @@ type Store interface {
 	// AdvanceCursor advances the watermark from expected to newID via an optimistic
 	// CAS (WHERE last_id=expected). Returns whether a row was actually updated.
 	AdvanceCursor(ctx context.Context, table string, expected, newID int64) (bool, error)
+	// MaxID returns COALESCE(MAX(id),0) of the shard table — the source watermark
+	// for lag (MAX(id) - cursor_position). Observability only.
+	MaxID(ctx context.Context, table string) (int64, error)
 }
 
 // MySQLStore implements Store over database/sql (keyset pagination, no OFFSET).
@@ -130,6 +133,19 @@ func (s *MySQLStore) AdvanceCursor(ctx context.Context, table string, expected, 
 		return false, err
 	}
 	return n == 1, nil
+}
+
+// MaxID returns COALESCE(MAX(id),0) of the shard table (source watermark for lag).
+func (s *MySQLStore) MaxID(ctx context.Context, table string) (int64, error) {
+	if !safeTableName(table) {
+		return 0, fmt.Errorf("producer: unsafe table name %q", table)
+	}
+	var maxID int64
+	q := fmt.Sprintf("SELECT COALESCE(MAX(id),0) FROM `%s`", table)
+	if err := s.db.QueryRowContext(ctx, q).Scan(&maxID); err != nil {
+		return 0, fmt.Errorf("producer: max id %s: %w", table, err)
+	}
+	return maxID, nil
 }
 
 // OpenMySQL opens the source DB with an explicit connection pool (no bare driver


### PR DESCRIPTION
Closes #42

## What

Adds a per-shard `searchetl_producer_source_max_id{shard}` gauge so producer lag can be computed directly:

```
lag = searchetl_producer_source_max_id - searchetl_producer_cursor_position
```

## Changes

- **`internal/producer/metrics.go`** — new `sourceMaxID *prometheus.GaugeVec` + `SetSourceMaxID`, mirroring the existing `cursor` / `SetCursor` on the same private registry. Series: `searchetl_producer_source_max_id{shard}`.
- **`internal/producer/source.go`** — `Store.MaxID(ctx, table)` + `MySQLStore` impl: `SELECT COALESCE(MAX(id),0) FROM <table>`, guarded by the existing `safeTableName`.
- **`internal/producer/etl.go`** — `runTick` records `MaxID` once per shard. Observability-only: a query failure is logged via `e.logf` and skipped, never failing the tick.
- **`internal/producer/etl_test.go`** — `fakeStore.MaxID` + two tests: gauge is set to `MAX(id)`, and a `MaxID` failure is logged while the tick still succeeds and the cursor advances.

## Notes

- Purely additive metric; backward compatible. Producer-side only — no consumer / contract / schema changes.
- Reuses the MySQL connection the producer already opens each tick — no standalone exporter.
- No new go.mod dependency (gauge value read in tests via `client_model/go`, already a transitive dep).

## Verification

- `go build ./...` ✅
- `go test ./internal/producer/...` ✅
- `go vet ./internal/producer/...` ✅
- `gofmt -l` clean ✅
