### PR TITLE
feat: file content indexing (payload.file.content + file-extractor + backfill)

### DIFF
--- a/cmd/file-content-backfill/main.go
+++ b/cmd/file-content-backfill/main.go
@@ -1,0 +1,176 @@
+// Command file-content-backfill 一次性 K8s Job：把 IDX-4 file-extractor 上线**之前**的历史
+// type=8 文件消息回填 payload.file.content（v1.12 file content indexing）。
+//
+// 数据链路：
+//
+//	OpenSearch → scroll query [payload.type=8 且 must_not exists payload.file.content]
+//	           → 逐条限速抽取（复用 internal/fileextract.Extractor）
+//	           → OS partial `_update` 只写 payload.file.content + contentMeta
+//
+// 幂等：query 的 `must_not exists content` 天然跳过已抽取 doc，中断重跑无副作用。
+//
+// 用法（K8s Job）：
+//
+//	file-content-backfill \
+//	  -es https://10.10.148.6:9200,https://10.10.148.15:9200,https://10.10.148.12:9200 \
+//	  -es-user octosearch -es-pass "$OS_PASSWORD" \
+//	  -es-index octo-message \
+//	  -tika-url http://tika-service:9998 \
+//	  -rate 50 -timeout 2h
+//
+// 退出码：Stats.OSTransient > 0 或 DLQ 占比 > 10% → exit 1 让 K8s 报错；正常 exit 0。
+//
+// 🔴 隔离纪律：真实环境执行须 Yu / 运维 sign-off，主人决策 backfill 走 K8s Job 一次性跑
+// （不常驻），跑完手动 delete Job 释放资源。
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	fbf "github.com/Mininglamp-OSS/octo-search-indexer/internal/filebackfill"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+	if err := run(); err != nil {
+		log.Printf("file-content-backfill error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		esAddrs     = flag.String("es", envOr("BACKFILL_ES", ""), "comma-separated OpenSearch addresses (required)")
+		esIndex     = flag.String("es-index", envOr("BACKFILL_ES_INDEX", "octo-message"), "OpenSearch index / alias")
+		esUser      = flag.String("es-user", os.Getenv("BACKFILL_ES_USER"), "OS username (optional)")
+		esPass      = flag.String("es-pass", os.Getenv("BACKFILL_ES_PASS"), "OS password (optional)")
+		tikaURL     = flag.String("tika-url", envOr("BACKFILL_TIKA_URL", "http://tika-service:9998"), "Tika Server URL")
+		rate        = flag.Float64("rate", envFloat("BACKFILL_RATE", 50), "extraction rate limit (docs/s; <=0 = unlimited)")
+		scrollSize  = flag.Int("scroll-size", envInt("BACKFILL_SCROLL_SIZE", 500), "OS scroll batch size")
+		scrollTTL   = flag.Duration("scroll-ttl", envDuration("BACKFILL_SCROLL_TTL", 5*time.Minute), "scroll keep-alive TTL")
+		timeout     = flag.Duration("timeout", envDuration("BACKFILL_TIMEOUT", 2*time.Hour), "overall Job timeout")
+		downloadMS  = flag.Int("download-timeout-ms", envInt("BACKFILL_DOWNLOAD_TIMEOUT_MS", 30000), "CDN download timeout (ms)")
+		extractMS   = flag.Int("extract-timeout-ms", envInt("BACKFILL_EXTRACT_TIMEOUT_MS", 30000), "Tika extract timeout (ms)")
+		maxSize     = flag.Int64("max-file-size", int64(envInt("BACKFILL_MAX_FILE_SIZE_BYTES", 20*1024*1024)), "max file size (bytes)")
+		maxContent  = flag.Int("max-content-bytes", envInt("BACKFILL_MAX_CONTENT_BYTES", 256*1024), "max extracted content bytes")
+		httpRetries = flag.Int("http-retries", envInt("BACKFILL_HTTP_RETRIES", 3), "CDN GET retry count")
+		dlqRatioMax = flag.Float64("max-dlq-ratio", 0.10, "max allowed DLQ/scanned ratio; over threshold → exit 1")
+	)
+	flag.Parse()
+
+	if *esAddrs == "" {
+		return fmt.Errorf("es addresses required (-es or BACKFILL_ES)")
+	}
+
+	cfg := fbf.Config{
+		ESAddresses:     splitCSV(*esAddrs),
+		ESIndex:         *esIndex,
+		ESUsername:      *esUser,
+		ESPassword:      *esPass,
+		TikaURL:         *tikaURL,
+		DownloadTimeout: time.Duration(*downloadMS) * time.Millisecond,
+		ExtractTimeout:  time.Duration(*extractMS) * time.Millisecond,
+		MaxFileSize:     *maxSize,
+		MaxContentBytes: *maxContent,
+		HTTPRetries:     *httpRetries,
+		Rate:            *rate,
+		ScrollSize:      *scrollSize,
+		ScrollTTL:       *scrollTTL,
+		Timeout:         *timeout,
+	}
+
+	runner, err := fbf.NewRunner(cfg)
+	if err != nil {
+		return fmt.Errorf("build runner: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	log.Printf("file-content-backfill starting: es_index=%s tika=%s rate=%.1f scroll_size=%d timeout=%v",
+		*esIndex, *tikaURL, *rate, *scrollSize, *timeout)
+
+	stats, err := runner.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("runner.Run: %w (stats: %+v)", err, stats)
+	}
+
+	// 退出码判定：OSTransient>0 或 DLQ 占比过高 → 让 K8s Job 报错
+	if stats.OSTransient > 0 {
+		return fmt.Errorf("os transient errors during backfill: %d (stats: %+v)", stats.OSTransient, stats)
+	}
+	if stats.Scanned > 0 {
+		ratio := float64(stats.DLQ) / float64(stats.Scanned)
+		if ratio > *dlqRatioMax {
+			return fmt.Errorf("dlq ratio %.3f > threshold %.3f (dlq=%d scanned=%d)", ratio, *dlqRatioMax, stats.DLQ, stats.Scanned)
+		}
+	}
+	return nil
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+		log.Printf("file-content-backfill: invalid %s=%q, using default %d", key, v, def)
+		return def
+	}
+	return n
+}
+
+func envFloat(key string, def float64) float64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	var f float64
+	if _, err := fmt.Sscanf(v, "%f", &f); err != nil {
+		log.Printf("file-content-backfill: invalid %s=%q, using default %f", key, v, def)
+		return def
+	}
+	return f
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Printf("file-content-backfill: invalid %s=%q, using default %v", key, v, def)
+		return def
+	}
+	return d
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cmd/file-content-backfill/main_test.go
+++ b/cmd/file-content-backfill/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// resetBackfillEnv 清空 BACKFILL_ 前缀所有 env，避免 test 污染。
+func resetBackfillEnv(t *testing.T) {
+	t.Helper()
+	for _, kv := range os.Environ() {
+		if idx := strings.IndexByte(kv, '='); idx > 0 {
+			key := kv[:idx]
+			if strings.HasPrefix(key, "BACKFILL_") {
+				t.Setenv(key, "")
+			}
+		}
+	}
+}
+
+// TestSplitCSV 覆盖 CSV 解析各种输入形态。
+func TestSplitCSV(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", []string{}},
+		{"a", []string{"a"}},
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a, b , c", []string{"a", "b", "c"}}, // trim
+		{",a,,b,", []string{"a", "b"}},        // 忽略空
+	}
+	for _, c := range cases {
+		got := splitCSV(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("splitCSV(%q): len got=%d want=%d (%v)", c.in, len(got), len(c.want), got)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("splitCSV(%q)[%d]: got %q want %q", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+// TestEnvOr 默认值 / env 覆盖。
+func TestEnvOr(t *testing.T) {
+	resetBackfillEnv(t)
+	if got := envOr("BACKFILL_NOT_SET_XYZ", "default"); got != "default" {
+		t.Errorf("envOr default: got %q", got)
+	}
+	t.Setenv("BACKFILL_TEST_KEY", "override")
+	if got := envOr("BACKFILL_TEST_KEY", "default"); got != "override" {
+		t.Errorf("envOr override: got %q", got)
+	}
+}
+
+// TestEnvInt 有效整数 / 无效字符串走 default / env 缺省。
+func TestEnvInt(t *testing.T) {
+	resetBackfillEnv(t)
+	if got := envInt("BACKFILL_NOT_SET", 42); got != 42 {
+		t.Errorf("envInt default: got %d", got)
+	}
+	t.Setenv("BACKFILL_NUM", "100")
+	if got := envInt("BACKFILL_NUM", 42); got != 100 {
+		t.Errorf("envInt override: got %d", got)
+	}
+	t.Setenv("BACKFILL_BAD", "not-a-number")
+	if got := envInt("BACKFILL_BAD", 42); got != 42 {
+		t.Errorf("envInt invalid falls back to default: got %d", got)
+	}
+}

--- a/cmd/file-extractor/main.go
+++ b/cmd/file-extractor/main.go
@@ -1,0 +1,183 @@
+// Command file-extractor 是 octo-im 消息检索管线的文件正文抽取服务（v1.12）。
+// 消费与 es-indexer 同一个 Kafka topic `octo.message.v1{,.prod}`，独立 consumer group
+// `file-extractor`（不抢 es-indexer 位点）。命中 payload.type=8 (File) 时下载 CDN 文件 → 调
+// Tika HTTP 抽取正文 → OS partial `_update` 只写 payload.file.content + payload.file.contentMeta。
+// 命中非 file 类型 → commit 位点跳过。
+//
+// 与 es-indexer 的分工：
+//
+//	Kafka topic octo.message.v1
+//	  ├── consumer group `octo-search-indexer` → es-indexer   → 写主 doc (_bulk index)
+//	  └── consumer group `file-extractor`      → file-extractor → 更新 payload.file.content (_update)
+//	                                                              ↑ 本服务
+//	OS partial `_update` doc_as_upsert=false：主 doc 未落时报 404（errDocNotYet），
+//	由本服务重试兜底（v2 §7 #1 时序竞态设计）。
+//
+// 配置全部走环境变量（一仓一镜像、独立部署，同 es-indexer 惯例）。未开通 (FILE_EXTRACTOR_ENABLED
+// != true 或 brokers/ES 未配置) 时空转到收到终止信号——保持「未开通即零运行期行为」，须显式注入
+// 配置才工作。
+//
+// IDX-3 是骨架 commit：Kafka 消费 + type=8 filter + DLQ 8 种 reason 常量就位，但抽取核心
+// (download / Tika / OS update) 是 stub，命中 file 时只 log 占位。IDX-4 补齐抽取。
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/fileextract"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil && ctx.Err() == nil {
+		log.Printf("file-extractor exited with error: %v", err)
+		os.Exit(1)
+	}
+	log.Printf("file-extractor stopped")
+}
+
+func run(ctx context.Context) error {
+	cfg, enabled := loadConfig()
+	if !enabled {
+		log.Printf("file-extractor: FILE_EXTRACTOR_ENABLED not true (or brokers/ES unset); idling (no backend connection)")
+		<-ctx.Done()
+		return nil
+	}
+	// v1.13 P2-10：startup mapping-compat fail-closed 断言。es-indexer 已用 esindex.Writer
+	// 的 AssertLiveMappingCompatible 校验 mapping 齐备；file-extractor 也需同验证，避免部署
+	// 顺序错（mapping 未 PUT 就上 file-extractor）导致 permanent 400 与 Blocker #2 修复的
+	// in-place retry 循环叠加浪费时间才发现问题。缺字段 → loud crash 让 K8s 重启并告警。
+	if err := assertLiveMapping(ctx, cfg); err != nil {
+		return err
+	}
+	svc, err := fileextract.NewService(cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := svc.Close(); cerr != nil {
+			log.Printf("file-extractor: close error: %v", cerr)
+		}
+	}()
+	log.Printf("file-extractor running: topic=%s group=%s dlq=%s es_index=%s tika=%s",
+		cfg.Topic, cfg.GroupID, cfg.DLQTopic, cfg.ESIndex, cfg.TikaURL)
+	return svc.Run(ctx)
+}
+
+// assertLiveMapping 用 esindex.Writer 复用 mapping-compat 校验（P2-10）。
+// 写完立即 Close 释放 client（本调用只做健康检查，主流程另建自己的 osWriter）。
+func assertLiveMapping(ctx context.Context, cfg fileextract.ServiceConfig) error {
+	w, err := esindex.NewWriter(esindex.Config{
+		Addresses: cfg.ESAddresses,
+		Index:     cfg.ESIndex,
+		Username:  cfg.ESUsername,
+		Password:  cfg.ESPassword,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = w.Close() }() //nolint:errcheck // close-on-check: nothing to do with close err
+	if err := w.AssertLiveMappingCompatible(ctx); err != nil {
+		return err
+	}
+	log.Printf("file-extractor: live mapping compat OK for index=%s", cfg.ESIndex)
+	return nil
+}
+
+// loadConfig 从环境读配置。返回 enabled=false 时服务空转（未开通）。
+// 开通条件：FILE_EXTRACTOR_ENABLED (可解析为 true) 且 brokers / ES 地址均已配置。
+func loadConfig() (fileextract.ServiceConfig, bool) {
+	cfg := fileextract.ServiceConfig{
+		Brokers:             splitCSV(os.Getenv("KAFKA_BROKERS")),
+		Topic:               envOr("KAFKA_TOPIC", "octo.message.v1"),
+		DLQTopic:            envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.file-extract.dlq"),
+		GroupID:             envOr("KAFKA_GROUP_ID", "file-extractor"),
+		BatchSize:           envInt("EXTRACTOR_BATCH_SIZE", 50),
+		ESAddresses:         splitCSV(os.Getenv("ES_ADDRESSES")),
+		ESIndex:             envOr("ES_INDEX", "octo-message"),
+		ESUsername:          os.Getenv("ES_USERNAME"),
+		ESPassword:          os.Getenv("ES_PASSWORD"),
+		TikaURL:             envOr("TIKA_URL", "http://localhost:9998"),
+		DownloadTimeout:     time.Duration(envInt("EXTRACTOR_DOWNLOAD_TIMEOUT_MS", 30000)) * time.Millisecond,
+		ExtractTimeout:      time.Duration(envInt("EXTRACTOR_EXTRACT_TIMEOUT_MS", 30000)) * time.Millisecond,
+		MaxFileSize:         int64(envInt("EXTRACTOR_MAX_FILE_SIZE_BYTES", 20*1024*1024)),
+		MaxContentBytes:     envInt("EXTRACTOR_MAX_CONTENT_BYTES", 256*1024),
+		HTTPRetries:         envInt("EXTRACTOR_HTTP_RETRIES", 3),
+		ExtractStartupDelay: time.Duration(envInt("EXTRACT_STARTUP_DELAY_SECONDS", 5)) * time.Second,
+
+		// v1.13 Blocker #2 fix — in-place bounded retry 参数。生产运维按 OS SLA 与业务
+		// 延迟容忍度调整；未设 env 时走 fileextract 包内 default（10 / 1s / 60s）。
+		MaxRetriesPerMessage: envInt("EXTRACTOR_MAX_RETRIES_PER_MESSAGE", 0), // 0 → fileextract 用 defaultMaxRetriesPerMessage=10
+		TransientBackoffBase: time.Duration(envInt("EXTRACTOR_TRANSIENT_BACKOFF_BASE_MS", 0)) * time.Millisecond,
+		TransientBackoffMax:  time.Duration(envInt("EXTRACTOR_TRANSIENT_BACKOFF_MAX_MS", 0)) * time.Millisecond,
+
+		// v1.13 Blocker #1 fix — SSRF 防护参数。允许运维在不改代码前提下扩展 host 白名单
+		// （future 切内网 COS 时用），未设 env 时走 fileextract 包内 default
+		// (["cdn.deepminer.com.cn"] + ["https"])。
+		AllowedDownloadHosts:   splitCSV(os.Getenv("ALLOWED_DOWNLOAD_HOSTS")),
+		AllowedDownloadSchemes: splitCSV(os.Getenv("ALLOWED_DOWNLOAD_SCHEMES")),
+		// 🔴 SSRFAllowLoopback 显式不从 env 读取：生产必须 false（loopback 是 SSRF 目标之一）。
+		// 测试专用；httptest.NewServer 走 127.0.0.1 需 test cfg 直接设 true，无 env 通道防止
+		// 生产误开或运维在紧急情况下 hot-toggle 打开攻击面。
+		SSRFAllowLoopback: false,
+
+		// v1.13 P2-1 fix (yujiawei review) — DLQ 有界重试 + 本地 spill 逃逸。SpillDir 生产建议
+		// 挂 K8s emptyDir 或 PVC（示例 /var/lib/file-extractor/dlq-spill），未设时走硬停 pattern
+		// （DLQ 写耗尽 → errDLQHardStop → K8s 重启保 offset 不推进 + 告警 page 运维）。
+		DLQMaxRetries:   envInt("DLQ_MAX_RETRIES", 0),
+		DLQRetryBackoff: time.Duration(envInt("DLQ_RETRY_BACKOFF_MS", 0)) * time.Millisecond,
+		DLQSpillDir:     os.Getenv("DLQ_SPILL_DIR"),
+	}
+	enabledFlag, err := strconv.ParseBool(os.Getenv("FILE_EXTRACTOR_ENABLED"))
+	if err != nil {
+		enabledFlag = false // 无效值当未启用（保持"未开通即零运行"语义）
+	}
+	enabled := enabledFlag && len(cfg.Brokers) > 0 && len(cfg.ESAddresses) > 0
+	return cfg, enabled
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Printf("file-extractor: invalid %s=%q, using default %d", key, v, def)
+		return def
+	}
+	return n
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cmd/file-extractor/main_test.go
+++ b/cmd/file-extractor/main_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// resetEnv 清空 EXTRACTOR/KAFKA/ES/FILE_EXTRACTOR/TIKA 前缀所有环境变量，保证 test 无污染。
+func resetEnv(t *testing.T) {
+	t.Helper()
+	for _, prefix := range []string{"FILE_EXTRACTOR_", "KAFKA_", "ES_", "EXTRACTOR_", "TIKA_", "EXTRACT_"} {
+		for _, kv := range os.Environ() {
+			if idx := strings.IndexByte(kv, '='); idx > 0 {
+				key := kv[:idx]
+				if strings.HasPrefix(key, prefix) {
+					t.Setenv(key, "")
+				}
+			}
+		}
+	}
+}
+
+// TestLoadConfig_DisabledByDefault 未设 FILE_EXTRACTOR_ENABLED → enabled=false。
+func TestLoadConfig_DisabledByDefault(t *testing.T) {
+	resetEnv(t)
+	_, enabled := loadConfig()
+	if enabled {
+		t.Fatal("expected enabled=false when FILE_EXTRACTOR_ENABLED is unset")
+	}
+}
+
+// TestLoadConfig_MissingBrokers Enabled=true 但缺 KAFKA_BROKERS → enabled=false。
+func TestLoadConfig_MissingBrokers(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("ES_ADDRESSES", "http://os:9200")
+	_, enabled := loadConfig()
+	if enabled {
+		t.Fatal("expected enabled=false without KAFKA_BROKERS")
+	}
+}
+
+// TestLoadConfig_MissingES Enabled=true + brokers 但缺 ES_ADDRESSES → enabled=false。
+func TestLoadConfig_MissingES(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	_, enabled := loadConfig()
+	if enabled {
+		t.Fatal("expected enabled=false without ES_ADDRESSES")
+	}
+}
+
+// TestLoadConfig_HappyPath_Defaults 完整启用，覆盖默认值（DLQ topic / group / batch size 等）。
+func TestLoadConfig_HappyPath_Defaults(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	t.Setenv("ES_ADDRESSES", "http://os:9200")
+	cfg, enabled := loadConfig()
+	if !enabled {
+		t.Fatal("expected enabled=true")
+	}
+	if cfg.Topic != "octo.message.v1" {
+		t.Errorf("Topic default: got %q want octo.message.v1", cfg.Topic)
+	}
+	if cfg.DLQTopic != "octo.message.v1.file-extract.dlq" {
+		t.Errorf("DLQTopic default: got %q", cfg.DLQTopic)
+	}
+	if cfg.GroupID != "file-extractor" {
+		t.Errorf("GroupID default: got %q", cfg.GroupID)
+	}
+	if cfg.BatchSize != 50 {
+		t.Errorf("BatchSize default: got %d", cfg.BatchSize)
+	}
+	if cfg.TikaURL != "http://localhost:9998" {
+		t.Errorf("TikaURL default: got %q", cfg.TikaURL)
+	}
+	if cfg.MaxFileSize != 20*1024*1024 {
+		t.Errorf("MaxFileSize default: got %d want %d", cfg.MaxFileSize, 20*1024*1024)
+	}
+	if cfg.MaxContentBytes != 256*1024 {
+		t.Errorf("MaxContentBytes default: got %d", cfg.MaxContentBytes)
+	}
+	if cfg.HTTPRetries != 3 {
+		t.Errorf("HTTPRetries default: got %d", cfg.HTTPRetries)
+	}
+	if cfg.ExtractStartupDelay.Seconds() != 5 {
+		t.Errorf("ExtractStartupDelay default: got %v", cfg.ExtractStartupDelay)
+	}
+}
+
+// TestLoadConfig_V113ConfigDefaults v1.13 新增 6 字段未设 env 时留零值，由 fileextract 包内
+// default 在 NewProcessor / newDownloadClient 兜底（10 / 1s / 60s / cdn.deepminer.com.cn / https / false）。
+func TestLoadConfig_V113ConfigDefaults(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	t.Setenv("ES_ADDRESSES", "http://os:9200")
+	cfg, _ := loadConfig()
+	if cfg.MaxRetriesPerMessage != 0 {
+		t.Errorf("MaxRetriesPerMessage default: got %d want 0 (fileextract pkg default kicks in)", cfg.MaxRetriesPerMessage)
+	}
+	if cfg.TransientBackoffBase != 0 {
+		t.Errorf("TransientBackoffBase default: got %v want 0", cfg.TransientBackoffBase)
+	}
+	if cfg.TransientBackoffMax != 0 {
+		t.Errorf("TransientBackoffMax default: got %v want 0", cfg.TransientBackoffMax)
+	}
+	if len(cfg.AllowedDownloadHosts) != 0 {
+		t.Errorf("AllowedDownloadHosts default: got %v want empty (fileextract pkg default kicks in)", cfg.AllowedDownloadHosts)
+	}
+	if len(cfg.AllowedDownloadSchemes) != 0 {
+		t.Errorf("AllowedDownloadSchemes default: got %v want empty", cfg.AllowedDownloadSchemes)
+	}
+	if cfg.SSRFAllowLoopback {
+		t.Fatal("SSRFAllowLoopback must be false in prod (no env channel)")
+	}
+}
+
+// TestLoadConfig_V113ConfigOverride v1.13 新 env 被读取到 cfg。SSRFAllowLoopback 无论 env
+// 设什么都必须保持 false（生产安全 gate；测试专用只能通过 test cfg 注入）。
+func TestLoadConfig_V113ConfigOverride(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	t.Setenv("ES_ADDRESSES", "http://os:9200")
+	t.Setenv("EXTRACTOR_MAX_RETRIES_PER_MESSAGE", "5")
+	t.Setenv("EXTRACTOR_TRANSIENT_BACKOFF_BASE_MS", "500")
+	t.Setenv("EXTRACTOR_TRANSIENT_BACKOFF_MAX_MS", "30000")
+	t.Setenv("ALLOWED_DOWNLOAD_HOSTS", "cdn.deepminer.com.cn,internal-cos.example")
+	t.Setenv("ALLOWED_DOWNLOAD_SCHEMES", "https,http")
+	// SSRFAllowLoopback 无 env 通道；设任何 env 都无效
+	t.Setenv("SSRF_ALLOW_LOOPBACK", "true")
+	cfg, _ := loadConfig()
+	if cfg.MaxRetriesPerMessage != 5 {
+		t.Errorf("MaxRetriesPerMessage: got %d want 5", cfg.MaxRetriesPerMessage)
+	}
+	if cfg.TransientBackoffBase != 500*time.Millisecond {
+		t.Errorf("TransientBackoffBase: got %v want 500ms", cfg.TransientBackoffBase)
+	}
+	if cfg.TransientBackoffMax != 30*time.Second {
+		t.Errorf("TransientBackoffMax: got %v want 30s", cfg.TransientBackoffMax)
+	}
+	if len(cfg.AllowedDownloadHosts) != 2 || cfg.AllowedDownloadHosts[0] != "cdn.deepminer.com.cn" || cfg.AllowedDownloadHosts[1] != "internal-cos.example" {
+		t.Errorf("AllowedDownloadHosts: got %v", cfg.AllowedDownloadHosts)
+	}
+	if len(cfg.AllowedDownloadSchemes) != 2 || cfg.AllowedDownloadSchemes[0] != "https" || cfg.AllowedDownloadSchemes[1] != "http" {
+		t.Errorf("AllowedDownloadSchemes: got %v", cfg.AllowedDownloadSchemes)
+	}
+	if cfg.SSRFAllowLoopback {
+		t.Fatal("SSRFAllowLoopback must stay false even when SSRF_ALLOW_LOOPBACK=true env is set (no env channel by design)")
+	}
+}
+
+// TestLoadConfig_DLQEnvOverride v1.13 P2-1 (yujiawei review) — DLQ 有界重试/spill 三个 env 挂载。
+// SpillDir 默认空 → 硬停 pattern；生产设 emptyDir/PVC 路径转成 spill 逃逸。
+func TestLoadConfig_DLQEnvOverride(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	t.Setenv("ES_ADDRESSES", "http://os:9200")
+
+	// 默认 unset → cfg 都是 zero，由 dlqHandler 内部 default 兜底
+	cfg, _ := loadConfig()
+	if cfg.DLQMaxRetries != 0 {
+		t.Errorf("DLQMaxRetries default: got %d want 0 (handler kicks default 5)", cfg.DLQMaxRetries)
+	}
+	if cfg.DLQRetryBackoff != 0 {
+		t.Errorf("DLQRetryBackoff default: got %v want 0 (handler kicks default 200ms)", cfg.DLQRetryBackoff)
+	}
+	if cfg.DLQSpillDir != "" {
+		t.Errorf("DLQSpillDir default: got %q want empty (hard-stop pattern)", cfg.DLQSpillDir)
+	}
+
+	// 设 env → cfg 载入
+	t.Setenv("DLQ_MAX_RETRIES", "3")
+	t.Setenv("DLQ_RETRY_BACKOFF_MS", "150")
+	t.Setenv("DLQ_SPILL_DIR", "/var/lib/file-extractor/dlq-spill")
+	cfg2, _ := loadConfig()
+	if cfg2.DLQMaxRetries != 3 {
+		t.Errorf("DLQMaxRetries: got %d want 3", cfg2.DLQMaxRetries)
+	}
+	if cfg2.DLQRetryBackoff != 150*time.Millisecond {
+		t.Errorf("DLQRetryBackoff: got %v want 150ms", cfg2.DLQRetryBackoff)
+	}
+	if cfg2.DLQSpillDir != "/var/lib/file-extractor/dlq-spill" {
+		t.Errorf("DLQSpillDir: got %q", cfg2.DLQSpillDir)
+	}
+}
+
+// TestLoadConfig_ProdTopicOverride 覆盖 topic/DLQ topic 到 .prod 后缀（部署时环境变量注入）。
+func TestLoadConfig_ProdTopicOverride(t *testing.T) {
+	resetEnv(t)
+	t.Setenv("FILE_EXTRACTOR_ENABLED", "true")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	t.Setenv("ES_ADDRESSES", "http://os:9200")
+	t.Setenv("KAFKA_TOPIC", "octo.message.v1.prod")
+	t.Setenv("KAFKA_DLQ_TOPIC", "octo.message.v1.file-extract.dlq.prod")
+	cfg, _ := loadConfig()
+	if cfg.Topic != "octo.message.v1.prod" {
+		t.Errorf("Topic override: got %q", cfg.Topic)
+	}
+	if cfg.DLQTopic != "octo.message.v1.file-extract.dlq.prod" {
+		t.Errorf("DLQTopic override: got %q", cfg.DLQTopic)
+	}
+}

--- a/docs/file-content-indexing-code-review.md
+++ b/docs/file-content-indexing-code-review.md
@@ -1,0 +1,546 @@
+# file content indexing — Code Review
+
+**Branch**: `feat/file-content-indexing` (5 commits ahead of `origin/main`)
+**Reviewer**: cc-octo (以 fresh-context independent reviewer 立场，非原作者视角)
+**Review date**: 2026-07-02
+**Scope**: 5 commits (IDX-1 → IDX-5) 共 33 files / 5042+ / 7-；重点 pkg `internal/fileextract`、`internal/filebackfill`、两个 `cmd/*`、`internal/esindex` FilePayload/mapping/mapping_compat 改动，以及 3 份 docs 与代码对齐度。
+
+---
+
+## §0 总判定
+
+**BLOCK** — push GitHub PR 前必须修 §1 里的 1 条严重问题（backfill snowflake messageId float64 精度丢失，直接导致 K8s Job OS `_update` 打不到目标 doc）。修完后建议一并处理 §2 里的可维护性 / 单测覆盖问题，再走 push → PR → 主人 sig-off 流程。
+
+**理由摘要**：
+
+- 严重 1 条：backfill 从 OS `_source.messageId`（mapping 声明 `long`，snowflake 19 位数字）反解到 `MessageID any`，Go 默认 JSON unmarshal 把 JSON number 解成 `float64` → `fmt.Sprintf("%v", ...)` 输出科学计数法 `1.234e+18` → 作为 OS `_id` 送 partial `_update` → 100% 打不到真 doc（要么 404 计入 OSTransient 撤销 Job，要么写错到 alias 里精度相同的假 doc）。这与本 repo 早已确立的 snowflake 精度铁律（`internal/esindex/buildraw.go:22` 明确注释 + `TestProject_SnowflakePrecision` 现有测试）冲突。
+- 应修 9 条：`defer cancel()` 在 for 循环内累积、JSON body 用 `fmt.Sprintf` 拼接、Content-Disposition 头未 sanitize（filename 用户可控存在 CRLF 注入面）、runner ctx 取消被当作错误、`strings.Contains` 被手写复刻、tika ctx 取消只覆盖 DeadlineExceeded、`Runner.Run` 零测试覆盖、DLQ retry/spill 字段声明但未实现、ratelimit 无锁但无 doc 警示。
+- Nit 若干：陈旧的 IDX-3/4/5 stub 注释、`FilePayload` 拆参 bridge 冗余、backoff 注释在 config vs download 不一致、`formatDuration(500ms)` 返回 `"0s"` 是 OS scroll 立即过期陷阱、`DLQMaxRetries` 等未消费字段。
+
+---
+
+## §1 严重问题（BLOCK — 必须修才能 push）
+
+### S1. `internal/filebackfill/source.go:159` — snowflake messageId 被 float64 截断
+
+**问题**：`parseHits` 里 struct 定义把 messageId 声明为 `any`：
+
+```go
+var src struct {
+    MessageID any `json:"messageId"` // long 反序列成 float64；用 fmt %v 转字符串
+    ...
+```
+
+Go 标准 `json.Unmarshal` 遇到 JSON number 且目标是 `interface{}` 时，一律解为 `float64`。IEEE 754 double 只能无损表示 2^53 以内的整数，snowflake messageId 通常 18-19 位（远超 2^53 ≈ 9e15）。`fmt.Sprintf("%v", float64(1234567890123456789))` 输出 `"1.2345678901234568e+18"`（后 3-4 位精度丢失 + 科学计数法字符串）。
+
+**下游影响链**：
+1. `sourceDoc.MessageID = "1.234e+18"` （错误字符串）
+2. `runner.processOne` → `fileextract.ExtractAndWriteForBackfill(..., doc.MessageID, ...)`
+3. `extractor.ExtractAndWrite` → `osWriter.UpdateContent(ctx, messageID, ...)`
+4. `opensearchapi.UpdateReq{DocumentID: "1.234e+18"}` → OS 找不到该 `_id`
+5. 返 HTTP 404 → `errDocNotYet` → `stats.OSTransient++` → K8s Job 退出码 1
+6. 更坏情况：若两条不同的 snowflake 落入同一 float64 桶（低位截断相同），可能把一条的 content 写到另一条上（数据污染，很难排查）
+
+**建议修法**：
+
+方案 A（首选，最小改动，与 `internal/esindex/buildraw.go:180` `decodeObjectUseNumber` 风格对齐）：
+
+```go
+// 用 json.Decoder + UseNumber() 保精度
+dec := json.NewDecoder(bytes.NewReader(h.Source))
+dec.UseNumber()
+var src struct {
+    MessageID json.Number `json:"messageId"`
+    Payload   struct{...} `json:"payload"`
+}
+if err := dec.Decode(&src); err != nil { continue }
+msgID := src.MessageID.String()  // 全精度字符串，无科学计数法
+```
+
+方案 B（更保守）：改 `MessageID string` — OS 会自动把 long 序列化成带引号的字符串？No，OS 不会，long 类型 `_source` 返 JSON number。所以必须走方案 A。
+
+**新增回归测试**：
+
+```go
+func TestParseHits_SnowflakePrecision(t *testing.T) {
+    // 19 位真实 snowflake id
+    body := `{"messageId":1234567890123456789,"payload":{"file":{"url":"x"}}}`
+    hit := opensearchapi.SearchHit{Source: []byte(body)}
+    docs := (&osScrollSource{}).parseHits([]opensearchapi.SearchHit{hit})
+    if docs[0].MessageID != "1234567890123456789" {
+        t.Fatalf("precision loss: got %q", docs[0].MessageID)
+    }
+}
+```
+
+**严重性理由**：backfill Job 是本项目一次性 123K docs 存量回填的核心动作，主人已 sig-off 「backfill 走 K8s Job 一次性跑」路径。此 bug 使 Job **100% 无法完成 happy path**（每条 doc 都是 OS 404），Job 会被 dlqRatio 或 OSTransient 判为失败退出，测试环境 e2e 就会暴露，但也可能被误诊为「主 doc 未落」时序竞态，浪费排查时间。且该 pattern 与 repo 已有铁律冲突（同类 bug 早在 esindex 里被显式防御），是纯粹的忘记复用既有防御方案。修不修属于是否遵守项目工程铁律的问题。
+
+---
+
+## §2 应修问题（REQUEST CHANGES — 强烈建议 push 前处理，最低限度处理 M1/M2/M4/M7）
+
+### M1. `internal/fileextract/consumer.go:88-92` — `defer cancel()` 在 for 循环内堆积
+
+**问题**：
+
+```go
+for len(batch) < size {
+    fetchCtx := ctx
+    if len(batch) > 0 {
+        var cancel context.CancelFunc
+        fetchCtx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
+        defer cancel()  // <-- 每次循环都注册一个 defer，直到 fetchBatch 返回才统一 fire
+    }
+    m, err := p.source.Fetch(fetchCtx)
+    ...
+}
+```
+
+每循环一次 `defer cancel()` 入栈，凑一个 50 条 batch 就堆 49 个 pending cancel（+ 关联 timer / goroutine 资源），全部等 fetchBatch 返回才释放。相对：`internal/consumer/consumer.go:103-105` 是 idiomatic 写法：
+
+```go
+fctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+m, ferr := p.src.Fetch(fctx)
+cancel()  // 立即释放，不 defer
+```
+
+**建议修法**：删掉 `defer`，紧跟 `Fetch` 后 `cancel()` 显式释放（同 reference impl）：
+
+```go
+for len(batch) < size {
+    fetchCtx, cancel := deriveFetchCtx(ctx, len(batch))
+    m, err := p.source.Fetch(fetchCtx)
+    cancel()
+    if err != nil { ... }
+    batch = append(batch, m)
+}
+```
+
+**严重性理由**：稳态每分钟 12-60 批（Kafka poll 频率），每批堆 ~50 defer + timer，一小时数万个未释放 context/timer 资源慢慢积压。虽然 fetchBatch 返回时会全释放（不是不可恢复泄漏），但 Kafka client 内部若因 rebalance 之类拖长 fetchBatch 生命周期就出问题。且属于典型 go vet / golangci-lint `deferloop` 类可自动检出的 lint 违规，push 到 GitHub CI 大概率就红。
+
+---
+
+### M2. `internal/fileextract/tika.go:70` — Content-Disposition filename 未 sanitize（HTTP 头注入面）
+
+**问题**：
+
+```go
+req.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+```
+
+`filename` 来自 `filePayload.Name`，源头是 octo-server 上传时 user-supplied 的文件名，**未经任何 sanitize**。攻击面：
+- filename 含 `"` → 头被过早闭合，剩余字符可能被 Tika 视作后续 header 参数
+- filename 含 `\r\n` → CRLF 注入，可以插入任意额外 header 到 Tika 请求（typical HTTP header smuggling）
+- filename 含 unicode → 非 RFC-compliant，Tika 可能拒收或误解
+
+实际用户上传中文文件名（`预算表2026.pdf`）也常见，双引号 quote 已经不 robust。
+
+**建议修法**：
+
+```go
+// 只保留 ASCII 可打印字符 + 常见中文/日文；过滤 CR/LF/双引号
+sanitized := sanitizeFilename(filename)
+if sanitized != "" {
+    req.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, sanitized))
+}
+
+func sanitizeFilename(s string) string {
+    var b strings.Builder
+    for _, r := range s {
+        if r == '"' || r == '\r' || r == '\n' || r < 0x20 {
+            continue
+        }
+        b.WriteRune(r)
+    }
+    return b.String()
+}
+```
+
+或更严格：走 RFC 6266 `filename*=UTF-8''...` 编码格式（Tika 支持）。
+
+**回归测试**：filename = `"attack.pdf\r\nX-Injected: yes\r\n\r\n"` 应产出无 CRLF 的头值。
+
+**严重性理由**：即使源头 octo-server 应该 sanitize，file-extractor 是新引入的外部依赖（Tika Server）调用方，防御性 sanitize 是 code hygiene 硬要求。真实攻击可能性低（要 octo 上传接口先漏），但 CRLF 注入 → Tika 拒服务 → 该 doc extract_error DLQ 是相对高概率的 non-attack 场景（用户上传了不规范文件名）。
+
+---
+
+### M3. `internal/filebackfill/source.go:89-99, 118-123, 192` — JSON body 用 `fmt.Sprintf` 字符串拼接
+
+**问题**：三处 OS 请求 body 都是 raw string + `fmt.Sprintf` 拼字段，例如：
+
+```go
+body := `{
+    "size": ` + fmt.Sprintf("%d", s.size) + `,
+    ...
+}`
+```
+
+```go
+body := fmt.Sprintf(`{"scroll":"%s","scroll_id":"%s"}`, formatDuration(s.scrollTTL), s.scrollID)
+```
+
+问题：
+1. **风格与 repo 不一致**：整个 `esindex` 包用 `json.Marshal` 或结构化 builder，唯独此处退化到字符串拼接。
+2. **潜在注入面**：`s.scrollID` 来自 OS 返回，理论上是 base64 变体，但如果未来 OS 版本升级返回结构变化，或 `s.size` 被恶意 config 注入 `1, "malicious": true`，都会破坏 JSON。
+3. **难以扩展**：加 `_source_includes` 之类过滤需再拼字符串，容易漏 comma。
+
+**建议修法**：
+
+```go
+type scrollQuery struct {
+    Size    int             `json:"size"`
+    Query   json.RawMessage `json:"query"`
+    Source  []string        `json:"_source"`
+}
+body, _ := json.Marshal(scrollQuery{Size: s.size, Query: filterQuery, Source: []string{"messageId", "payload.file"}})
+```
+
+**严重性理由**：不是运行期 bug（当前 inputs 都是内部可信值），但是明确 code smell，push 前顺手清理性价比高。也是 §6 里陈旧文档更新的一部分。
+
+---
+
+### M4. `internal/filebackfill/runner.go:74-83` — ctx.Canceled 被当作 error 返回
+
+**问题**：
+
+```go
+for {
+    if err := ctx.Err(); err != nil {
+        return stats, nil  // ← 循环开头判 ctx 是 nil 返回
+    }
+    batch, err := r.source.Next(ctx)
+    if errors.Is(err, io.EOF) {
+        return stats, nil
+    }
+    if err != nil {
+        return stats, err  // ← 但 source.Next 的 ctx 取消错也走这里
+    }
+    ...
+}
+```
+
+`source.Next()` 内部调 `client.Search(ctx, ...)`，ctx 取消时返回 wrapped `context.Canceled` err（不是 nil）。此处直接 `return stats, err` 冒泡到 `main.go:103`：
+
+```go
+stats, err := runner.Run(ctx)
+if err != nil {
+    return fmt.Errorf("runner.Run: %w (stats: %+v)", err, stats)
+}
+```
+
+结果 K8s Job 收到 SIGTERM（滚动更新 / 手动 delete pod）后退 1 + 打错误日志，实际是「正常优雅退出」。误报会让运维困惑。
+
+**建议修法**：
+
+```go
+batch, err := r.source.Next(ctx)
+if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+    return stats, nil
+}
+if err != nil {
+    return stats, err
+}
+```
+
+**严重性理由**：影响 K8s Job 退出语义 + 运维排障成本；不影响正确性但影响 signal-noise ratio。
+
+---
+
+### M5. `internal/fileextract/download.go:139-146` — 手写复刻 `strings.Contains`
+
+**问题**：
+
+```go
+// contains 是 strings.Contains 的替身避免多导一个包（本文件仅两处 substring 判断）。
+func contains(s, sub string) bool {
+    for i := 0; i+len(sub) <= len(s); i++ {
+        if s[i:i+len(sub)] == sub {
+            return true
+        }
+    }
+    return false
+}
+```
+
+且 `tika.go:90` 也调这个 `contains`。理由（「避免多导一个包」）不成立：`strings` 是 stdlib 零 cost 依赖，本 repo 其它文件（`esindex/mapping_compat.go`, `consumer.go`）大量使用。手写实现还比 `strings.Contains`（走 Rabin-Karp 优化）慢。
+
+**建议修法**：删 `contains`，全部改 `strings.Contains`。改动 3 行：`download.go:135`, `tika.go:90`, 加 `import "strings"` 到 download.go。
+
+**严重性理由**：纯 code hygiene，独立 nit 但和 M3 组合起来读起来像作者要么在赶时间要么不熟 stdlib，任何 reviewer 会挑。
+
+---
+
+### M6. `internal/fileextract/tika.go:74` — ctx 取消判定只覆盖 DeadlineExceeded
+
+**问题**：
+
+```go
+resp, err := t.hc.Do(req)
+if err != nil {
+    if ctx.Err() == context.DeadlineExceeded {
+        return "", false, errExtractTimeout
+    }
+    return "", false, fmt.Errorf("%w: %v", errExtractGeneric, err)
+}
+```
+
+如果 caller ctx 是 `context.WithCancel` 且手动 cancel（用户 SIGINT），此处会走 errExtractGeneric 分支，caller 判 permanent 失败进 DLQ = extract_error，浪费一条重试机会 + DLQ 污染。
+
+**建议修法**：
+
+```go
+if err != nil {
+    if ctxErr := ctx.Err(); ctxErr != nil {
+        // ctx 取消/超时都视为 timeout，caller 决定是否重试/退出
+        return "", false, errExtractTimeout
+    }
+    return "", false, fmt.Errorf("%w: %v", errExtractGeneric, err)
+}
+```
+
+同样问题在 `download.go` 的重试循环里也存在（line 84-87 处理 `ctx.Done()` OK，但 `tryFetch` 里 `d.hc.Do(req)` 返错时不区分是 ctx 取消还是网络错，走 transient 分支会白白重试 3 次然后失败）。参考建议：`tryFetch` 出错后加 `if ctx.Err() != nil { return nil, "", ctx.Err() }` 快速返。
+
+**严重性理由**：影响优雅关停语义 + DLQ 干净度。
+
+---
+
+### M7. `internal/filebackfill/runner_test.go` — 核心 `Runner.Run` 零直接测试覆盖
+
+**问题**：`runner_test.go` 只测了 rateLimiter / Stats 字段类型 / Config 转换 / formatDuration / sourceDoc 字段。**`Runner.Run` 主循环没有一条直接测试**：
+- ❌ mock source 塞 3 batch (10/20/EOF)，mock extractor 分别返 success / DLQ reason / errDocNotYet，验证 Stats.Extracted=25 DLQ=3 OSTransient=2
+- ❌ ctx 中途 cancel，验证 Run 优雅返回 + Stats 部分数据
+- ❌ progress log 分支（time.Since > progress → 打日志）
+- ❌ defer Close 一定被调（`mockSource.closed` 状态验证）
+
+**建议**：至少加 3 条测试：
+```go
+func TestRun_HappyPath(t *testing.T) { /* 全 success */ }
+func TestRun_MixedOutcomes(t *testing.T) { /* success + DLQ + OSTransient 各若干 */ }
+func TestRun_CtxCancelDuringLoop(t *testing.T) { /* 中途 cancel */ }
+```
+
+用 `mockSource` + inject 一个 mock extractor（现在 extractor 类型是 `*fileextract.Extractor` 具体类型，不易 mock；建议在 filebackfill 里定义一个 `extractorIface interface { ExtractAndWrite(...) }`，Runner 依赖 interface 而非 struct）。
+
+**严重性理由**：backfill 是本项目一次性 K8s Job 的**唯一**执行路径，其状态机（success/DLQ/transient/ctx-cancel 分支）零测试覆盖 = 上线只能靠人工 e2e，且 S1 那个 bug 一条基本 Run 测试就能捕获（造一个 messageId=1234567890123456789 的假 hit 走一遍 processOne 即可）。缺少这些测试是导致 S1 上线才发现的直接原因。
+
+---
+
+### M8. `internal/fileextract/config.go:53-55` — DLQMaxRetries / DLQRetryBackoff / DLQSpillDir 声明但未消费
+
+**问题**：三个字段在 config 里声明，在 `cmd/file-extractor/main.go` 从 env 读入，但 `internal/fileextract/kafka.go` 的 `kafkaDLQSink.WriteDLQ` 就是一次 `writer.WriteMessages` 直接返，没有 retry、没有 spill 到 disk。config.go:52 注释还写：
+
+```
+// DLQ 自身 transient 重试参数（复用 consumer/dlq.go 语义）
+```
+
+—— 但实现完全没有。误导性文档 + 死配置。
+
+**建议修法**：二选一
+- **A（首选）**：删掉这三个 field + env 读取 + 注释；DLQ 就是一次写，写不了错就 return，让 caller 决定（consumer.go 已经有 `return err` 逻辑，会暂停批推进）。
+- **B**：真正实现 retry + spill，参考 `internal/consumer/dlq.go` 的 handler 结构。
+
+给规划来看，A 更合理（file-extractor 场景 DLQ 量远小于主 consumer，简化就够）。
+
+**严重性理由**：dead code + 文档欺骗，push 之前挑，避免运维被误导设置 spill dir 结果没落文件。
+
+---
+
+### M9. `internal/filebackfill/ratelimit.go` — 无锁 + 无线程安全 doc 警示
+
+**问题**：`rateLimiter` struct 有 mutable fields (`tokens`, `last`) 但 `Wait` 无 mutex，无 doc 明说「非线程安全」。当前 `runner.go` 单 goroutine 调用 OK，但下次谁 refactor 加个并发 worker 池就会 silent 破坏限速。
+
+**建议修法**：
+- **最小改动**：加 doc `// NOT safe for concurrent use; caller must serialize.`
+- **稳妥**：加 `sync.Mutex` 保护 `Wait`（对性能影响可忽略）
+
+**严重性理由**：defensive coding，future-proof。
+
+---
+
+## §3 nits（optional，push 后可跟进；建议顺手改 N1/N4/N5）
+
+### N1. 陈旧 IDX-3 stub 注释
+
+`internal/fileextract/config.go:9-16`, `consumer.go:1-4, 26, 37, 40, 105, 141-146` 都仍在讲「IDX-3 骨架期字段声明但未使用」「本 commit 只搭骨架 stub」「IDX-4 补齐」等阶段性叙事。5 commits 合并成 branch 后阶段性说明失去意义，读起来像作者忘了清理。
+
+**建议**：删所有 `IDX-3`/`IDX-4`/`IDX-5` 阶段词，把语义描述改成稳态视角。例：`consumer.go:1-3` 从「IDX-4 补 抽取」改成「type=8 消息走 download → Tika → OS partial update；非 type=8 跳过 commit 位点」。
+
+### N2. `internal/fileextract/backfill_bridge.go` — 拆参 bridge 冗余
+
+现在为了让 `filePayload` 保持 unexported，写了个 5 参 wrapper：
+
+```go
+func ExtractAndWriteForBackfill(ctx, e, messageID, url, name, ext string, size int64) (string, error, error)
+```
+
+如果 filePayload 就是纯数据 struct（当前是），直接 export 它成 `FilePayload` 会更清爽，backfill 直接构造：
+
+```go
+e.ExtractAndWrite(ctx, doc.MessageID, &fileextract.FilePayload{URL:..., Name:..., ...})
+```
+
+拆参没有隐藏什么，5 参跟 5 字段一模一样。且返回 signature `(string, error, error)` 两个 error 也不 idiomatic — dlqReason 更适合是 `Outcome` enum，cause 应该合并进 `err` 的 wrapping。
+
+**建议**：export `FilePayload`，删 `backfill_bridge.go`。或至少把 `(reason, cause, err)` 三元组改成 `Result` struct，语义更清楚。
+
+### N3. `internal/fileextract/config.go:45` vs `download.go:82` — backoff 注释矛盾
+
+- `config.go:45`: `HTTPRetries int // CDN GET 重试次数（默认 3，指数退避 1s/4s/16s）`
+- `download.go:82`: `wait := d.retryBackoff * time.Duration(1<<attempt) // 1s / 2s / 4s / 8s (base=1s, retries=3 → 1s/2s/4s)`
+
+实际是 `1s / 2s / 4s / 8s`（2^n），不是 `1s/4s/16s`（4^n）。config.go 注释错，删或改。
+
+### N4. `internal/filebackfill/source.go:203-208` — `formatDuration(500ms) → "0s"` 陷阱
+
+`formatDuration` 对 < 1s 返 `"0s"`。OS 视 `scroll=0s` 为立即过期 → scroll context 首批就没了。如果有人误设 `-scroll-ttl 500ms` 或 env `BACKFILL_SCROLL_TTL=500ms`，backfill 立刻死。
+
+**建议**：加 floor —
+```go
+func formatDuration(d time.Duration) string {
+    if d < time.Second { d = time.Second }
+    ...
+}
+```
+或在 `newOSScrollSource` 里加 validation：`if ttl < time.Second { return nil, fmt.Errorf("ScrollTTL must be >= 1s") }`。
+
+### N5. `cmd/file-extractor/main.go:96` — `strings.EqualFold` 判 bool
+
+```go
+enabled := strings.EqualFold(os.Getenv("FILE_EXTRACTOR_ENABLED"), "true") && ...
+```
+
+只识别 `"true"/"TRUE"/"True"`，不识别 `"1"/"yes"`。K8s manifest 常用 `enabled: "1"`。用 `strconv.ParseBool` 更 idiomatic + 覆盖广：
+
+```go
+b, _ := strconv.ParseBool(os.Getenv("FILE_EXTRACTOR_ENABLED"))
+enabled := b && ...
+```
+
+### N6. `internal/fileextract/consumer.go:141-146` stub 分支只测试用
+
+`extractor == nil → stub log` 分支在生产 `NewService` 里不可能触发（NewExtractor 失败会直接 return error）。只有 `TestProcessOne_TypeFileHitsStub` 走这里，测试的是「stub 兼容」而不是任何真实行为。
+
+**建议**：删该分支 + 该测试，让 consumer_test 走真 extractor（httptest CDN + Tika + OS 已经有基础设施在 idx4_test.go 里）。测的东西反而更真实。
+
+### N7. `internal/filebackfill/source.go:172` — `fmt.Sprintf("%v", src.MessageID)` 若为 `<nil>` 判定被 stringify 侵蚀
+
+即使修了 S1 用 `json.Number`，`json.Number` 也有 `""` 零值情况（field 缺失）。此处 line 173 判 `msgID == "<nil>"` 只对 `any` 类型有效，改 `json.Number` 后应改成 `if src.MessageID == "" { continue }`。修 S1 时一起调整。
+
+### N8. `internal/esindex/mapping/README.md:1` — 版本号叙事
+
+标题写 `v1.12 — file content indexing`，但 repo 里其它文件（如 `doc.go`）叙事还是 v1.9/1.10/1.11 演进，v1.12 一致性 OK。这条 nit 撤销，仅记录我检查了。
+
+---
+
+## §4 已识别的正向亮点（不超过 5 条）
+
+1. **`internal/esindex/mapping_compat.go` v1.12 断言集扩展设计干净**：`requiredMappingFieldPaths` 加两条 + 走既有 flatten/断言路径，`mapping_compat_test.go` 补 4 条测试（missing content / missing contentMeta / IncludesV112Fields / 全 mapping pass），fail-closed 语义与既有 payloadRaw / mergeForward 断言一致，这是本 PR 最干净的一部分。
+2. **`internal/fileextract/tika.go:101-113` `truncateContent` UTF-8 边界回退** + `TestTika_Utf8SafeTruncate` 直接测中文截断不产生半字符，这类细节做到位显示作者对 IK 分词下游影响有考虑。
+3. **`internal/fileextract/oswriter.go:9-11` errDocNotYet 分类文档 + errors.Is 分类清晰**：把 OS 404 / 409 / 5xx / 4xx 四类分成 3 个 sentinel error 让 caller 分级决策，比一个统一 error 好读。
+4. **`internal/filebackfill/config.go:12-15` scroll query 幂等设计**：`must_not exists content` 天然跳过已抽取 doc，中断重跑无副作用 —— 这个决策免掉了 checkpoint 复杂度，是明智的 trade-off（作者显式在 `Package filebackfill` doc 里陈述这个决策也是加分）。
+5. **`internal/fileextract/consumer.go:45-54` startupDelay 缓解时序竞态 + `errDocNotYet` 稳态兜底**：Phase 1 startup sleep + Phase 2 独立 retry topic 备选的分阶段设计，加上错误分类 → Kafka rebalance 自然重试，思路清楚，实现相对简单。
+
+---
+
+## §5 未验证但值得后续 e2e 关注的点
+
+1. **Tika 3.3.0.0 minimal 镜像实际行为**：`TestTika_EncryptedDocument500Body` 用 `"org.apache.tika.exception.EncryptedDocumentException"` 字符串锁死契约（v2 §7 #2 提及升级需 review），但实际 Tika minimal 镜像启动参数、default JVM heap、是否装 IK-friendly OCR pipeline 都需要 test 环境跑真实 PDF 才能确认。特别是加密 PDF 的错误路径，`EncryptedDocumentException` 是否总是出现在 body 里、是否有 wrap 层影响 substring 匹配，需在 test 环境用 3-5 个真实加密 PDF 样本 validate。
+2. **OS `_update` doc_as_upsert=false + retry_on_conflict=3 的行为**：单测覆盖 code path，但 partial update 遇到 mapping 上 dynamic:strict 时若 `contentMeta` 里出现意外字段（比如 truncated 为 true 被 omitempty 掉、extractedAt 是零值）的实际行为需 e2e 跑一遍。特别是 `TestFilePayload_ContentSerialization` 里 truncated=false 走 omitempty 不落盘，若真的 partial update 缺 truncated 字段，OS 索引里对应 doc 的 truncated 会保留旧值还是 unset 需实测。
+3. **file-extractor vs es-indexer 稳态竞态 rebalance 兜底**：作者主张 errDocNotYet 触发本批 Kafka 上抛让 rebalance 重取，但 kafka-go Reader 的 offset 提交语义（`CommitInterval=0` 手动）+ rebalance 时 uncommitted messages 是否真会重取，代码逻辑合理但缺一个双 pod 交替 rebalance 的 chaos 测试 validate。
+4. **backfill Job 大量 DLQ 时 dlqRatioMax=0.10 阈值合理性**：`cmd/file-content-backfill/main.go:65` 硬编码 10%，123K docs 里若 12K 走 DLQ 就 exit 1。若真实 corpus 里加密 PDF / 空白 doc / oversize 比例本来就高（feasibility.md 提「阶段 2 视 empty_extract 占比决定是否上 MinerU」），这个阈值可能一开始就误报。需 test 环境跑一批采样看真实占比再决定 threshold。
+5. **CDN 直连稳定性**：`download.go` 走公网 CDN + 指数退避重试，但没有 circuit breaker（例如 CDN 短暂全挂时 file-extractor 会 3s+6s+... 阻塞每条消息 → Kafka 滞后堆积）。稳态跑 24h 观察 CDN p99 延迟 + 失败率再决定是否加熔断。
+
+---
+
+## §6 review 方法论
+
+**顺序**（约 55 min）：
+
+1. (5 min) `git log --oneline`, `git diff --stat`, 确认改动范围与我先前脑中的实现路径吻合。
+2. (10 min) `internal/fileextract` 6 个非-test 文件全读：`service.go` → `consumer.go` → `extractor.go` → `download.go` → `tika.go` → `oswriter.go` → `dlq.go` → `payload.go` → `kafka.go` → `metrics.go` → `config.go` → `backfill_bridge.go`。按调用链自顶向下读。
+3. (10 min) `internal/filebackfill` 3 个非-test 文件 + `cmd/file-content-backfill/main.go`：`config.go` → `runner.go` → `source.go` → `ratelimit.go` → cmd 入口。
+4. (5 min) `internal/esindex/doc.go` diff (FilePayload 加字段) + `mapping/octo-message.json` diff + `mapping_compat.go` diff。
+5. (10 min) 测试文件覆盖度扫描：每个 pkg 的 `*_test.go` 都过一遍，标记「测了 A、B，没测 C、D」。发现 `runner_test.go` 零 Run 覆盖 = 红旗。
+6. (5 min) `go build ./...` + `go test -race ./internal/fileextract/... ./internal/filebackfill/...`，确认基础工具链干净（都过）。
+7. (5 min) 对比 reference impl（`internal/consumer/consumer.go` fetchBatch pattern）+ 查 opensearch-go v3.1.0 vendored src 确认 `RetryOnConflict`, `BuildRequest`, `Update` API 语义 + err 返回契约。
+8. (5 min) `docs/*.md` 三份文档快速扫，找与代码不对齐的地方（发现 config.go 里 IDX-3 stub 注释叙事全篇陈旧）。
+
+**跳过说明**：
+- 没深读 `docs/file-content-indexing-feasibility.md` v2 全文（460 行），主要看目录结构 + 与代码对齐的关键段（DLQ 8 种 reason 表格、`_source.excludes` 决策、payload.type=8 数值）。假定 v2 已在早期 review 通过。
+- 没跑 e2e 或 mock OS，`go test -race` 都过即视为基础健康。§5 明确列出 e2e 才能验证的点。
+- `docs/file-extractor-tool-comparison.md` 只扫标题，Tika 选型论证不在本 code review 范围（那是设计层决策，本轮只 review 实现）。
+
+**发现分布**：
+- §1 严重: 1 条（snowflake 精度）
+- §2 应修: 9 条（defer cancel 循环、CRLF 注入、JSON 拼接、ctx.Canceled 误报、手写 Contains、tika ctx 分类、Runner.Run 零覆盖、DLQ 字段死代码、ratelimit 无锁 doc）
+- §3 nits: 8 条
+
+**最出乎意料的发现**：§1 的 snowflake 精度 bug —— 这个陷阱在 `internal/esindex/buildraw.go` 里 line 22 有一整段 doc 显式讲「json.Decoder + UseNumber()，否则默认 float64 会截断 >2^53 的雪花 id」，还配了 `TestProject_SnowflakePrecision` 测试。作者写 backfill 时明显没参考 esindex 里已有的 `decodeObjectUseNumber` helper（line 180-194），也没运行一次带真实 snowflake 数字的 mock hit 走通 Runner.Run。这是一个「repo 已经把答案写在墙上，但复用没发生」的失误 —— 也直接对应 M7 里 Runner.Run 零测试覆盖的问题。修 S1 时把 M7 的 Runner.Run mock 测试一起补，等于两个问题一次解决。
+
+---
+
+## 交付给 Max
+
+- (a) review 文档路径：`~/Project/Mininglamp-OSS/octo-search-indexer/docs/file-content-indexing-code-review.md`
+- (b) 总判定：**BLOCK**
+- (c) §1 严重问题条数：**1**（snowflake messageId 精度丢失）
+- (d) 最出乎意料的发现：backfill parseHits 里 `MessageID any` + `fmt.Sprintf("%v", ...)` 让 19 位 snowflake id 变成科学计数法字符串，与 repo 已有的 `decodeObjectUseNumber` + `TestProject_SnowflakePrecision` 铁律直接冲突 —— 且 Runner.Run 零测试覆盖是这个 bug 逃逸的直接原因，修 S1 时应把 Runner.Run mock 测试（M7）一起补上，一箭双雕。
+
+---
+
+## §7 修复轮结论（2026-07-02 追加）
+
+主人拍板"应修尽修"（review §2 应修 = 全部必修，nit 至少改 6 条），cc-octo 在同一分支 `feat/file-content-indexing` 追加 3 个 commit 完成修复。
+
+### 追加 commit 列表
+
+```
+9a3231d refactor(filebackfill): json.Marshal + ratelimit thread-safety + scroll TTL floor (M3+M9+N4)
+b5ca29d fix(file-extractor): defer cancel loop + CRLF sanitize + ctx classification (M1+M2+M6+M8+nits)
+de5b64c fix(backfill): snowflake messageId precision + Runner.Run test coverage (S1+M7+N7)
+```
+
+### §1 严重 + §2 应修落地位置
+
+| 编号 | 落地文件:行 | 修法一句话 |
+|---|---|---|
+| **S1** | `internal/filebackfill/source.go:160-200` | `MessageID json.Number` + `json.Decoder.UseNumber()`，size 字段同法处理；参考 `esindex/buildraw.go:22` 铁律 |
+| **M1** | `internal/fileextract/consumer.go:81-107` | 删掉 for 循环内 `defer cancel()`，改为 `cancel()` 紧跟 Fetch 后立即释放，对齐 `internal/consumer/consumer.go:103-105` |
+| **M2** | `internal/fileextract/tika.go:60-77` + 新增 `sanitizeFilename` | 剔除 CR/LF/双引号/反斜杠/控制字符；新增 `TestTika_FilenameCRLFInjection` + `TestSanitizeFilename` 回归 |
+| **M3** | `internal/filebackfill/source.go:89-172` | 三处 `fmt.Sprintf` 拼 JSON 全改 `json.Marshal(map[...])`；去掉冗余 `req.Header.Set("Content-Type", ...)` |
+| **M4** | `internal/filebackfill/runner.go:74-107` + Commit 6 部分 | `errors.Is(err, context.Canceled/DeadlineExceeded)` 视为优雅退出返 `(stats, nil)`，不再让 SIGTERM 造 K8s Job exit 1 |
+| **M5** | `internal/fileextract/download.go` + `tika.go:100` | 删手写 `contains` funcion，改 `strings.Contains` |
+| **M6** | `internal/fileextract/tika.go:73-79` + `download.go:97-104,73-76` | tika 判 `ctx.Err() != nil` 全部走 `errExtractTimeout`；download `tryFetch` 出错先判 ctx 快速返；`Fetch` 循环也识别 ctx err 不再消耗 backoff |
+| **M7** | `internal/filebackfill/runner.go:23-42` + `runner_test.go` | 引入 `docExtractor` interface + `realExtractor` 适配器；补 `TestRun_HappyPath` / `TestRun_MixedOutcomes` / `TestRun_CtxCancelDuringLoop` / `TestRun_CtxDeadlineExceeded` / `TestRun_SourceRealError` + `TestParseHits_SnowflakePrecision` / `TestParseHits_MissingMessageIDSkipped` / `TestParseHits_MalformedJSONSkipped` |
+| **M8** | `internal/fileextract/config.go:52-55` + `cmd/file-extractor/main.go:92-94` | 删 `DLQMaxRetries` / `DLQRetryBackoff` / `DLQSpillDir` 三个未消费字段 + 对应 env 读取；避免误导运维 |
+| **M9** | `internal/filebackfill/ratelimit.go` | 加 `sync.Mutex` 保护 `tokens/last`；unlock 前不阻塞 select 保证 ctx 取消响应 |
+
+### 顺手改的 nits
+
+- **N1** 陈旧 IDX-3/4/5 stub 叙事全清（`config.go` doc / `consumer.go` doc / processOne 分支注释）
+- **N3** `config.go:45` backoff 注释从 `1s/4s/16s` 改成 `1s/2s/4s/8s`（与 download.go:82 对齐）
+- **N4** `formatDuration` < 1s floor 到 `"1s"` + `newOSScrollSource` 构造期同步 normalize；`TestFormatDuration` 用例改为 `500ms → "1s"`
+- **N5** `cmd/file-extractor/main.go:96` `strings.EqualFold(..., "true")` 改 `strconv.ParseBool`，兼容 `"1"/"yes"` 等 K8s manifest 常见写法
+- **N6** 删 `consumer.go` 里 `extractor == nil → stub log` 分支 + `TestProcessOne_TypeFileHitsStub` 对应测试；合并 `NewProcessor` / `NewProcessorWithExtractor` 为一个构造函数
+- **N7** S1 修复一并处理：`msgID` 判空条件从 `msgID == "" || msgID == "<nil>"` 简化为 `msgID == ""`（`json.Number` 零值就是 `""`）
+
+**未改的 nits**：
+- N2（`FilePayload` export 决策）—— 涉及 API 面外部化，主人指令明确「不改」
+- N8（`mapping/README.md` 版本一致性）—— 本身就是 「已检查通过」的正向记录，无需改
+
+### 修复过程中新发现的问题
+
+1. **`TestTika_FilenameCRLFInjection` 首轮误设 assertion**：初版把 `X-Injected` 关键字也列进 `mustNot`，实际 sanitize 只剔除结构性危险字符（CRLF/双引号/控制字符），字面「X-Injected」是普通字符，剔除 CRLF 之后就没有 header 注入面了。校正 assertion 为「只检查 CR/LF 被剔除」。这是设计边界澄清，不是新 bug —— 记录以便后续 reviewer 理解 sanitize 的语义边界。
+2. **`consumer_test.go` 的 test helper `mkFileMessage` 变孤儿**：N6 删了唯一使用者 `TestProcessOne_TypeFileHitsStub`，helper 也一起删。发现时 `go build` 没报错（test-only helper 不参与 build），是 `go test` 运行后 vet 才提示的 —— 顺手删掉。
+
+### 验收数字
+
+- `go vet ./...` ✅ 干净
+- `go build ./...` ✅ 全绿
+- `go test -race -timeout 120s ./...` ✅ 全 15 个包绿
+- 新增测试 8 条（S1 精度回归 + Runner.Run 5 条状态机 + parseHits 2 条 malformed 分支 + M2 CRLF injection + sanitizeFilename 单元）
+- 3 commit 主题清晰单一，每 commit body 明确 review 报告条目对应关系
+
+### 与本次 review 的关联
+
+修复轮把「repo 铁律墙上写着但复用没发生」这类问题一次性拉齐（S1 复用 `esindex/buildraw.go:180` decodeObjectUseNumber pattern、M1 复用 `consumer/consumer.go:103-105` fetchBatch pattern、M3 复用 esindex 里 `json.Marshal` request body pattern）。下次 file-extractor / filebackfill 类新增服务时，可把这 3 处作为参照对齐点。

--- a/docs/file-content-indexing-feasibility.md
+++ b/docs/file-content-indexing-feasibility.md
@@ -1,0 +1,460 @@
+# File Content Indexing — Feasibility Study
+
+> Author: cc-octo · Date: 2026-06-30 · **Version: v2**
+> Scope: 评估「让 octo 搜索能搜到 type=8 文件消息的文件正文内容」可行性、推荐方案、风险与未决问题。
+> 输入命题: 用户发了一个 PDF，搜「季度营收」 → 列出这个文件消息（+ 高亮命中片段）。
+> Companion: 抽取工具深入对比见 [`file-extractor-tool-comparison.md`](./file-extractor-tool-comparison.md)
+
+---
+
+## Changelog
+
+**v2 (2026-06-30, 集成 Max review + 主人拍板 + prod 实测数据)**：
+
+| # | 变更点 | 位置 |
+|---|---|---|
+| 1 | §4.1 双 hit 论证收语气 → "边缘 case 下双 hit" | §4.1 |
+| 2 | §5 补充 docling/MinerU 阶段 2 OCR 考量一句话 | §5 尾 |
+| 3 | MVP 三步 → 两步：mapping + indexer + file-extractor + Tika 一锅端上 test，然后 reader + prod + backfill | §13 |
+| 4 | §12.1 数据安全从"⚠️ 真风险"降为"不是 blocker，PRD 走个流程"；§12.2 未决问题 #3 撤回 | §12 |
+| 5 | 🆕 §16「文件获取链路」— 推荐 (d) 公网 CDN URL 直连（Max 实测通过） | §16 |
+| 6 | §6 DLQ reason 表细化 `EncryptedDocumentException` catch 路径 | §6 |
+| 7 | §11 资源估算全部替换为 prod 实测数据（type=8=123,628，OS 可用 726GB，增量 3-5GB） | §11 |
+| 8 | 🆕 §16.3 file-extractor 部署形态两方案并列（单 Pod 双容器 vs 独立 Deploy） | §16.3 |
+| 9 | §5 引用 tool-comparison 时新增"Go 原生 unidoc/unipdf AGPL 传染风险，硬阻断" | §5 |
+| 10 | §0 总判断：可行性结论保持，容量/风险描述按实测收敛 | §0 |
+
+**v1 (2026-06-30, 初版)**：三仓扫源 → 9 维度方案对比 + MVP 三步走 + 未决问题清单。
+
+---
+
+## 0. 总体可行性判断（一句话）
+
+**可行 — 推荐分两阶段交付**：阶段 1 直接扩 `payload.file.content` 字段 + 起独立 `file-extractor` 服务异步抽取后回写（覆盖 90% 业务场景，~2 周）。阶段 2 视扫描版 PDF 实际占比决定要不要引入 MinerU 兜底 OCR。
+
+**prod 实测容量绰绰有余**：type=8 = **123,628 条**（占 17M 总 docs 的 0.7%），OS 可用磁盘 726GB，content 字段增量 **3-5GB**，不到 1%。
+
+**不推荐** Max 提的方案 4-C（type=8 派生 virtual sub-doc）— 理由见 §4：边缘 case 双 doc 命中冲突 + 复杂度回流。
+
+---
+
+## 1. 推荐方案总图
+
+```
+┌──────────────┐  MySQL binlog/scan   ┌──────────────────────┐  octo.message.v1   ┌─────────────┐
+│   MySQL      │ ───────────────────► │ searchetl-producer   │ ─────────────────► │ Kafka topic │
+│ message_*    │                      │ (现存，不改)         │                    │             │
+└──────────────┘                      └──────────────────────┘                    └──────┬──────┘
+                                                                                          │
+                                            ┌─────────────────────────────────────────────┴───────┐
+                                            │                                                     │
+                                            ▼ (consumer group: octo-search-indexer)               ▼ (consumer group: file-extractor) [新增]
+                                  ┌──────────────────┐                                ┌────────────────────────┐
+                                  │  es-indexer      │                                │  file-extractor        │
+                                  │  (现存)          │                                │  (新独立 Deploy)       │
+                                  │ 写主 doc         │                                │ • 过滤 type=8          │
+                                  │ payload.file = { │                                │ • GET CDN url (公网)  │
+                                  │   url,name,      │                                │ • 调 Tika HTTP        │
+                                  │   caption,size,  │                                │ • OS partial-update   │
+                                  │   ext            │                                │   payload.file.content│
+                                  │ }                │                                │ • 失败 → DLQ          │
+                                  └────────┬─────────┘                                └────────────┬───────────┘
+                                           │                                                       │
+                                           ▼                                                       ▼
+                                  ┌────────────────────────────────────────────────────────────────┐
+                                  │  OpenSearch backing index ...-2026.06-000001                   │
+                                  │  payload.file.content (新 mapping field, IK 分词)              │
+                                  └────────────────────────────────────────────────────────────────┘
+                                                              ▲
+                                                              │  (reader 端搜 payload.file.name/caption/content)
+                                                              │
+                                  ┌────────────────────────────┴───────────────────────────────────┐
+                                  │  octo-server /v1/messages/_search_files                        │
+                                  │  + payload.file.content^0.5 加入 multi_match                   │
+                                  │  + highlight payload.file.content                              │
+                                  └────────────────────────────────────────────────────────────────┘
+```
+
+**核心选择四连**：
+
+| 维度 | 选择 |
+|---|---|
+| 抽取位置 | 独立 file-extractor Deploy（新增，见 §3） |
+| 存储位置 | 扩 `FilePayload.Content` 进**同 doc**（不另起索引、不派生子 doc，见 §7） |
+| 抽取工具 | Apache Tika sidecar（HTTP 模式，详见 [tool-comparison](./file-extractor-tool-comparison.md)） |
+| **文件获取** | **公网 CDN URL 直连**（Max 实测通过，详见 §16） |
+
+---
+
+## 2. 当前现状定锚（避免重复扫）
+
+### 2.1 文件链路 (octo-server)
+- 上传上限 `MaxFileSize = 100MB`（`modules/file/const.go:128`）
+- 白名单 60 种扩展名（图/文档/音/视/压缩/其他），见 `allowedExtensions`
+- magic-number 校验，过滤伪装可执行文件
+- 存储后端：腾讯云 COS，CDN 域名 `cdn.deepminer.com.cn`（Max 实测 prod URL 形态 `https://cdn.deepminer.com.cn/im-test-xming/chat/...`）
+
+### 2.2 Kafka 契约 (octo-lib `searchmsg.Message`)
+- `RawPayload` 整包送入；indexer 端 `buildraw.go` 按 `payload.type` 分流投影
+- type=8 当前投影 `{url, name, caption, size, extension}`，**无 content 字段**
+
+### 2.3 OS Mapping (`internal/esindex/mapping/octo-message.json`)
+- `payload.file` 已有 `name`（IK）+ `caption`（IK）+ `url`(keyword) + `size`(long) + `extension`(keyword)
+- `dynamic: "strict"` — 新增字段必须改 mapping
+- 已有 v1.10/v1.11 virtual sub-doc 机制 (`parentMessageId/parentPayloadType/virtual/subSeq`)，本期只派生 richText→image (type=14→type=2)
+
+### 2.4 Reader (octo-server `modules/messages_search/search_files.go`)
+- `_search_files` filter `payload.type=8` + multi_match `payload.file.name^2 + payload.file.caption`
+- ⚠️ search_files **未** apply `applyExcludeVirtual` — 这是后面方案 C 的关键反对理由
+- `_search_all` keyword 路径 whitelist = `[1,8,11,14]`，已含 file (`search_all.go:142`)
+- reader join MySQL 过滤撤回（`applyChannelAndRevoked`）— 撤回联动天然 handled
+
+### 2.5 prod 实测容量数据（Max 拉自跳板）
+- type=8 文件消息 count = **123,628**（占 17M 总 docs 的 **0.7%**）
+- OS 集群：3 nodes × 267GB = **801GB 总容量**，已用 ~85GB，**可用 726GB**
+- 当前 indices 总大小 ~12.4GB
+
+---
+
+## 3. 抽取位置（9 维度逐一）
+
+| 选项 | 推荐? | trade-off |
+|---|---|---|
+| **A. producer 同步抽** | ❌ | producer 现在 5s tick 拉 MySQL 极轻量 (~30min 追平 3.4M)，加抽取拖慢主链路 + 镜像变重 + 文件 URL 抽取依赖外部 CDN 可达性 |
+| **B. 独立 file-extractor Deploy** | ✅ **推荐** | 解耦 — 失败/退避不影响 es-indexer；可独立扩容；可独立金丝雀；和 es-indexer 共享 image 模式继续可用（同镜像两 Deploy + `EXTRACTOR_ENABLED=true` 切角色，复用 producer/indexer 现有套路） |
+| C. es-indexer 内抽 | ❌ | 抽取 RT 长（PDF 10MB 抽取秒级），会拉低 indexer 吞吐 → Kafka lag |
+| D. octo-server 上传同步抽 | ❌ | 阻塞用户上传 UX；上传成功 != 抽取成功，无重试机制 |
+
+**B 方案细节**：
+- 复用 `octo-lib/contract/searchmsg` 消息契约，消费 `octo.message.v1{,.prod}` topic
+- consumer group 独立 `file-extractor`（不抢 es-indexer 的位点）
+- 命中 `payload.type != 8` 直接 commit 跳过
+- 命中 type=8 → HTTP GET `payload.file.url`（公网 CDN，详见 §16）→ 调 Tika → 走 OS partial update API 仅写 `payload.file.content`（不动主 doc 其他字段）
+- DLQ 独立 topic `octo.message.v1.file-extract.dlq{,.prod}`
+
+---
+
+## 4. 为什么不选方案 4-C（虚拟子文档）
+
+主人在派单里说「方案 C 最自然，请你重点评估可行性」— 评估完结论：**技术上可行，但反而比 4-A 复杂、收益更低**。
+
+### 4.1 边缘 case 双 hit 冲突
+4-C 方案下主 doc 的 content 字段本就是空的（内容只在 virtual sub-doc），日常搜索命中只会返回 sub-doc；**但当关键词同时出现在 name/caption 里 + content 里时**，主 doc + virtual sub-doc 都命中，返回结果里同一物理文件出现 2 条 hit（父 + 子，messageId 相同）。频率不高但**必然存在**（文件名往往含内容关键词，如"2026Q2财报_季度营收.pdf"）。
+
+修复需要 reader 在 `_search_files` 加 dedupe by messageId 或改 `applyExcludeVirtual` 逻辑 + 把搜索 fields 同时配在父和子上 — 转一圈**复杂度回到了 4-A**。
+
+### 4.2 v1.11 设计文档明示 sub-doc 语义
+`internal/esindex/mapping/README.md` v1.11 子文档目的：「让富文本里内嵌的 image 能被 reader `_search_media` 搜到」。**核心是「父 doc 的 payload.type 跟子 doc 不一样」**（父 type=14, 子 type=2）。type=8 文件本身已经是独立消息、独立 doc、独立 type=8，**没有"派生不同 type"的语义**，硬塞 sub-doc 机制是为模式而用模式。
+
+### 4.3 撤回联动
+v1.10 路线甲设计「reader 用 parentMessageId 回 MySQL join 判可见性/撤回」是为「子 doc 没有独立 MySQL 行」准备的。文件消息**本身有 MySQL 行**，撤回信号现成走主 doc 路径，sub-doc 模式徒增 join 复杂度。
+
+### 4.4 结论
+方案 4-A（扩 `payload.file.content`）：mapping 改 1 行 + indexer FilePayload 加 1 字段 + reader multi_match 加 1 field + highlight 加 1 行。完。
+
+---
+
+## 5. 抽取工具
+
+**详细五方案对比 + 决策矩阵见 [file-extractor-tool-comparison.md](./file-extractor-tool-comparison.md)**。此处只列本文档需要的结论：
+
+| 候选 | 结论 | 一句话 |
+|---|---|---|
+| **Apache Tika Server (HTTP sidecar)** | ✅ **阶段 1 主引擎** | 覆盖 19 种白名单格式 + 无 GPU 无 Python 依赖 + JVM 成本可控 |
+| MinerU | 阶段 2 兜底候选 | 中文扫描版王者，但 GPU 硬依赖 + 输出结构过度投入 |
+| Docling | 备选 | Chinese "not yet enterprise-validated"（IBM 官方原话） |
+| unstructured.io | 不用 | 商用 API 云依赖 + 已有 Kafka pipeline 不需要再套 ETL |
+| Go 原生组合 | ❌ **硬阻断** | `unidoc/unipdf` AGPL 传染风险与公司 OSS 政策冲突；纯 Go PDF 库中文支持不成熟 |
+| LibreOffice headless | 不用 | subprocess 冷启动 2-5s，稳定性坑多 |
+
+**Tika 使用形态**：`apache/tika:3.3.0.0` minimal 镜像（~500MB，Max 待实拉验证），`--server` 模式监听 9998，`PUT /tika` header `Accept: text/plain`。
+
+**OCR 决策**：
+- 阶段 1 **不做** OCR（minimal 镜像不预装 Tesseract）
+- 扫描版 PDF 抽出空串 → DLQ reason=`empty_extract`
+- 阶段 2 分支决策：`empty_extract` 占比 < 10% 不做 OCR；10-30% 切 Tika full 镜像开 Tesseract；> 30% 且业务确认多为中文扫描版 → 引入 MinerU 作为兜底 pipeline（Tika 抽空 → 转发 MinerU 补抽）。**docling 不作为 OCR 候选**（中文实验性 + 输出结构复杂度不匹配需求）
+
+---
+
+## 6. 大文件 / 抽取约束策略
+
+| 策略点 | 建议值 | 理由 |
+|---|---|---|
+| 单文件抽取 size cutoff | **≤ 20MB** | 100MB 上限的 20%；20MB PDF 已属罕见超大；超过直接跳过 (DLQ reason=`oversize`) |
+| 抽取超时 | **30s** | Tika 默认 120s 过长；30s 覆盖 95%+ 文档；超时跳过 + DLQ |
+| 抽取出文本截断 | **≤ 256KB** UTF-8 | IK 分词器对超长文本效率断崖；超过截断 + 标记 `truncated=true`（前 256KB 已够搜索命中） |
+| 抽取失败重试 | **3 次指数退避**（1s/4s/16s） | 文件 URL 临时 5xx 常见 |
+| 重试耗尽 | 进 DLQ | 不影响主链路 commit |
+| 黑名单扩展名（不抽取） | `.mp4 .mov .avi .mkv .webm .flv .wmv .m4v .mp3 .wav .aac .flac .ogg .wma .m4a .amr .zip .rar .7z .tar .gz .bz2 .xz .dmg .pkg .deb .rpm .appimage .jpg .jpeg .png .gif .bmp .webp .ico` | 二进制媒体/压缩包/图片，抽取无意义；白名单 60 种里约 26 种纯文本可抽 |
+
+**抽取目标扩展名**（白名单）：`.pdf .doc .docx .xls .xlsx .ppt .pptx .txt .csv .rtf .odt .ods .md .html .htm .json .xml .yaml .yml`（19 种，覆盖业务搜索需求）
+
+### 6.1 DLQ reason 完整清单（含 Tika 异常映射）
+
+| reason | 触发条件 | 是否重试 | 备注 |
+|---|---|---|---|
+| `oversize` | 文件 > 20MB | ❌ | 上传时已过 100MB 门；此处二次筛 |
+| `blacklist_ext` | 扩展名在黑名单 | ❌ | 二进制/媒体，不抽 |
+| `download_failed` | HTTP GET CDN 5xx 或连接超时 | ✅ 3 次 | 3 次仍失败入 DLQ |
+| `extract_timeout` | Tika 抽取 > 30s | ❌ | 超时不重试（重试仍会超） |
+| `encrypted` | Tika 抛 `org.apache.tika.exception.EncryptedDocumentException` | ❌ | Java 侧异常 → HTTP 500 body 含类名 → Go 侧 catch reason 字符串 |
+| `empty_extract` | Tika 返回空串或空白 | ❌ | 通常是扫描版 PDF / 加密后的破损文件 |
+| `parse_error` | Tika 其他 parse 异常（`TikaException` etc.） | ✅ 1 次 | 有时 Tika 内部 GC 抖动导致伪失败 |
+| `truncated` | 抽取成功但内容 > 256KB | N/A | 不进 DLQ，写 `contentMeta.truncated=true` |
+
+---
+
+## 7. ES 存储设计
+
+| 方案 | trade-off |
+|---|---|
+| **A. 扩 `FilePayload.Content` 进主 doc** ✅ **推荐** | mapping 改动小；reader 只改 fields list；但 _source 膨胀（用 `_source.excludes: ["payload.file.content"]` 缓解，content 仍可被搜被 highlight） |
+| B. 独立 index `octo-file-content-{env}` | mapping 干净 + 可独立 retention；但 reader 要 multi-index 搜索 + 父子 doc dedupe，复杂 |
+| C. 富文本 virtual sub-doc | **不推荐** — §4 已论证 |
+
+**推荐 mapping 增量**（最小改动）：
+
+```json
+"payload": {
+  "properties": {
+    "file": {
+      "properties": {
+        "url":       { "type": "keyword", "ignore_above": 1024 },
+        "name":      { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+        "caption":   { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+        "size":      { "type": "long" },
+        "extension": { "type": "keyword", "ignore_above": 32 },
+        "content":   { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },   // ← 新增
+        "contentMeta": {                                                                                // ← 新增（可选）
+          "type": "object",
+          "properties": {
+            "extractedAt": { "type": "date", "format": "epoch_second" },
+            "extractor":   { "type": "keyword", "ignore_above": 32 },
+            "truncated":   { "type": "boolean" },
+            "extractMs":   { "type": "long" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**_source 控制**：
+- 加 `"_source": { "excludes": ["payload.file.content"] }` 到 mapping settings
+- 搜索时 highlight 仍能拿到片段（highlight 走倒排不走 _source）
+- reader 端用 `requireFieldMatch=true` + `payload.file.content` field 高亮
+
+---
+
+## 8. 搜索端 API 改动 (octo-server)
+
+### 8.1 `_search_files` (主战场)
+```go
+// modules/messages_search/search_files.go::buildSearchFilesDSL
+clause, err := buildKeywordClauseGated(ctx, analyzer, stopwordStripEnabled, req.Keyword,
+    "payload.file.name^2",      // 文件名最高权重（短，命中度高）
+    "payload.file.caption",     // caption 次之
+    "payload.file.content^0.5", // ← 新增 content，权重 < name/caption（内容长易噪声）
+)
+b.Must(clause)
+```
+- highlight: 在 `_search_files` 加 highlight 配置（当前没有；之前 search_messages 才有），新增 field `payload.file.content` + `FragmentSize(120)` + `NumOfFragments(1)`
+
+### 8.2 `_search_all` (大全搜)
+```go
+// modules/messages_search/search_all.go:171-172
+"payload.file.name^2",
+"payload.file.caption",
+"payload.file.content^0.5",  // ← 新增
+```
+- pickSnippet field 优先级表 (`dsl.go:202`) 在 `payload.file.name` 后追加 `payload.file.content`
+
+### 8.3 `_search` (text 类) 不动
+- 当前 type whitelist `[1,11,14]` 不含 file，content 不参与 text 搜
+- 不变更口径，避免文本搜结果被文件内容污染
+
+---
+
+## 9. 历史回灌
+
+| 问题 | 答案 |
+|---|---|
+| prod 现有 type=8 数量 | **123,628 条**（Max 实测，占 17M 总 docs 的 0.7%） |
+| 历史是否回灌？ | **建议回灌**（否则历史文件全文搜不到，体验断层） |
+| 怎么做 | 起 one-off Job `cmd/file-content-backfill`（仿 `cmd/backfill` 模式），从 OS 反查 type=8 docs → 触发 file-extractor 抽取 → partial update |
+| 切流策略 | (1) test 环境验证 file-extractor + Tika；(2) prod 部署 + 接增量；(3) 等增量稳定 24h；(4) 跑历史 backfill Job（限速 50 RPS 避免压垮 Tika 或 CDN）；(5) 抽完核对 OS count(content) ≈ count(type=8 in whitelist) |
+| 回灌耗时估算 | 123K 文件 × 50 RPS ≈ **40 分钟**（假设 Tika 抽取 avg 200ms/file）— 半小时到 1 小时窗口即可完成 |
+
+---
+
+## 10. 撤回 / 删除联动
+
+**结论：不用单独处理**。
+
+- file 消息撤回路径：MySQL `message_*` 行 `revoked=1` → reader join MySQL 时 `applyChannelAndRevoked` 直接过滤
+- 选方案 7-A（扩主 doc）后，`payload.file.content` 跟父 doc 同生同死，OS doc 不删，reader 端过滤
+- 与现有撤回机制零差异
+
+---
+
+## 11. 资源 / 成本预估（prod 实测口径 v2）
+
+| 项 | 实测/预估 | 备注 |
+|---|---|---|
+| **prod type=8 count** | **123,628** | 占 17M 总 docs 的 **0.7%**（远低于 v1 估算的 525K） |
+| **OS 集群总容量** | 3 nodes × 267GB = **801GB** | |
+| **OS 已用磁盘** | ~85GB | 当前 indices 12.4GB |
+| **OS 可用磁盘** | **726GB** | 90% 空闲 |
+| **content 字段增量估算** | **3-5GB** | 123K × 30KB 平均 ≈ 3.7GB；含倒排 + 不入 _source |
+| **容量占比** | **< 1%** | 相对可用 726GB 忽略不计 |
+| file-extractor Deploy | 1 副本，0.5 CPU / 512MB 起步 | prod 看 lag 扩到 3 副本 |
+| Tika sidecar | 1 副本，1 CPU / 1.5GB | JVM 吃内存 |
+| Kafka 容量 | 0 | 复用现有 topic |
+| 抽取吞吐 | 单 Tika 实例 ~5-10 docs/s（PDF 主导） | 3 副本足够 100 docs/s 峰值 |
+| 上线阶段 1 工时 | ~2 周 | mapping + indexer 改字段 + file-extractor 服务 + 部署 + e2e 测试 |
+
+**结论**：容量层零风险；机器资源需求最小（file-extractor 1 副本 + Tika sidecar 1 副本 起步）。
+
+---
+
+## 12. 风险与未决问题清单
+
+### 12.1 风险（标 → 缓解）
+
+| 风险 | 缓解 |
+|---|---|
+| 加密 PDF / 带密码文档 | Tika 抛 `EncryptedDocumentException` → HTTP 500 body 含类名 → Go 侧 catch reason 字符串 → DLQ reason=`encrypted`；前端搜不到但不影响功能（见 §6.1） |
+| 二进制畸形文件 | Tika 兜底返空串 → DLQ reason=`empty_extract` |
+| 中文分词覆盖 | 复用现有 IK 配置，零风险（payload.text.content 已验证） |
+| 数据安全边界 | ✅ **不是 blocker，PRD 走个流程即可**。搜索鉴权已是 channel 维度（`checkChannelAccess`），文件在会话里所有成员都能下载阅读，"搜 content" = "搜可见内容"，**不是新增权限边界**。上线前 PRD 走个 review 走个流程即可 |
+| 抽取服务故障导致 lag | file-extractor 跟 es-indexer 独立 consumer group，互不影响；监控 file-extractor lag > 1000 告警 |
+| Tika OOM | Tika sidecar 加 memory limit 1.5GB + JVM `-Xmx1g`；2.x+ 走 pipes-async，`--spawnChild` 默认开，OOM 只 kill child 不带崩 server |
+| OS 容量超 | ✅ **风险几乎为零**（v2 实测：726GB 可用，content 增量 3-5GB） |
+| 撤回时间窗 | 文件撤回但 content 已索引到 OS — reader join MySQL 过滤掉，不显示，但 OS 内部仍有数据。如有合规要求"撤回即物理删除"需另议（不在本期范围） |
+| CDN 公网访问失败 | HTTP GET 失败 → 3 次退避重试 → DLQ reason=`download_failed`；备胎方案 (a) 内部 COS SDK 直连保留说明"如公网访问出问题时切"（详见 §16） |
+| CDN 出口带宽成本 | 走公网 CDN 而非内网直连 COS，出口费未测；123K 文件 × avg 5MB ≈ **600GB** 一次性回灌流量，日常增量文件流量小；建议阶段 1 上线后观察 CDN 账单 |
+
+### 12.2 未决问题（要主人 / Max 拍板）
+
+1. ✅ **prod 现有 type=8 数量** — 已解，Max 实测 = 123,628
+2. **是否需要 OCR**（扫描版 PDF/图片型 PDF 抽出为空的占比未知）— 阶段 1 先不做，阶段 2 看实际占比。**需要业务侧 Max 抽 100 个真实业务 PDF 肉眼判"文本原生 vs 扫描"占比**，决定阶段 2 是否上 Tesseract 或 MinerU
+3. ~~数据安全审查~~ ✅ **已撤回**（v2 §12.1 已论证）
+4. **历史是否回灌** — 默认建议回灌；否决方需说明业务可接受度
+5. ✅ **OS 集群当前 disk 余量** — 已解，Max 实测 726GB 可用
+6. 🆕 **file-extractor 部署形态**（单 Pod 双容器 vs 独立 Deploy + Service）— 见 §16.3 两方案并列，MVP 先按单 Pod 起，可后续拆分
+
+---
+
+## 13. 最小 MVP 路线 (两步走 v2)
+
+按交付顺序：
+
+### MVP-1 (week 1-1.5): 一锅端上 test
+一次性做完：
+- 改 `internal/esindex/mapping/octo-message.json` 加 `payload.file.content` + `contentMeta`
+- 改 `internal/esindex/doc.go::FilePayload` 加 `Content string` + `ContentMeta`
+- 改 `internal/esindex/mapping_compat.go::requiredMappingFieldPaths` 加新字段
+- 起 `cmd/file-extractor` 单文件 main，消费 Kafka 同 topic、独立 consumer group `file-extractor`
+- 加 Tika sidecar 到 file-extractor Deploy（`apache/tika:3.3.0.0` minimal）
+- 实现：consume → filter type=8 → HTTP GET `payload.file.url`（CDN 直连） → 调 Tika → OS partial update `payload.file.content`
+- DLQ 实现（§6.1 完整 reason 表）
+- **验证**：test 环境 e2e — 发一个 PDF → 1 分钟内 OS doc.payload.file.content 有内容 → 手工 `_msearch` 用 content 关键词命中该 doc
+- **金丝雀**：只在 test 跑 1 周观察 DLQ 比例 < 5%
+
+### MVP-2 (week 2): reader 改 + 上 prod + 历史 backfill
+- 改 `search_files.go` + `search_all.go` 加 content field 权重 + highlight
+- 跑 octo-server CI 全套（dsl_test / search_files_test）
+- prod 切流顺序：
+  1. reader 先 ready（允许 content field 不存在，向后兼容）
+  2. file-extractor 上线 prod，接增量
+  3. 稳定 24h 后跑历史 backfill Job（限速 50 RPS）
+  4. 抽完核对 OS `count(payload.file.content exists) / count(type=8 in whitelist) > 90%`
+- **验证**：prod 选 10 个已知 PDF 文件，调 `_search_files` 用 PDF 内容关键词搜，能命中
+
+---
+
+## 14. Out of scope（本期不做）
+
+- ❌ 图片 OCR (image OCR 是另一条线，需 GPU + 模型)
+- ❌ 音视频转录 (Whisper 类，更大工程)
+- ❌ 文件智能问答（文件向量化 + RAG）
+- ❌ 跨文件去重 / 文件相似度
+- ❌ 文件内容审核 / 合规扫描
+- ❌ 富文本(type=14) 内嵌文件抽取（octo-lib `ValidateRichTextBlocks` 当前还不放行 file block，先等契约打开再说，参见 `richtext_derive.go:13`）
+
+---
+
+## 15. 给 Max 的回执清单
+
+- (a) **文档路径**：`~/Project/Mininglamp-OSS/octo-search-indexer/docs/file-content-indexing-feasibility.md`
+- (b) **可行性总判断**：可行，推荐 §1 总图四连（B 独立 extractor + A 扩主 doc + Tika sidecar + CDN URL 直连），不选 4-C virtual sub-doc
+- (c) **v2 剩余未决问题（要主人拍板）**：
+  1. **扫描版 PDF 占比** — 需 Max 抽 100 个真实业务 PDF 肉眼判断，决定阶段 2 是否上 OCR / MinerU
+  2. **是否回灌历史 123K 文件** — 默认建议回灌，回灌窗口 ~40 分钟
+  3. **file-extractor 部署形态** — 单 Pod 双容器 vs 独立 Deploy，MVP 先按单 Pod 起，可后续拆分（§16.3）
+
+---
+
+## 16. 文件获取链路（🆕 v2 新增）
+
+file-extractor 拿到 Kafka 消息里的 `payload.file.url` 后，怎么把文件字节读出来给 Tika？四种方案：
+
+### 16.1 方案对比
+
+| 方案 | 描述 | 推荐? |
+|---|---|---|
+| (a) 内部 COS/S3 SDK 直连 | file-extractor 复用 octo-server 的 `cfg.FileService` 配置，直接初始化同一个 storage backend client，绕过 HTTP 层 | 备胎 |
+| (b) 特权 service token | 给 file-extractor 一个 service token bypass octo-server auth | ❌ 反 pattern |
+| (c) 新增 internal-only endpoint | 在 octo-server 加 `/internal/file/raw/*path` 不走用户 auth | 备胎 |
+| **(d) 公网 CDN URL 直连** | HTTP GET `payload.file.url`（腾讯云 COS CDN 直挂域名），无 auth 无签名 | ✅ **推荐** |
+
+### 16.2 方案 (d) 推荐理由
+
+**Max prod 实测事实**（2026-06-30）：
+- `payload.file.url` 形态：`https://cdn.deepminer.com.cn/im-test-xming/chat/...`（腾讯云 COS CDN 直挂域名）
+- 公网可达，无 auth 无签名
+- 三种真实格式 curl 测试：
+
+| 格式 | 大小 | Content-Type | 状态 |
+|---|---|---|---|
+| PDF | 128KB | `application/pdf` | ✅ 200，magic `%PDF-1.7` 校验通过 |
+| DOCX | 16KB | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | ✅ 200 |
+| PPTX | 5MB | `application/vnd.openxmlformats-officedocument.presentationml.presentation` | ✅ 200 |
+
+**方案 (d) 优点**：
+- **零耦合**：不绑 COS SDK / 不改 octo-server / 不需要 auth 逻辑
+- **依赖最少**：file-extractor 只依赖 Kafka + Tika + OS
+- **未来兼容**：将来存储后端换掉（S3 / MinIO / 自建），只要 URL 还能 HTTP GET 就零改动
+- **实现最简**：`http.Get(url)` 一行
+
+**方案 (d) 潜在风险**（不阻塞 MVP，标为观察项）：
+- 走公网 CDN 而非内网直连 COS，出口带宽成本（回灌 123K × avg 5MB ≈ 600GB 一次性流量，账单待观察）
+- CDN miss 回源速度未测（正常业务上传后热数据应命中 CDN 缓存）
+- 如 CDN 或域名遇故障 → file-extractor 全线抽取失败 → DLQ 暴增（同 octo-web 用户下载失败情形，风险共担）
+
+**降级路径**：若 CDN 访问出现系统性问题，切换到方案 (a) 内部 COS SDK 直连；改动限于 file-extractor 内部 download client 实现，接口不变。
+
+### 16.3 file-extractor 部署形态（方案分歧，两方案并列）
+
+MVP 阶段先按 **方案 α** 起，观察 1-2 周后再决定是否拆到 β。
+
+| 方案 | 描述 | 优点 | 缺点 |
+|---|---|---|---|
+| **α. 单 Pod 双容器 (sidecar)** ✅ **MVP 用** | file-extractor 主容器 + Tika 副容器同 Pod，共享 emptyDir 临时盘 | 部署单元少（1 个 Deploy）；延迟低（localhost HTTP）；配置简单；符合 kubernetes sidecar pattern | Tika 和 extractor 生命周期绑定，rolling update 时 Tika 也重启浪费；扩缩策略无法独立（Tika 内存重、extractor IO 重） |
+| β. Tika 独立 Deploy + Service | file-extractor Deploy 通过 K8s Service 调 Tika Deploy | Tika 可独立扩缩 / 独立 rolling；将来 chatbot 文件问答 / 审核可复用同一个 Tika 服务；解耦干净 | 多一个 Deploy 要维护；网络多一跳（K8s ClusterIP）；MVP 阶段无第二个消费方，收益兑现不了 |
+
+**决策**：MVP 用 α（单 Pod）先跑；观察运维摩擦（是否 rolling update 频繁重启 Tika 造成实际浪费？是否出现第二个 Tika 消费方？）后再决定是否拆到 β。**拆分改动小**（只是把 sidecar 容器搬到独立 Deploy + 改 file-extractor 的 Tika endpoint 从 `localhost:9998` 到 `tika-service:9998`），不是不可逆决策，MVP 不阻塞。
+
+---
+
+## 附录 A: v1 → v2 diff 摘要
+
+- **总判断保留**：可行，两阶段交付；不选 4-C
+- **实测数据替换**：type=8 count 525K→**123,628**；OS 容量增量 15-25GB→**3-5GB**；OS 可用 **726GB**（新披露）
+- **文件获取链路澄清**：v1 §12.2 遗漏项（Max review 指出），v2 §16 补齐并推荐 CDN 直连（Max 实测通过）
+- **数据安全降级**：v1 列为"⚠️ 真风险"，v2 §12.1 降为"不是 blocker"（Max 判断 channel 鉴权已覆盖）
+- **MVP 三步→两步**：v1 MVP-1 只改 mapping 无数据价值低，合并到 MVP-2
+- **DLQ reason 表完善**：v2 §6.1 8 种 reason 完整清单，含 EncryptedDocumentException catch 路径
+- **抽取工具决策抽离**：v1 §5 表格短，v2 引用 [tool-comparison](./file-extractor-tool-comparison.md) 深入版；补 Go 原生 AGPL 硬阻断
+- **部署形态两方案并列**：v2 §16.3 新增；MVP 用单 Pod，可后续拆分

--- a/docs/file-content-indexing-fix-plan.md
+++ b/docs/file-content-indexing-fix-plan.md
@@ -1,0 +1,796 @@
+# file-content-indexing 综合修复方案 + 具体 diff 计划
+
+> **文档定位**：本文档是 PR #46（`feat/file-content-indexing`）在收到 4 位 reviewer CHANGES_REQUESTED 后的**修复设计文档**，覆盖 3 blocker + 10 P2 + CI Lint 修复 + commit 组织 + 部署顺序。**先出方案 Max review → 主人可选看 → 才开工改代码**。
+>
+> **上下文**：
+> - PR: https://github.com/Mininglamp-OSS/octo-search-indexer/pull/46
+> - Head SHA: `9f2ffa8`
+> - 主人 2026-07-02 拍板：Blocker #2 走**方案 A（in-place bounded retry）**；Blocker #3 走**方案 A（es-indexer 改 script update 保留 content）**
+> - reviewer 原文：`/tmp/pr46-review/review-{0..6}-*.md` + `comment-0-yujiawei.md`
+> - 4 份姊妹文档（本文档不改动）：`file-content-indexing-feasibility.md` / `-implementation.md` / `-code-review.md` / `file-extractor-tool-comparison.md`
+
+---
+
+## §1 摘要（一览表）
+
+| 编号 | 类型 | 问题 | 状态 | 处置方向 |
+|---|---|---|---|---|
+| **Blocker #1** | SSRF | download URL 无 scheme/host/private-IP 校验 | Max 判断 | host allowlist + SSRF-restricted transport（config 可扩） |
+| **Blocker #2** | 数据丢失 | Kafka `FetchMessage` 已 advance offset，err 上抛不 commit → 后续消息 commit 越过 → 永久丢 | **主人拍板方案 A** | in-place bounded retry（照抄 `internal/consumer` state-machine pattern），N 次未成功 → DLQ `reason=retry_exhausted` |
+| **Blocker #3** | 数据丢失 | es-indexer `_bulk index` full-replace，redeliver 时会覆盖 file-extractor 写的 content | **主人拍板方案 A** | es-indexer 改 `scripted_upsert` + painless 保留 `payload.file.content` + `contentMeta` |
+| **P2-1** | 分类 | OS 429 归 permanent | Max 判断 | 合入 Commit 12（Blocker #2）：`classifyOSErr` 加 `429 → errOSTransient` |
+| **P2-2** | 分类 | `errOSPermanent` 无 DLQ 路径 | Max 判断 | 合入 Commit 12：extractor 加 `errors.Is(uerr, errOSPermanent) → ReasonExtractError` |
+| **P2-3** | 语义 | backfill `DeadlineExceeded` 与 signal 混同为 success | Max 判断 | Runner.Run 判 `ctx.Err()` 类型：DeadlineExceeded → 非零退出 |
+| **P2-4** | 内存 | Tika `io.ReadAll` 无 LimitReader | Max 判断 | 合入 Commit 14：加 `io.LimitReader(resp.Body, maxContentBytes+4)` |
+| **P2-5** | 语义 | `Truncated bool` + `omitempty` 无法清除 stale `true` | Max 判断 | 改 `*bool`（doc.go + 所有引用点） |
+| **P2-6** | 健壮性 | `isPermanentDownloadErr` 字符串匹配 | Max 判断 | 改 sentinel error + `errors.Is` |
+| **P2-7** | 语义 | `empty_extract` 只判 `== ""`，whitespace-only 漏 | Max 判断 | 改 `strings.TrimSpace(content) == ""` |
+| **P2-8** | 健壮性 | backfill scroll 无 transient retry | Max 判断 | `source.Next()` 外套 bounded backoff retry |
+| **P2-9** | 分类 | Tika `http.Client.Timeout` 与 ctx 混淆 | Max 判断 | 用 `context.WithTimeout` 驱动 + `errors.Is(err, context.DeadlineExceeded)` |
+| **P2-10** | 部署 | file-extractor 无 startup mapping-compat 检查 | Max 判断 | 复用 `esindex.AssertLiveMappingCompatible` |
+| **CI Lint** | 门禁 | 16 issues（15 errcheck + 1 staticcheck） | Max 判断 | 合入 Commit 14 顺手修 |
+
+**新发现问题**：见 §8（1 条：`retry_on_conflict` 语义在 script update 下的行为需实证）。
+
+**总工时预估**：**5-7 h**（含新 test + 本地 e2e，不含 push 后 CI 迭代）
+- Blocker #3（script update）：2-3 h（最复杂，改 core writer + 完整回归 test）
+- Blocker #2（retry state machine）：1.5-2 h（架构对齐 `internal/consumer`，可复用思路）
+- Blocker #1（SSRF）：0.5-1 h（加 config + 校验层）
+- 10 条 P2 + CI Lint：1-1.5 h（都是小改动）
+- 本地 e2e 复测（test 环境 tika-service:9998）：0.5 h
+
+---
+
+## §2 Blocker 修复方案
+
+### §2.1 Blocker #1 — SSRF 防护（Max 判断）
+
+#### 问题重述
+
+`internal/fileextract/payload.go:48-49` 从 Kafka 消息 raw 读 `payload.file.url`，`internal/fileextract/download.go:102` `tryFetch` 用**裸 `http.Client`** 发 GET，全程无 scheme / host / private-IP 校验。
+
+Reviewer 引用：
+- `review-0-CHANGES_REQUESTED-OctoBoooot.md:11-15`（Major SSRF）
+- `review-6-CHANGES_REQUESTED-Jerry-Xin.md:7-11`（byte-verified at `9f2ffa81c911`）
+- `comment-0-yujiawei.md:23`（P2 defense-in-depth）
+
+失败输入：`type=8` 消息的 `payload.file.url = http://169.254.169.254/latest/meta-data/…` → in-cluster GET 触达 cloud metadata；或 `http://internal-service:port/…` → 内网端口扫描 / API 打点。
+
+#### 修法（方案：host allowlist + SSRF-restricted dialer）
+
+**双闸门设计**（layered defense）：
+
+1. **URL 前置校验**（`download.go::Fetch` 入口，无 net I/O 前完成）：
+   - scheme 必须 `https`（如需兼容 `http` 可 config 化，默认只 https）
+   - host 必须在 allowlist 内（默认 `["cdn.deepminer.com.cn"]`，env `ALLOWED_DOWNLOAD_HOSTS` 可扩，逗号分隔）
+   - port 校验：如 host 带 port，须与 allowlist 中登记的一致（缺 port 默认 443）
+
+2. **Dial 时校验**（`http.Transport.DialContext` hook，防 DNS rebinding）：
+   - 解析后的 IP 拒绝 private / link-local / loopback / metadata（`169.254.169.254`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `::1`, `fc00::/7`, `fe80::/10`, `100.64.0.0/10`, `0.0.0.0/8`, `::` unspecified）
+   - Redirect 时**重新触发**闸门 1 + 闸门 2（`http.Client.CheckRedirect`）
+
+#### diff 计划
+
+**新文件 `internal/fileextract/ssrf.go`**（~150 行）：
+
+```go
+package fileextract
+
+// ssrf.go — URL 前置校验 + SSRF-restricted transport。
+// 双闸门：(1) URL 语法/host allowlist 前置判 (2) dial 时 IP 判 private/metadata。
+
+var (
+    errSSRFScheme    = errors.New("fileextract: url scheme not allowed")
+    errSSRFHost      = errors.New("fileextract: url host not in allowlist")
+    errSSRFPrivateIP = errors.New("fileextract: resolved IP is private/link-local/metadata")
+)
+
+// validateURL 前置校验 URL（scheme + host allowlist）。无 net I/O。
+func validateURL(rawURL string, allowedHosts []string, allowedSchemes []string) error {
+    u, err := url.Parse(rawURL)
+    if err != nil { return fmt.Errorf("%w: parse: %v", errSSRFScheme, err) }
+    // 校验 scheme ∈ allowedSchemes（默认 ["https"]）
+    // 校验 u.Host ∈ allowedHosts（含 port 归一化）
+}
+
+// newSSRFRestrictedDialer 返回 dial 时拒 private/metadata IP 的 DialContext。
+func newSSRFRestrictedDialer(base *net.Dialer) func(ctx context.Context, network, addr string) (net.Conn, error) {
+    return func(ctx context.Context, network, addr string) (net.Conn, error) {
+        host, _, _ := net.SplitHostPort(addr)
+        ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+        if err != nil { return nil, err }
+        for _, ip := range ips {
+            if isBlockedIP(ip.IP) { return nil, fmt.Errorf("%w: %s", errSSRFPrivateIP, ip.IP) }
+        }
+        return base.DialContext(ctx, network, addr)
+    }
+}
+
+// isBlockedIP 判 IP 是否在 SSRF 黑名单（private / link-local / loopback / metadata / unspecified）。
+func isBlockedIP(ip net.IP) bool {
+    // 覆盖 IsPrivate / IsLoopback / IsLinkLocalUnicast / IsLinkLocalMulticast / IsUnspecified
+    // 加 169.254.169.254 (cloud metadata) 显式判 + 100.64.0.0/10 (CGNAT) + fc00::/7 (ULA)
+}
+```
+
+**改 `internal/fileextract/config.go`**：加 `AllowedDownloadHosts []string` + `AllowedDownloadSchemes []string`，env 读 `ALLOWED_DOWNLOAD_HOSTS`（默认 `["cdn.deepminer.com.cn"]`）+ `ALLOWED_DOWNLOAD_SCHEMES`（默认 `["https"]`）。
+
+**改 `internal/fileextract/download.go`**（`newDownloadClient` + `Fetch`）：
+- `newDownloadClient` 构造 `http.Transport{DialContext: newSSRFRestrictedDialer(...)}` 注入 http.Client；`CheckRedirect` 加校验 hook
+- `Fetch` 入口先调 `validateURL()`，失败 → `errDownloadFailed`（走现有 DLQ reason=download_failed 路径，不新增 reason）
+- 校验失败**不重试**（scheme/host 不变，重试无意义）
+
+#### 影响面
+
+- 单文件新增 + 3 文件小改（download.go / config.go / config_test.go）
+- **无跨模块变更**（只在 fileextract 包内）
+- 无 mapping / API / 契约变更
+- 环境变量新增：`ALLOWED_DOWNLOAD_HOSTS` / `ALLOWED_DOWNLOAD_SCHEMES`（cm 加），未来切内网 COS 直接改 cm 即可，代码不动
+
+#### 回归测试计划
+
+新增 `internal/fileextract/ssrf_test.go`（~200 行）：
+
+| Test | 场景 | 断言 |
+|---|---|---|
+| `TestValidateURL_HTTPSAllowedHost` | `https://cdn.deepminer.com.cn/x.pdf` | pass |
+| `TestValidateURL_HTTPRejectedByScheme` | `http://cdn.deepminer.com.cn/x.pdf` | `errSSRFScheme` |
+| `TestValidateURL_UnknownHostRejected` | `https://evil.example.com/x.pdf` | `errSSRFHost` |
+| `TestValidateURL_MetadataHostRejected` | `https://169.254.169.254/latest/…` | `errSSRFHost`（host allowlist 层就拦下） |
+| `TestValidateURL_MalformedURL` | `://bad-url` | `errSSRFScheme` (parse err) |
+| `TestSSRFDialer_PrivateIP` | mock DNS → 10.0.0.1 | `errSSRFPrivateIP` |
+| `TestSSRFDialer_MetadataIP` | mock DNS → 169.254.169.254 | `errSSRFPrivateIP` |
+| `TestSSRFDialer_PublicIP` | mock DNS → 1.1.1.1 | pass |
+| `TestFetch_RedirectToPrivate` | 200 → 302 → `http://10.0.0.1/x` | 拒 redirect（`errDownloadFailed`） |
+| `TestFetch_AllowlistViaEnv` | env `ALLOWED_DOWNLOAD_HOSTS=a.com,b.com` | 两个 host 都放行 |
+
+#### 部署顺序 / 已知坑
+
+- 无部署顺序约束（纯 fileextract 内变更，es-indexer / mapping 不动）
+- **坑**：`net.Dialer.DialContext` 在解析 host → IP 后如 IP 从 A 变 B（DNS rebinding），必须**在真正 dial 前**重解析 + 判 IP。示例已用 `net.DefaultResolver.LookupIPAddr(ctx, host)` 显式解析后传 base.DialContext 目标 IP（而不是让 Transport 内部再解析一次），避免 TOCTOU。
+- **坑**：Redirect 时 `CheckRedirect` 只能拿到 `req.URL`，须**手动重跑** `validateURL()`，Transport 层 dialer 只兜底 IP。
+
+#### 权衡
+
+- **不用 net.IP.IsPrivate**：Go 1.17+ `IsPrivate` 只覆盖 RFC 1918 `10./172.16-31./192.168.`，不含 CGNAT `100.64/10` / metadata `169.254.169.254` / IPv6 ULA `fc00::/7`。自定义 `isBlockedIP` 更严格。
+- **不新增 DLQ reason**：`download_failed` 语义已足够覆盖 SSRF 拦截（"下载被拒"）。future 如需精细分类可加 `reason=blocked_by_ssrf`，本次不做。
+
+---
+
+### §2.2 Blocker #2 — Consumer 数据丢失（主人拍板方案 A）
+
+#### 问题重述
+
+`internal/fileextract/consumer.go:65-67`（`Run`）+ `consumer.go:105-115`（`processBatch`）+ `consumer.go:124-151`（`processOne`）：
+
+Reviewer 引用：
+- `review-4-CHANGES_REQUESTED-yujiawei.md:27-41`（P0 详解）
+- `review-6-CHANGES_REQUESTED-Jerry-Xin.md:13-17`
+- `review-2-CHANGES_REQUESTED-mochashanyao.md:34-61`（P1，含 429 misclassification）
+- `comment-0-yujiawei.md:7-9`（**机制校正**：kafka-go `FetchMessage` 在 fetch 时执行 `r.offset = m.message.Offset + 1`，err 上抛并非 infinite loop 而是 **silent skip**）
+
+**当前行为**：
+1. `processOne` 返 `errDocNotYet` / `errOSTransient` → `processBatch` `return err` 不 commit 本条
+2. `Run` 只 `log` `processBatch error` 后 continue → `fetchBatch` → 下一 `FetchMessage` 返**下一 offset**（reader 已本地 advance）
+3. 下一条成功 → `source.Commit()` 提交更高 offset → **失败的那条 offset 被永久越过**
+4. 一旦 group 高水位越过，重启也救不回
+
+**根因**：`file-extractor` 的 `Run` + `processBatch` 只做「fetch → process → commit」单向流，没有 retry state machine 概念。而 `internal/consumer/consumer.go` 早已有成熟的 in-place retry 模式（`resolvePass` + `dispositions` state machine + `for attempt` loop）。
+
+#### 修法（方案 A：in-place bounded retry，照抄 `internal/consumer` 模式）
+
+**核心思路**：
+- 引入 `itemDisposition` 三态枚举 `{transient, ok, dlqResolved}`
+- `processBatch` 变成 `for attempt := 0; ; attempt++` 循环，只对仍 transient 的条目重跑
+- 重试次数上限 N（默认 10）→ 达上限后**强制 DLQ** `reason=retry_exhausted`，然后 commit（避免 partition 永久阻塞）
+- commit 只推进"连续成功前缀"（同 `internal/consumer::commitPrefixes`）
+
+**关键差异 vs `internal/consumer`**：
+- `internal/consumer` 的 retry 无上限（依赖 4xx→DLQ 自然收敛）；file-extractor 涉及 `errDocNotYet`（主 doc 永久缺）+ OS 5xx 长期挂等场景，**必须有上限**避免 partition 阻塞
+- `internal/consumer` 是 batch bulk（`writer.Bulk`）；file-extractor 是**单条**（每条独立下载 + Tika + OS update），retry loop 粒度是**单条**，state machine 简化
+
+#### diff 计划
+
+**改 `internal/fileextract/consumer.go`**（主体重写 processBatch + processOne 分离）：
+
+```go
+// itemDisposition 三态：transient（未终态）/ ok / dlqResolved。
+type itemDisposition int
+
+const (
+    dispTransient itemDisposition = iota
+    dispOK
+    dispDLQResolved
+)
+
+// Config 加字段：
+type ServiceConfig struct {
+    // ... 原有字段
+    // MaxRetriesPerMessage 单条消息最大 in-place 重试次数（默认 10）。
+    // 超过 → 强制 DLQ reason=retry_exhausted + commit offset（避免 partition 阻塞）。
+    MaxRetriesPerMessage int
+    // TransientBackoffBase 指数退避基（默认 1s）。1s / 2s / 4s / 8s / 16s / 32s / 60s(cap) …
+    TransientBackoffBase time.Duration
+    // TransientBackoffMax 单次退避上限（默认 60s，避免退避到不可接受的延迟）。
+    TransientBackoffMax time.Duration
+}
+
+// processBatch 改成 in-place retry state machine。
+func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) error {
+    n := len(batch)
+    dispositions := make([]itemDisposition, n)
+    attempts := make([]int, n) // 每条独立 attempt 计数
+
+    for {
+        if err := ctx.Err(); err != nil { return err }
+
+        changed := false
+        for i, m := range batch {
+            if dispositions[i] != dispTransient { continue }
+
+            // 退避（attempts[i]>0 才 sleep）
+            if attempts[i] > 0 {
+                if err := sleepCtx(ctx, expBackoff(p.cfg.TransientBackoffBase, p.cfg.TransientBackoffMax, attempts[i])); err != nil {
+                    return err
+                }
+            }
+
+            // 达重试上限 → 强制 DLQ retry_exhausted + 落 disposition
+            if attempts[i] >= p.cfg.MaxRetriesPerMessage {
+                if err := p.writeDLQ(ctx, m, ReasonRetryExhausted, "", nil,
+                    fmt.Errorf("in-place retry exhausted after %d attempts", attempts[i])); err != nil {
+                    return err // DLQ 硬停 → 让 Run loop 退出（K8s 重启保 offset 未推进）
+                }
+                p.metrics.IncRetryExhausted()
+                dispositions[i] = dispDLQResolved
+                changed = true
+                continue
+            }
+
+            // 走原 processOne 单条处理（拆出下面）
+            outcome, err := p.attemptOne(ctx, m)
+            attempts[i]++
+            switch outcome {
+            case outcomeOK:
+                dispositions[i] = dispOK
+                changed = true
+            case outcomeDLQ:
+                // processOne 内部已投 DLQ
+                dispositions[i] = dispDLQResolved
+                changed = true
+            case outcomeTransient:
+                // 保持 transient，下轮重试
+            case outcomeFatal:
+                // DLQ 写失败等 → 硬停
+                return err
+            }
+        }
+
+        // 有条目终态 → 推进"连续成功前缀"commit
+        if changed {
+            if err := p.commitPrefix(ctx, batch, dispositions); err != nil {
+                return err
+            }
+        }
+
+        // 全终态 → 本批完
+        if !hasTransient(dispositions) { return nil }
+    }
+}
+
+// attemptOne 单次尝试，返回三态结果。
+type attemptOutcome int
+const (
+    outcomeOK attemptOutcome = iota
+    outcomeDLQ           // 已投 DLQ（永久失败）
+    outcomeTransient     // 需重试
+    outcomeFatal         // DLQ 写失败等，硬停
+)
+
+func (p *Processor) attemptOne(ctx context.Context, m fetchedMessage) (attemptOutcome, error) {
+    var msg searchmsg.Message
+    if err := json.Unmarshal(m.Value, &msg); err != nil {
+        if werr := p.writeDLQ(ctx, m, ReasonParseError, "", nil, err); werr != nil {
+            return outcomeFatal, werr
+        }
+        return outcomeDLQ, nil
+    }
+    fp, isFile := extractContentTypeFile(msg.RawPayload)
+    if !isFile {
+        p.metrics.IncSkippedNonFile()
+        return outcomeOK, nil
+    }
+    p.metrics.IncProcessed()
+    dlqReason, cause, err := p.extractor.ExtractAndWrite(ctx, msg.MessageID, fp)
+    if err != nil {
+        // errDocNotYet / errOSTransient → transient
+        // errOSPermanent → 走 DLQ（P2-2 修复）
+        if errors.Is(err, errOSPermanent) {
+            if werr := p.writeDLQ(ctx, m, ReasonOSPermanent, msg.MessageID, fp, err); werr != nil {
+                return outcomeFatal, werr
+            }
+            return outcomeDLQ, nil
+        }
+        return outcomeTransient, nil
+    }
+    if dlqReason != "" {
+        if werr := p.writeDLQ(ctx, m, dlqReason, msg.MessageID, fp, cause); werr != nil {
+            return outcomeFatal, werr
+        }
+        return outcomeDLQ, nil
+    }
+    return outcomeOK, nil
+}
+
+// commitPrefix 提交"从头连续终态"的最后一条 offset。
+// 与 internal/consumer 差异：file-extractor 单分区消费（GroupID + 单 topic），无跨分区聚合。
+func (p *Processor) commitPrefix(ctx context.Context, batch []fetchedMessage, dispositions []itemDisposition) error {
+    lastIdx := -1
+    for i := range batch {
+        if dispositions[i] == dispTransient { break }
+        lastIdx = i
+    }
+    if lastIdx < 0 { return nil }
+    return p.source.Commit(ctx, batch[lastIdx])
+}
+
+// hasTransient 判是否还有未终态条目。
+func hasTransient(d []itemDisposition) bool {
+    for _, x := range d {
+        if x == dispTransient { return true }
+    }
+    return false
+}
+```
+
+**改 `internal/fileextract/oswriter.go`**（P2-1：429 分类）：
+
+```go
+// classifyOSErr：加 429 → errOSTransient（与 download.go 一致）
+case status == http.StatusTooManyRequests: // 429
+    return errOSTransient
+case status == http.StatusNotFound:
+    return errDocNotYet
+// ... 原有分支
+```
+
+**改 `internal/fileextract/dlq.go`**（新增 DLQ reason 常量）：
+
+```go
+const (
+    // ... 原有 8 个 reason
+    ReasonRetryExhausted = "retry_exhausted"  // in-place retry N 次未成功
+    ReasonOSPermanent    = "os_permanent"     // OS 写永久失败（非 404/409/429/5xx）
+)
+```
+
+**改 `internal/fileextract/metrics.go`**（加 `IncRetryExhausted` counter）。
+
+**改 `docs/file-content-indexing-implementation.md`**（如需同步 retry 上限 + 新 DLQ reason 到已 sig-off 任务书 v2 — 这一步待 Max 判是否要动 v2 doc，本文档只列 diff 计划）。
+
+#### 影响面
+
+- `internal/fileextract/consumer.go` 主体重写（~180 行 → ~250 行）
+- `oswriter.go` + `dlq.go` + `metrics.go` 小改
+- **无跨模块变更**（file-extractor 独立 Deploy）
+- **不影响 es-indexer 主流程**
+- 新增 env: `MAX_RETRIES_PER_MESSAGE`（默认 10）+ `TRANSIENT_BACKOFF_BASE` / `TRANSIENT_BACKOFF_MAX`
+
+#### 回归测试计划
+
+新增/改 `internal/fileextract/consumer_test.go`（~300 行新 test）：
+
+| Test | 场景 | 断言 |
+|---|---|---|
+| `TestProcessOne_TransientRetryThenSuccess` | 前 2 次 mock 返 errDocNotYet，第 3 次成功 | offset 只 commit 一次且是成功那次 attempts=3 |
+| `TestProcessOne_RetryExhausted` | 10 次全 errDocNotYet | 第 11 次不再调 attemptOne，DLQ reason=retry_exhausted，offset commit |
+| `TestProcessOne_429IsTransient` | OS 返 429 → 第 2 次成功 | 走 retry 不是 DLQ；offset 只 commit 成功那次 |
+| `TestProcessOne_OSPermanentToDLQ` | OS 返 400（非 404/409/429）| 立即 DLQ reason=os_permanent，不 retry |
+| `TestProcessOne_ParseErrorToDLQ` | 消息 JSON 非法 | 立即 DLQ reason=parse_error，不 retry |
+| `TestProcessBatch_OffsetPrefixCommit` | offset 100/101/102 中 101 fails first attempt | 102 不 commit 直到 101 达终态（对齐 Jerry-Xin `review-6:17` 建议） |
+| `TestProcessBatch_HeadStuckDoesNotCommitTail` | offset 100 forever transient（未达上限）、101/102 立即 OK | commit 停在 100 之前（不提交），直到 100 终态 |
+| `TestProcessBatch_HeadDLQResolvedAdvancesTail` | 100 达上限 → DLQ retry_exhausted，101/102 OK | commit 推进到 102（100 也算终态） |
+| `TestProcessBatch_MixedDLQAndOK` | 100 OK, 101 parse_error→DLQ, 102 OK | commit 推进到 102 |
+| `TestExpBackoff_MonotoneAndCap` | 单元测试退避函数 | 递增且 cap=Max，SIGTERM 立即返 |
+| `TestProcessBatch_CtxCancelDuringBackoff` | Sleep 时 ctx cancel | 立即返 nil，无 goroutine 泄漏 |
+
+#### 部署顺序 / 已知坑
+
+- 无部署顺序约束（file-extractor 独立 Deploy，单方向兼容）
+- **坑**：`internal/consumer::processBatch` 有多分区 `commitPrefixes`，file-extractor 是**单 topic 单 GroupID**，理论也是多分区，但 kafka-go `FetchMessage` 返的顺序与 partition 无关。**必须按 partition group 分别推进前缀**，否则跨分区的 head-of-line blocking 会互相干扰。**当前 diff 假设简化为单一 commit prefix**（现有 file-extractor 无跨分区聚合），若未来发现跨分区问题需照抄 `internal/consumer::partitionCommitPoints`。**这是 §8 新发现问题 #1**。
+- **坑**：`MaxRetriesPerMessage=10` + `TransientBackoffMax=60s` → 单条最坏阻塞 ~10 min。生产要根据实际 OS SLA 调（业务 SLO 允许延迟范围内）。
+- **坑**：retry_exhausted DLQ 后 offset 推进，**回灌需要人肉从 DLQ topic 拉回**（现有 SOP 已支持，见父群 group.md「DLQ 排查 / 回灌」）。
+
+#### 权衡
+
+- **不实现 Phase 2 retry-topic**（feasibility 曾提）：本 PR 范围内加 in-place retry + 硬上限已足够守住数据不丢；retry-topic 是未来独立 PR
+- **不动 `internal/consumer`**：本 PR 只改 file-extractor（`internal/fileextract`），主 es-indexer 消费路径不动（Blocker #3 只碰 esindex writer，不碰 consumer）
+
+---
+
+### §2.3 Blocker #3 — Dual-writer overwrite（主人拍板方案 A）
+
+#### 问题重述
+
+`internal/esindex/writer.go:130-135`（`bulkActionLine{index}`）+ `internal/esindex/buildraw.go` `payloadTypeFile` 分支：
+
+Reviewer 引用：
+- `review-4-CHANGES_REQUESTED-yujiawei.md:43-52`（P1 详解 + `_source.excludes` ≠ 保留倒排语义）
+- `review-5-COMMENTED-OctoBoooot.md:7-15`（补充 verify + at-least-once 侧写）
+- `review-6-CHANGES_REQUESTED-Jerry-Xin.md:21`（non-blocking 交叉验证）
+
+**当前行为**：
+- **es-indexer** 用 `_bulk index`（`writer.go:130-135`）—— full-document 替换，同 `_id` 覆盖
+- **file-extractor** 用 `_update`（`oswriter.go:67`）+ `doc_as_upsert=false` —— 只 merge `payload.file.content` + `contentMeta`
+- **race**：es-indexer 写 doc → file-extractor 补 content → es-indexer 重放（rebalance / restart / retry）**再次写 doc** → `index` full-replace → **content 被抹掉**
+
+关键：`_source.excludes` 只影响 `_source` 存储字段可见性，**不阻止** `index` action 全量替换 doc 内容。倒排索引也随 doc 覆盖失效。
+
+#### 修法（方案 A：es-indexer 改 `_bulk update` + scripted_upsert，保留 file-extractor 写的字段）
+
+**核心思路**：
+- 把 `_bulk index` action 改成 `_bulk update` + `scripted_upsert`
+- Painless script 逻辑：
+  - **首次写入（doc 不存在，走 upsert）**：`ctx.op == 'create'`，用 `params.doc` 覆盖 `ctx._source`（无 preserve 需求）
+  - **重复写入（doc 已存在，走 script）**：先保存 `ctx._source.payload.file.content` + `contentMeta` → 用 `params.doc` 全量替换 → 恢复保留字段
+
+#### diff 计划
+
+**改 `internal/esindex/writer.go`**（`bulkActionLine` + `writeBulkDoc` + `encodedSingleDocSize`）：
+
+```go
+// bulkActionLine 从 index 改成 update：
+type bulkUpdateAction struct {
+    Update struct {
+        ID              string `json:"_id"`
+        RetryOnConflict int    `json:"retry_on_conflict"`
+    } `json:"update"`
+}
+
+// preservePainless 保留 file-extractor 写的 payload.file.content + contentMeta。
+// scripted_upsert=true：doc 不存在时也走 script，ctx.op 会是 'create'。
+const preservePainless = `
+if (ctx.op == 'create') {
+  ctx._source = params.doc;
+} else {
+  def savedContent = null;
+  def savedMeta = null;
+  if (ctx._source.containsKey('payload') && ctx._source.payload instanceof Map) {
+    def f = ctx._source.payload.get('file');
+    if (f instanceof Map) {
+      savedContent = f.get('content');
+      savedMeta = f.get('contentMeta');
+    }
+  }
+  ctx._source = params.doc;
+  if (savedContent != null || savedMeta != null) {
+    if (!ctx._source.containsKey('payload') || !(ctx._source.payload instanceof Map)) {
+      ctx._source.payload = new HashMap();
+    }
+    if (!ctx._source.payload.containsKey('file') || !(ctx._source.payload.file instanceof Map)) {
+      ctx._source.payload.file = new HashMap();
+    }
+    if (savedContent != null) { ctx._source.payload.file.content = savedContent; }
+    if (savedMeta != null) { ctx._source.payload.file.contentMeta = savedMeta; }
+  }
+}
+`
+
+// bulkUpdateBody：一条 doc 的 update+scripted_upsert body。
+type bulkUpdateBody struct {
+    Script          scriptBlock `json:"script"`
+    Upsert          Doc         `json:"upsert"`
+    ScriptedUpsert  bool        `json:"scripted_upsert"`
+}
+
+type scriptBlock struct {
+    Lang   string         `json:"lang"`
+    Source string         `json:"source"`
+    Params map[string]any `json:"params"`
+}
+
+// writeBulkDoc 改成 write update action + scripted_upsert body。
+func writeBulkDoc(buf *bytes.Buffer, d Doc) error {
+    id := d.idString()
+    var action bulkUpdateAction
+    action.Update.ID = id
+    action.Update.RetryOnConflict = 3  // 与 file-extractor 一致
+    actionJSON, err := json.Marshal(action)
+    if err != nil {
+        return fmt.Errorf("esindex: marshal bulk action for %s: %w", id, err)
+    }
+    body := bulkUpdateBody{
+        Script:         scriptBlock{Lang: "painless", Source: preservePainless, Params: map[string]any{"doc": d}},
+        Upsert:         d,
+        ScriptedUpsert: true,
+    }
+    bodyJSON, err := json.Marshal(body)
+    if err != nil {
+        return fmt.Errorf("esindex: marshal update body for %s: %w", id, err)
+    }
+    buf.Write(actionJSON)
+    buf.WriteByte('\n')
+    buf.Write(bodyJSON)
+    buf.WriteByte('\n')
+    return nil
+}
+
+// encodedSingleDocSize 重算：update+scripted_upsert body 比 index body 大约 ~2x
+// (script 常量 + params.doc + upsert.doc)，行动行也大 ~40 → ~80 bytes。
+func encodedSingleDocSize(d Doc) int {
+    docJSON, err := json.Marshal(d)
+    if err != nil { return 0 }
+    // 动作行 ~80 字节（{"update":{"_id":"...","retry_on_conflict":3}}）
+    // body 行 ≈ script const (~800 bytes) + 2×doc（params.doc + upsert）+ overhead
+    return 80 + len(preservePainless) + 2*len(docJSON) + 100 + 2
+}
+
+// mapBulkResults 响应解析：action key 从 "index" 改成 "update"
+// 但 update+scripted_upsert 的响应也在 items[i]["update"] 下
+func bulkItemResult(id string, resp *opensearchapi.BulkResp, idx int) BulkItemResult {
+    // ... 原有防御逻辑
+    item, ok := resp.Items[idx]["update"]  // 从 "index" 改成 "update"
+    // ...
+}
+```
+
+**改 `internal/esindex/writer_test.go`**（同步 mock response 用 `"update"` key）。
+
+**改 `internal/esindex/mapping/README.md`**（可选，说明 script update 的语义 + preserve 契约，让未来 reader 或运维知道 script 保留字段的清单）。
+
+#### 影响面
+
+- 🔴 **影响面 = 现网 17M docs 已存在 + 所有新写入 doc**——**是当前项目最高风险变更**
+- 改动只在 `internal/esindex/writer.go`（`bulkActionLine` / `writeBulkDoc` / `mapBulkResults` / `encodedSingleDocSize`）
+- **无 mapping 变更**（只是写入 op 从 index 换 update）
+- 影响下游模块：`cmd/es-indexer`（消费主流程调 `Writer.Bulk`）+ `cmd/rt-backfill` + `internal/filebackfill`（如有调 `esindex.Writer` 的路径）+ 阶段 6 backfill 
+- **性能影响**：Painless script 比 index 慢约 **10-20%**（`params.doc` + `upsert.doc` 双 body + script 编译缓存 + `retry_on_conflict` 语义变化）。生产 17M docs / 5s 一 batch 500 条现有基线下**需实测**（Max 前置 e2e 覆盖）
+- **兼容性**：老 doc 已有的所有字段应完整保留 —— script `ctx._source = params.doc` 全量替换后**只 preserve `payload.file.content` + `contentMeta`**，其他 file-extractor 未来可能新增的字段需在 script 里显式列
+- **回滚方案**：改动集中在 `writer.go`，git revert 该 commit + 重部署 es-indexer 即可。回滚窗口：已用 script update 写入的 doc 结构上兼容 index op（doc 结构没变，只是写入方式变），回滚后自动切回 index op
+
+#### 回归测试计划
+
+新增/改 `internal/esindex/writer_test.go`（~250 行新 test）：
+
+| Test | 场景 | 断言 |
+|---|---|---|
+| `TestBulk_ScriptPreservesContent` | 模拟 doc 已含 payload.file.content='xxx' + contentMeta，es-indexer 重写同 _id | 响应 200，OS 端（mock 层校验请求 body）script 保留字段；无实 OS 时用 mock 断言 painless script 内容 |
+| `TestBulk_NewDocSetsAllFields` | 首次写入 doc，走 upsert 分支 | upsert 分支执行；ctx.op=='create' 走 params.doc 全量赋值 |
+| `TestBulk_OtherFieldsNotAffected` | doc 已有 content=A, extension=B；es-indexer 重写把 extension 改成 C | content 保留 A（file-extractor 写的不动），extension 从 B→C（es-indexer 主流程可覆盖） |
+| `TestBulk_UpdateActionEncoding` | 单条 doc encode | action 行 == `{"update":{"_id":"...","retry_on_conflict":3}}`，body 含 `scripted_upsert:true` + `script.lang=painless` |
+| `TestBulk_DerivativesUsePreserveScript` | doc 有 Derivatives（虚拟子文档） | 每个 derivative 也走 update+preserve script |
+| `TestBulk_ScriptPreservesContentMetaWhenContentMissing` | doc 已含 contentMeta 但 content=nil（异常 case） | contentMeta 保留，不因为 content=nil 触发 script 短路 |
+| `TestBulk_LargeDocSizeEstimateUpdated` | 单 doc 编码字节数估算 | `encodedSingleDocSize` 返回值反映 update body 的膨胀，subBatchEnd 按新估算切子批 |
+| `TestBulkResults_UpdateResponseKey` | mock BulkResp items[i]["update"] | `bulkItemResult` 从 "update" key 读 status |
+| `TestBulk_Idempotency` | 同 doc 写 3 次 | 每次都成功，content preserve 保持一致 |
+| `TestBulk_ScriptSyntaxSmoke` | 单元测试 painless script 常量非空且格式合法 | 简单字符串校验（script const 非 truncated） |
+| **`TestBulk_E2EAgainstOSMock`** | **在测试环境 OS test cluster 跑一遍真实 script**（Max 后续 e2e） | doc create → file-extractor update content → es-indexer bulk update → content 保留 |
+
+#### 部署顺序（**关键**）
+
+🔴 **Blocker #3 的 es-indexer 改动必须先于 file-extractor 上线**：
+
+1. **T-2h**：mapping v1.12 PUT to **test**（若未做，本 PR 已含 v1.12 mapping 已就绪）
+2. **T-1h**：**es-indexer 升级 test**（含 script update）→ 观察 15 min gating（DLQ 无暴增 / OS 5xx 率 / latency）
+3. **T-0h**：file-extractor 首次 apply test → gating 观察 30 min
+4. **T+1h**：DLQ 采样 / OS content 字段抽验 / 搜索 API smoke → ✅ → **prod 部署同顺序**
+5. **prod 顺序**：mapping 已 v1.12 (2026-06-27 已上线) → es-indexer 升 → file-extractor apply → gating
+
+若 es-indexer 后于 file-extractor 上线：**旧 es-indexer 会覆盖 file-extractor 写的 content**，本 PR 修复失效 → 触发 Blocker #3 原 bug。
+
+#### 已知坑 / 权衡
+
+- **坑**：Painless script 每次 update 都会**编译**（除非 hit script cache）。OS 默认 script cache = 100 slots，本 PR 的 script 是**参数化常量**（`preservePainless` 字符串每次一样，`params.doc` 用参数注入），会 hit cache。**要确认**：script 常量 hash 稳定，不会因序列化差异 miss cache。
+- **坑**：`retry_on_conflict=3` 在 update + scripted_upsert 下的语义是**版本冲突时重试整个 script**（不是重试单个 field）。file-extractor 的 update 也用 `retry_on_conflict=3`。两个 writer 并发写同 doc 时的最坏 case 是 3+3=6 次重试，OS 5xx 概率上升需实测。
+- **坑**：Painless 里 `ctx._source = params.doc` **不能直接赋值**（`ctx._source` 是 Map，Painless 允许赋值给 Map 类型的字段，但需要 `params.doc` 类型也是 `Map`）。JSON 反序列化默认 `params.doc` 就是 `Map<String, Object>`，OK。**要验证**：test 环境用真实 OS 3.6 跑一遍确认 script 语法 pass（Max 后续 e2e 承担）。
+- **权衡**：**不用 `_bulk update`+`doc:{}`+`doc_as_upsert:true` 模式**（更简单但无 script）—— 该模式下 update body 的 `doc:{}` 是 partial merge，file-extractor 写的 content 会被 es-indexer 的 partial 覆盖（如果 es-indexer 的 doc 也带 `payload.file` 子对象）。方案 A 用 script 完全掌控 preserve 语义，是唯一保证 content 不丢的路径。
+- **权衡**：**不改 doc structure / mapping**——只改写入 op，doc 字段照旧，兼容性最好，回滚容易。
+- **权衡**：**不缩小 script 到只 preserve 字段的 patch update**——考虑到 es-indexer 主流程可能新增字段的场景，全量 replace + preserve 更符合"es-indexer 拥有 doc 全量、file-extractor 只补 content 子字段"的所有权语义。
+
+---
+
+## §3 P2 修复清单（10 条）
+
+| P2 | 位置 | 改法 | 归属 commit | 是否有回归 test |
+|---|---|---|---|---|
+| **P2-1** OS 429 → transient | `internal/fileextract/oswriter.go::classifyOSErr` line 105-115 | `case status == http.StatusTooManyRequests: return errOSTransient` 加在 404 分支之前 | Commit 12（Blocker #2） | ✅ 已列 `TestProcessOne_429IsTransient` |
+| **P2-2** errOSPermanent → DLQ | `internal/fileextract/consumer.go::attemptOne` + `dlq.go` | 加 `ReasonOSPermanent` 常量；attemptOne 判 `errors.Is(err, errOSPermanent) → DLQ` | Commit 12（Blocker #2） | ✅ 已列 `TestProcessOne_OSPermanentToDLQ` |
+| **P2-3** backfill DeadlineExceeded vs signal | `internal/filebackfill/runner.go::Run` line 95-104 | 拆判：`ctx.Err()==context.DeadlineExceeded` → return `stats, ErrTimeout`（新 sentinel）；`context.Canceled` → 保留 `nil` | Commit 14（P2） | ✅ 新增 `TestRunner_TimeoutDistinctFromCancel` |
+| **P2-4** Tika LimitReader | `internal/fileextract/tika.go` line 96-97 | `body, readErr := io.ReadAll(io.LimitReader(resp.Body, int64(t.maxContentBytes)+4))` | Commit 14（P2） | ✅ 新增 `TestTika_LimitReadResponse` |
+| **P2-5** Truncated *bool | `internal/esindex/doc.go` line 148-153 `FileContentMeta.Truncated bool` → `*bool`；所有引用点 | 改 struct 字段类型 + `extractor.go:100-105` 构造用 `truncatedPtr := truncated; meta.Truncated = &truncatedPtr` | Commit 14（P2） | ✅ 新增 `TestFileContentMeta_TruncatedCanTransitionToFalse` |
+| **P2-6** sentinel error | `internal/fileextract/download.go` line 118 (`cdn permanent status`) + line 138-145 `isPermanentDownloadErr` | 定义 `errCDNPermanent = errors.New(...)`；`tryFetch` 用 `fmt.Errorf("%w: status %d", errCDNPermanent, status)`；`isPermanentDownloadErr` 改 `errors.Is(err, errCDNPermanent)` | Commit 14（P2） | ✅ 新增 `TestIsPermanentDownloadErr_UsesSentinel` |
+| **P2-7** empty_extract TrimSpace | `internal/fileextract/extractor.go` line 96 | `if strings.TrimSpace(content) == ""` | Commit 14（P2） | ✅ 新增 `TestExtractor_WhitespaceOnlyIsEmptyExtract` |
+| **P2-8** backfill scroll retry | `internal/filebackfill/runner.go::Run` line 105-107 | 抽出 `sourceNextWithRetry(ctx, retries=3, backoff=exp)`，OS 5xx 类 retry；permanent 错继续 return | Commit 14（P2） | ✅ 新增 `TestRunner_ScrollTransientRetry` |
+| **P2-9** Tika timeout ctx-driven | `internal/fileextract/tika.go::newTikaClient` + `Extract` | 去掉 `http.Client.Timeout`；`Extract` 内 `perReqCtx, cancel := context.WithTimeout(ctx, t.timeout); defer cancel()`；分类 `errors.Is(perReqCtx.Err(), context.DeadlineExceeded) → errExtractTimeout`；`errors.Is(err, context.Canceled) && ctx.Err() != nil → 上抛 ctx 取消` | Commit 14（P2） | ✅ 新增 `TestTika_TimeoutFiresDeadlineExceeded` + `TestTika_ParentCancelDistinctFromTimeout` |
+| **P2-10** file-extractor startup mapping-compat | `cmd/file-extractor/main.go` startup 前加 `esindex.NewWriter(cfg).AssertLiveMappingCompatible(ctx)` 复用（Writer 内部包 client + Index）；失败 → loud crash | Commit 14（P2） | ✅ 新增 `TestMain_AssertsMappingBeforeStart`（e2e level，可 skip 本地跑） |
+
+**新增 DLQ reason 汇总**（写进 `dlq.go`）：
+- `ReasonRetryExhausted = "retry_exhausted"`（Blocker #2）
+- `ReasonOSPermanent = "os_permanent"`（P2-2）
+
+---
+
+## §4 修复 commit 组织
+
+追加 4 个 commit，保持每 commit 独立可 revert：
+
+| # | Commit message | 变更范围 | 依赖 |
+|---|---|---|---|
+| 11 | `fix(esindex): scripted_upsert to preserve file-extractor written fields (Blocker #3)` | `internal/esindex/writer.go` + `writer_test.go` + mapping/README.md | 无依赖，最先出（部署要求先上） |
+| 12 | `fix(file-extractor): in-place retry + DLQ 429/permanent (Blocker #2 + P2-1 + P2-2)` | `internal/fileextract/{consumer,oswriter,dlq,metrics,config}.go` + `consumer_test.go` | 无依赖 |
+| 13 | `fix(file-extractor): SSRF host allowlist + private-IP block (Blocker #1)` | `internal/fileextract/{ssrf,download,config}.go` + `ssrf_test.go` | 无依赖 |
+| 14 | `fix: P2 cleanup (Tika timeout/LimitReader/Truncated ptr/backfill retry/mapping-compat/sentinel err/empty_extract/CI lint)` | `internal/fileextract/{tika,download,extractor}.go` + `internal/esindex/doc.go` + `internal/filebackfill/runner.go` + `cmd/file-extractor/main.go` + tests + CI lint errcheck/staticcheck fixes | 无依赖 |
+
+**顺序建议**（也可并行开工，但**push 前**按此顺序调整）：11 → 12 → 13 → 14（部署要求 11 先上）
+
+**关键要求**：每 commit 独立可 revert（reviewer re-review 时能定位问题；如某 commit 有问题只 revert 该 commit 不牵一发动全身）
+
+---
+
+## §5 测试策略
+
+### 新增 test case 汇总
+
+| 归属 commit | 新增/改动 test 文件 | 新 test case 数 |
+|---|---|---|
+| Commit 11 (Blocker #3) | `internal/esindex/writer_test.go` | 11 条（详见 §2.3 表） |
+| Commit 12 (Blocker #2) | `internal/fileextract/consumer_test.go` | 11 条（详见 §2.2 表） |
+| Commit 13 (Blocker #1) | `internal/fileextract/ssrf_test.go`（新文件） | 10 条（详见 §2.1 表） |
+| Commit 14 (P2) | 各文件散 test | 10 条（每 P2 一条 + 1 条 backfill timeout test） |
+
+**总计**：~42 条新 test case，预估覆盖新增逻辑 90%+
+
+### e2e 复测（Max 承担）
+
+在 test 环境（dmwork-test / tika-service:9998）跑一遍：
+
+1. **老 5 份文件**（沿用之前实测）
+2. **新增 scenario**：
+   - "故意让 OS 返 429" → 断言走 retry + 最终 OK（`kubectl exec` 手动降 OS 副本模拟）
+   - "故意 delete 主 doc 触发 errDocNotYet" → 断言 retry N 次后 DLQ retry_exhausted
+   - "故意让 es-indexer 重放" → 断言 file-extractor 写的 content 未丢（Blocker #3 修复验证）
+   - "故意让 URL 指向 metadata IP" → 断言 SSRF 拦截（Blocker #1 修复验证）
+3. **性能基线复测**：
+   - script update 引入的 latency 变化（p50/p99）
+   - OS 5xx 率变化（`retry_on_conflict` 语义变化后）
+
+---
+
+## §6 CI 修复
+
+### Lint 失败详情（`gh api repos/Mininglamp-OSS/octo-search-indexer/actions/jobs/84737633961/logs`）
+
+**16 issues：15 errcheck + 1 staticcheck**
+
+| 位置 | 类型 | 修法 |
+|---|---|---|
+| `cmd/file-extractor/main.go:92` | errcheck `strconv.ParseBool` | `_` 换成实名 var，判 err |
+| `internal/esindex/file_content_test.go:98` | errcheck `json.Marshal` | 加 `require.NoError(t, err)` |
+| `internal/filebackfill/runner_test.go:110` | errcheck `rl.Wait` | 加 `require.NoError(t, err)` |
+| `internal/filebackfill/source.go:144` | errcheck `resp.Body.Close` | `defer func() { _ = resp.Body.Close() }()` |
+| `internal/filebackfill/source.go:145` | errcheck `io.ReadAll` | 显式判 err |
+| `internal/filebackfill/source.go:228` | errcheck `s.client.Client.Perform` | 显式判 err |
+| `internal/fileextract/consumer_test.go:79` | errcheck `json.Marshal` | `require.NoError` |
+| `internal/fileextract/consumer_test.go:85` | errcheck `json.Marshal` | `require.NoError` |
+| `internal/fileextract/download.go:115` | errcheck `resp.Body.Close` | `defer func() { _ = resp.Body.Close() }()` |
+| `internal/fileextract/idx4_test.go:30/52/127` | errcheck `w.Write` | `_, _ = w.Write(...)` |
+| `internal/fileextract/idx4_test.go:342` | errcheck `ExtractAndWrite` | 显式判 err |
+| `internal/fileextract/idx4_test.go:365` | errcheck `io.ReadAll` | 显式判 err |
+| `internal/fileextract/tika.go:96` | errcheck `resp.Body.Close` | `defer func() { _ = resp.Body.Close() }()` |
+| `internal/fileextract/consumer.go:81` | staticcheck ST1023 | `var fetchCtx context.Context = ctx` → `fetchCtx := ctx` |
+
+**统一放到 Commit 14 里**（P2 cleanup），全是本项目引入的（`--new-from-patch` diff-only lint 门禁）
+
+### 其他 CI check 说明
+
+- `check-sprint / check-sprint`：**maintainer sprint-field gate**（governance，非代码），需 maintainer 手动清除
+- `code-review`：**已 review 且 requested changes**（4 位 reviewer 已 CR），re-request review 前先修完再 dismiss stale
+- 其他 `Build/Test/Vet/CodeQL/osv-scan/secret-scan` 全 pass ✅
+
+---
+
+## §7 部署顺序（合并后）
+
+### test 环境
+
+```
+Step 1  |  确认 mapping v1.12 已在 test（现状已上线，2026-06-27）
+Step 2  |  es-indexer 升级 test（Commit 11 script update）→ gating 15 min
+        |  · 检查：DLQ 无暴增 / OS 5xx 率 < 0.1% / p99 latency < 500ms
+Step 3  |  file-extractor 首次 apply test（含 Commit 12/13/14）→ gating 30 min
+        |  · 检查：抽取成功率 / DLQ 分布 / 无 SSRF 拦截误报
+Step 4  |  DLQ 采样 + OS content 字段抽验（挑 10 条最新写入 doc） + 搜索 API smoke（关键字搜到）
+Step 5  |  ✅ → prod 上线
+```
+
+### prod 环境
+
+同 test 顺序，mapping v1.12 已 2026-06-27 上线，直接从 Step 2 开始。
+
+**回滚触发条件**：
+- OS 5xx 率 > 1%（sustained 5 min）
+- p99 latency > 2s
+- DLQ 异常暴增（>10x 基线）
+- 搜索 API 命中率显著下降
+
+**回滚步骤**：
+1. `git revert <commit-11>` + 重部署 es-indexer（file-extractor 与 mapping 保持不动）
+2. Commit 12/13/14 独立可回滚，按需 revert
+
+---
+
+## §8 已识别的风险
+
+### 新发现问题（不在 4 位 reviewer 报的 3 blocker + 10 P2 里）
+
+**#1 file-extractor 多分区 commit prefix 未按 partition group 聚合**
+
+- **位置**：Blocker #2 修复中的 `commitPrefix` 函数
+- **描述**：`internal/consumer::commitPrefixes` 有多分区聚合（`partitionCommitPoints`）；file-extractor 单 topic 单 GroupID 也是多分区消费，但 kafka-go `FetchMessage` 返消息顺序与 partition 无关。若一批中混含多个 partition 的消息，只按"从头连续前缀"提交会**误跨 partition** commit。
+- **当前 file-extractor 现状**：BatchSize=50，每条独立 commit，无跨消息前缀概念，所以现有 bug 不受此影响；但 Blocker #2 修复引入 batch retry 后，如果 batch 内混多 partition，`commitPrefix` 需按 partition group 分别推进最大连续前缀。
+- **建议**：Blocker #2 修复直接按 partition group 聚合（照抄 `internal/consumer::partitionCommitPoints`），一次做到位，避免二次改动
+- **主人是否需 sig-off**：不需要（是 Blocker #2 方案 A 的实施细节，不改方案方向）
+- **本文档 §2.2 已在"已知坑"提及，实施时按此处理**
+
+### Painless script 兼容性
+
+- OS 3.6.0 版本 painless 语法支持已确认（3.x 一路兼容，语法与 ES 8.x 基本一致）
+- 生产 test 前用 mock unit test 覆盖 script 常量字段格式；实测在 Max 后续 e2e 阶段承担（无 real OS 单测环境）
+- **风险**：`ctx._source = params.doc` 全量替换在极老 OS 版本可能不支持（本项目 3.6.0 支持）
+
+### 性能损耗
+
+- script update vs index：预估 10-20% latency 上升 + OS CPU 占用上升 ~5-10%
+- 现网 5s/batch 500 条 → 单 batch 编码字节从 ~500KB → ~1MB（script 常量 + 双 doc），仍远低于 `maxBulkBodyBytes=50MB` 阈值
+- **风险**：极端场景（一批全大 doc，含 `payloadRaw` ~1MB×500 = 500MB） → 触发 `subBatchEnd` 按字节切子批更频繁；unit test `TestBulk_LargeDocSizeEstimateUpdated` 覆盖此路径
+
+### 老 doc 已有字段的完整保留
+
+- Painless script `ctx._source = params.doc` 是**全量替换**，只 preserve `payload.file.content` + `contentMeta` 两字段
+- 如果 es-indexer 老 doc 里有 file-extractor 未来打算写的其他 payload.file.* 字段（例如 `payload.file.previewURL`），本方案会丢
+- **当前不构成风险**（file-extractor 只写 content + contentMeta），但如未来 file-extractor 扩字段需**同步扩 script preserve 清单**
+- **建议**：script 里 preserve 的字段清单加注释 + 加一条 test `TestBulk_PreserveContractDocumented` 断言 script 常量含指定字段名（未来扩字段时测试失败提醒同步 script）
+
+### `retry_on_conflict` 语义
+
+- update + scripted_upsert 下的 `retry_on_conflict=3` 表示 OS 检测到 version conflict 时重试整个 script
+- file-extractor `oswriter.go` update 也用 `retry_on_conflict=3`
+- 两 writer 并发写同 doc 时最坏 case 是 3+3=6 次重试
+- **风险**：如生产实测发现冲突率高（>1%），需评估是否降 `retry_on_conflict` 或引入 external optimistic locking（`_seq_no` + `if_seq_no`），本 PR 不做
+
+### `_source.excludes` 与 script update 的交互
+
+- `_source.excludes: ["payload.file.content"]` 语义 = 从 `_source` 存储字段剔除
+- Painless script `ctx._source.payload.file.content` 是**索引前** `_source` 的镜像
+- 顺序：write → script 处理 `ctx._source` → `_source.excludes` 剔除 → 索引 → **倒排索引里 content 仍在**，但 `_source` 里没
+- **确认无兼容性问题**（`_source.excludes` 与 script 处理 `_source` 阶段无冲突）
+
+### 已由 mochashanyao P2 提出但暂不修复的项
+
+- **Kafka reader/DLQ writer 无 TLS/SASL**（`review-2:79-81`）：全仓统一缺失，非本 PR 引入，push GitHub 前**主人 sig-off 决定**是否本 PR 覆盖；建议独立 PR
+
+---
+
+## 完成清单交底
+
+- **(a) 文档路径**：`~/Project/Mininglamp-OSS/octo-search-indexer/docs/file-content-indexing-fix-plan.md`
+- **(b) 3 blocker + 10 P2 diff 计划复杂度评估**：
+  - Blocker #1 (SSRF)：**简单**（新 1 文件 + 3 文件小改，逻辑独立）
+  - Blocker #2 (retry)：**中等**（consumer.go 主体重写，需重设计 state machine + 10+ 条新 test）
+  - Blocker #3 (script update)：**复杂**（涉及 es-indexer core writer + Painless script + 部署顺序 + 性能实测；改动物理小但风险最大）
+  - 10 条 P2：**简单**（每条 < 30 min，其中 P2-9 Tika timeout 稍复杂 ~1h）
+- **(c) 预估修复总工时**：**5-7 h**（详见 §1 分解）
+- **(d) 新发现问题**：**1 条**（§8 #1 file-extractor 多分区 commit prefix），已合入 Blocker #2 diff 计划，不需主人拍板
+- **(e) Painless script 熟悉度**：**中等**——语法框架清晰（`ctx._source` / `params.doc` / `ctx.op`），生产版本 OS 3.6.0 兼容性已确认；细节实测在 Max e2e 阶段兜底。**不需要 Max 帮查文档**，如实际 diff 时遇到 corner case（例如 `containsKey` 对 nested Map 的行为）再来 Max 讨论。
+
+---
+
+## §9 待 Max review 的关键点
+
+1. **§2.3 Painless script 语法细节**（`preservePainless` 常量）——请 Max 判断是否需要主人再次 sig-off，还是属于"已 sig-off 方案 A 的实施细节"直接推进
+2. **§2.2 in-place retry 上限 = 10 + backoff base=1s max=60s**——参数是否合理，需要根据 test 环境实际 OS latency 调
+3. **§4 commit 组织顺序（11→12→13→14）**——是否符合 review 友好性预期
+4. **§8 已识别但暂不修复的 TLS/SASL**（mochashanyao P2）——是否本 PR 覆盖 or 独立 PR
+5. **§2.3 部署顺序 T-2h/T-1h/T-0h 是否 realistic**——test 环境 gating 时长（15/30 min）是否够
+
+Max review 通过后，cc-octo 按 §4 commit 顺序逐 commit 开工，本地 e2e 跑通后 push GitHub 前停报主人 sig-off。

--- a/docs/file-content-indexing-implementation.md
+++ b/docs/file-content-indexing-implementation.md
@@ -1,0 +1,1139 @@
+# File Content Indexing — Implementation Task Book (octo-search-indexer, single PR)
+
+> Author: cc-octo · Date: 2026-07-02 · Status: **v3 (v1.13 修复轮完成，push GitHub sig-off 中)**
+>
+> **v3 changelog (2026-07-02, v1.13 修复轮，同步 4 修复 commit 架构变更)**：
+> 1. **§2 IDX-4 processBatch 语义换血**：老 for-loop（一条 err 上抛 → 后续 message commit 越过 → silent skip / data loss）→ **in-place bounded retry state machine**（`dispositions` 三态 + `attemptOne` 4-outcome + `partitionCommitPoints` 多分区独立前缀聚合），照抄 `internal/consumer::processBatch` 模式；`MaxRetriesPerMessage=10` + backoff 1s→60s（指数 + 满抖动 + ctx-cancel 感知），达上限 → 强制 DLQ `retry_exhausted`（Blocker #2 修复）
+> 2. **§2 IDX-4 oswriter.classifyOSErr 加 `429 → errOSTransient`**：老代码走 `status >= 400` catch-all 误归 `errOSPermanent`，429 是 OS 限流是 transient 语义，与 download.go CDN 429 处理对齐（P2-1 修复）
+> 3. **§2 IDX-4 attemptOne 加 `errors.Is(err, errOSPermanent) → DLQ ReasonOSPermanent`**：老代码所有 OS 错都上抛无 DLQ 路径，与 Blocker #2 silent skip 叠加造成 4xx 永久错误也被永久丢（P2-2 修复）
+> 4. **§2 IDX-3 dlq.go DLQ reason 从 8 种扩到 10 种**：新增 `retry_exhausted` + `os_permanent`（Blocker #2 + P2-2 修复引入）
+> 5. **§2 IDX-4 download.go 新增 SSRF 双闸门**：URL 前置 `validateURL`（scheme + host allowlist，默认只 `https` + `cdn.deepminer.com.cn`）+ `ssrfRestrictedDialer`（dial 时拒 private/link-local/loopback/metadata/CGNAT/IPv6-ULA IP）+ `ssrfCheckRedirect`（防 redirect 跳板绕过），代码位于新增 `internal/fileextract/ssrf.go`（Blocker #1 修复）
+> 6. **§2 IDX-4 tika.go timeout 从 `http.Client.Timeout` 换成 per-request `context.WithTimeout`**：老代码 client-level timeout 与 ctx 独立，触发时 `ctx.Err()=nil` 被误分类 `errExtractGeneric`；改用 ctx 驱动后正确区分 per-request timeout（`errExtractTimeout`）vs parent cancel（`context.Canceled`）（P2-9 修复）
+> 7. **§2 IDX-2 `FileContentMeta.Truncated` 从 `bool` 改成 `*bool`**：老 `bool + omitempty` 无法把 stale `true` 清成 `false`（partial `_update` 语义下 field 缺失 = OS 保留旧值），指针可显式序列化 `false`（P2-5 修复）
+> 8. **§5 回滚方案新增 §5.4 部署顺序**：**es-indexer 升级（含 script update）必须先于 file-extractor 上线**——否则老 es-indexer 用 `_bulk index` 会覆盖 file-extractor 通过 partial `_update` 写的 `payload.file.content` + `contentMeta`（Blocker #3 修复引入依赖）；配套 v1.12 mapping 已在 2026-06-27 上线，不需要再 PUT
+> 9. **§7 未决问题 #1 反转**：v2 "MVP 走 5s delay + Kafka rebalance 自然重试"**被 reviewer 反驳且方案已换**（kafka-go `FetchMessage` 在 fetch 时 `r.offset++`，err 上抛不 commit → reader 已 advance → silent skip 而非 rebalance 重取）；改为 §7 #1' "in-place bounded retry state machine"，Phase 2 独立 retry topic 仍作为规模扩展方案备选
+> 10. **§10 交付清单新增 v1.13 修复轮完成事实**：3 blocker + 10 P2 + CI Lint 16 issues 已修，37 新 test 全绿，5 commit ahead of origin/main（未 push）；具体 diff 见姊妹文档 [`docs/file-content-indexing-fix-plan.md`](./file-content-indexing-fix-plan.md)
+>
+> **v2 changelog (2026-07-01, 集成 Max review 4 条 + 主人授权)**：
+> 1. §7 未决问题 #1（file-extractor vs es-indexer 竞态）：MVP 走 5s delay + Kafka rebalance 自然重试；独立 retry topic 作为 phase 2 备选 → **v3 反转，见 v3 changelog #9**
+> 2. §6.2 test 环境提前起 Tika sidecar 改为**硬要求**（不是 optional）
+> 3. §5 mapping 不可逆警告嵌入 IDX-1 commit message + PR description 顶部
+> 4. §8 估时 IDX-4 5h→**8-10h**，总估 11h→**13-15h ≈ 2 工作日**；timebox IDX-4 开发超 6h / 测试超 4h 回来对齐
+>
+> Repo scope: **`Mininglamp-OSS/octo-search-indexer`** 单仓单 PR，5 commit 串行（v2 计划）+ **v1.13 修复轮追加 4 commit**（Blocker #1/#2/#3 + P2 cleanup，见 `fix-plan.md` §4）
+> 依赖文档: [feasibility v2](./file-content-indexing-feasibility.md) + [tool-comparison](./file-extractor-tool-comparison.md) + [fix-plan v1.13](./file-content-indexing-fix-plan.md)（v1.13 修复轮方案文档）
+> **不在本任务书范围**：octo-server 的 `search_files.go / search_all.go` 改动（独立 PR，独立仓库）；deploy YAML（在 codex `dmwork/octo-search-indexer` manifests/ 下，独立 OPS-1/OPS-2 任务）
+>
+> **📌 v3 阅读指引**：本任务书保留 v2 IDX-1→IDX-5 commit 拆分**任务书视角**（保留原开发计划与 review 追溯价值）；v1.13 修复轮以 4 commit 追加分支尾部，**代码层面**的差异见 `fix-plan.md`。任务书内所有 v3 修订处**明确标注**修复轮变化，与原 v2 任务描述并存不覆盖，便于对比历史决策。
+
+---
+
+## §1 分支 + PR 元信息
+
+### 1.1 分支
+- **Base branch**: `Mininglamp-OSS/octo-search-indexer` 远程最新 `main`
+- **分支名**: `feat/file-content-indexing`
+- **Checkout 命令**：
+  ```bash
+  cd ~/Project/Mininglamp-OSS/octo-search-indexer
+  git fetch origin main
+  git checkout -b feat/file-content-indexing origin/main
+  ```
+
+### 1.2 Commit 消息模板
+每个 commit 用 conventional-commits 前缀（本仓 git log 已是这个风格），格式：
+```
+<type>(<scope>): <subject>
+
+<body — 一段说清「改了什么、为什么、验证方式」>
+
+Refs: docs/file-content-indexing-feasibility.md, docs/file-content-indexing-implementation.md
+```
+
+**⚠️ IDX-1 commit message 必须嵌以下警告段**（源自 Max review v2 §3）：
+> ⚠️ 此 PR 引入的 mapping 变更（`payload.file.content` + `contentMeta`）PUT 到 live index 后**不可逆**——OS 3.x mapping 字段只能通过 reindex + 切换 alias 才能移除。合并前 sig-off 意味着接受该单向决策。
+
+### 1.3 PR title 模板
+```
+feat: file content indexing (payload.file.content + file-extractor + backfill)
+```
+
+### 1.4 PR description 模板
+```markdown
+## Summary
+新增文件正文全文检索能力：抽取 type=8 消息里的 PDF/Office/纯文本内容 → 写 `payload.file.content` → reader 搜关键词命中文件正文（reader 侧改动在独立 PR：octo-server#XXX）。
+
+背景 + 方案参见 `docs/file-content-indexing-feasibility.md`（v2）；工具选型见 `docs/file-extractor-tool-comparison.md`；本 PR 实施拆分与设计决策见 `docs/file-content-indexing-implementation.md`。
+
+## Commits（5 步串行，建议按顺序 review）
+1. **IDX-1** `feat(mapping)`: OS mapping v1.12 加 payload.file.content + contentMeta
+2. **IDX-2** `feat(esindex)`: FilePayload 加 Content + ContentMeta 字段
+3. **IDX-3** `feat(file-extractor)`: 骨架 (Kafka consumer + type=8 filter + DLQ skeleton)
+4. **IDX-4** `feat(file-extractor)`: CDN download + Tika HTTP client + OS partial update
+5. **IDX-5** `feat(backfill)`: cmd/file-content-backfill one-shot job
+
+## Review 建议
+- 先看 IDX-1 mapping.json diff（可视化最小改动）
+- IDX-4 是最重的 commit，关注错误分类与 DLQ reason 触发点
+- IDX-5 backfill 关注限速与 checkpoint 语义
+
+## 回滚方案
+详见 `docs/file-content-indexing-implementation.md §5`。**mapping PUT 不可逆**（新字段只能靠 reindex 消除），故先 PR 合并但不执行 mapping PUT，等 test 部署时人工上（本 PR 不涉及部署）。
+
+## 测试
+- 单元测试全绿：`go test ./...`
+- 手工端到端联调：在本地 docker 起 kafka + opensearch + tika，跑 file-extractor 抽取一份 PDF，验证 `payload.file.content` 落 OS
+
+## Non-goals（不在本 PR）
+- octo-server reader 改动（独立仓独立 PR）
+- codex 部署 manifests 改动（OPS-1/OPS-2 独立任务）
+- 现役 OS index mapping PUT（等 test 部署前 admin 人工触发）
+- octo-web 前端改动（观察期）
+```
+
+---
+
+## §2 每个 commit 的详细 diff 计划
+
+### IDX-1 · `feat(mapping): add payload.file.content + contentMeta to OS mapping (v1.12)`
+
+**只改 JSON + Markdown，不改代码，不加测试**（mapping.json 由启动断言 mapping_compat.go 隐式测试，IDX-2 补测）
+
+#### 改动文件
+
+**修改**：`internal/esindex/mapping/octo-message.json`
+- `payload.properties.file.properties` 下新增两个字段：
+  ```json
+  "content": {
+    "type": "text",
+    "analyzer": "ik_max_word",
+    "search_analyzer": "ik_smart"
+  },
+  "contentMeta": {
+    "type": "object",
+    "properties": {
+      "extractedAt": { "type": "date", "format": "epoch_second" },
+      "extractor":   { "type": "keyword", "ignore_above": 32 },
+      "truncated":   { "type": "boolean" },
+      "extractMs":   { "type": "long" }
+    }
+  }
+  ```
+- `settings.index` 同层新增：
+  ```json
+  "_source": { "excludes": ["payload.file.content"] }
+  ```
+  ⚠️ 注意 OS `_source` config 位置是 `mappings._source`（不是 settings 下），需要放到 `"mappings": { "_source": {...}, "dynamic": "strict", "properties": {...} }` 位置。IDX-1 里对照 OS 官方 mapping schema 确认落点。
+
+**修改**：`internal/esindex/mapping/README.md`
+- 顶部加 v1.12 changelog：
+  ```markdown
+  ## v1.12 文件正文全文检索（file content indexing）
+  
+  v1.12 在 `payload.file` 下新增两个字段，配套 file-extractor 抽取的文件正文写入：
+  
+  - `payload.file.content` (text, IK 分词) — Tika 抽出的文件正文纯文本。用 IK 双分析器
+    保持与 `payload.text.content` 同口径。`_source.excludes` 排除该字段，节省 _source
+    体积；搜索仍可命中并 highlight（走倒排不走 _source）。
+  - `payload.file.contentMeta.{extractedAt, extractor, truncated, extractMs}` (object) —
+    抽取元信息，便于运维观察抽取延迟/覆盖率/截断率。
+  
+  写入契约：由独立 `cmd/file-extractor` 服务通过 OS `_update` partial update 只更新
+  这两个字段，不动主 doc 其他字段（父 doc 由 es-indexer 主流程写入）。
+  
+  详见 `docs/file-content-indexing-feasibility.md` v2 §7。
+  ```
+
+#### 单测覆盖点
+无（本 commit 无代码）。IDX-2 里 `mapping_compat_test.go` 会通过 fail-closed 断言隐式验证新字段。
+
+#### 可能的坑
+- **`_source.excludes` 位置**：OS mapping schema 里 `_source` 是 `mappings` 的直接子字段，不在 `settings.index` 下。旧代码里没有 `_source` 段，本次是首次引入 — 需查 OpenSearch 3.x mapping 官方文档确认精确 JSON 层级
+- **IK 分析器可用性**：`ik_max_word / ik_smart` 依赖 analysis-ik 插件已装（README v1.11 已说明由 octo-deployment 协调）— 现役 OS 已装（`payload.text.content` 早在用），无新增依赖
+- **`dynamic: strict` 与新字段冲突风险**：mapping.json 加了新字段后，代码写入含 `content` 的 doc 前 live mapping 必须已 PUT — 主人决策 #2 明确"改 mapping.json 但不 PUT 到现役 index"，本 PR 合并后到 test 部署前的窗口，如果误把新代码上到 test 但没 PUT mapping，会 4xx 塌 → **IDX-1 commit message 里加显式 warning**：merge 后先 PUT mapping 再上 file-extractor
+
+**开发+测试估时**: **20 分钟**（改 JSON + Markdown + 目视 diff）
+
+---
+
+### IDX-2 · `feat(esindex): add Content/ContentMeta fields to FilePayload`
+
+#### 改动文件
+
+**修改**：`internal/esindex/doc.go`
+- `FilePayload` struct 加两个字段（第 125-131 行）：
+  ```go
+  type FilePayload struct {
+      URL         string           `json:"url,omitempty"`
+      Name        string           `json:"name,omitempty"`
+      Caption     string           `json:"caption,omitempty"`
+      Size        int64            `json:"size,omitempty"`
+      Extension   string           `json:"extension,omitempty"`
+      Content     string           `json:"content,omitempty"`      // v1.12 新增
+      ContentMeta *FileContentMeta `json:"contentMeta,omitempty"`  // v1.12 新增
+  }
+  ```
+- 新增 struct `FileContentMeta`：
+  ```go
+  // FileContentMeta 是 file-extractor 抽取元信息（v1.12）。指针类型 + omitempty 保证
+  // 未抽取的 file doc 该子对象缺席，与 mapping "contentMeta" object 默认无子字段兼容。
+  type FileContentMeta struct {
+      ExtractedAt int64  `json:"extractedAt,omitempty"` // 抽取时刻 (epoch seconds)
+      Extractor   string `json:"extractor,omitempty"`   // "tika/3.3.0" 之类
+      Truncated   bool   `json:"truncated,omitempty"`   // content 是否被截到 256KB（v2 版；v3 已改 *bool）
+      ExtractMs   int64  `json:"extractMs,omitempty"`   // Tika 抽取耗时 (毫秒)
+  }
+  ```
+
+> **⚠️ v3 (v1.13 修复轮 P2-5)**：`Truncated` 字段从 `bool` 改为 `*bool`（生产代码）：
+>
+> ```go
+> // v3 生产版：*bool 允许 partial _update 显式序列化 false，把 stale true 清除
+> Truncated   *bool  `json:"truncated,omitempty"`
+> ```
+>
+> **原因**：老 `bool + omitempty` 语义下 zero-value(`false`) 会被 omitempty 剪掉 → partial `_update` body 里没这个字段 → OS 保留旧值（如果之前是 `true` 不会被清成 `false`）。改 `*bool` + 显式 `boolPtr(false)` 后可以正常清除 stale 值。`extractor.go` 构造改为 `meta.Truncated = &truncated`。回归 test `TestFileContentMeta_TruncatedFalseSerializes` 断言 `{"truncated":false}` 显式落盘。
+
+**修改**：`internal/esindex/mapping_compat.go`
+- `requiredMappingFieldPaths` 加两条新字段路径（第 29-40 行）：
+  ```go
+  var requiredMappingFieldPaths = []string{
+      // ... 现有字段保留
+      // v1.12：文件正文全文检索
+      "payload.file.content",
+      "payload.file.contentMeta.extractedAt",  // 采样一个子字段代表整个 contentMeta object
+  }
+  ```
+- 加注释说明 v1.12 增量含义（承接 v1.10/v1.11 注释风格）
+
+#### 新增文件
+无。
+
+#### 单测覆盖点
+
+**新增/扩展**：`internal/esindex/doc_test.go`
+- `TestFilePayload_ContentSerialization` — 构造 FilePayload{Content: "hello 你好", ContentMeta: {...}} → json.Marshal → 验证 JSON 字段名/嵌套/omitempty 语义
+- `TestFilePayload_EmptyContentOmitted` — Content="" + ContentMeta=nil → JSON 无 content/contentMeta 键（omitempty 生效）
+- `TestFileContentMeta_ExtractedAtSerialization` — 单独覆盖 ContentMeta 各字段
+
+**新增/扩展**：`internal/esindex/mapping_compat_test.go`
+- `TestRequiredMappingFieldPaths_IncludesV112Fields` — 验证 requiredMappingFieldPaths 包含 `payload.file.content` + `payload.file.contentMeta.extractedAt`
+- `TestAssertLiveMappingCompatible_FailsWithoutContent` — 构造缺 content 字段的假 mapping → AssertLiveMappingCompatible 应返 error（fail-closed 语义验证）
+
+#### 可能的坑
+- **buildraw.go 不用改**：现有 buildraw.go 从 RawPayload 投 FilePayload 不会填 Content（Kafka 消息里没有），Content 只由 file-extractor 后写。omitempty 保证不影响现有 doc 结构
+- **backfill 路径不用改**：backfill 走 buildraw 同路径，同样不填 Content
+- **BulkDocs 不用改**：Doc.Payload.File.Content 有值时自动序列化进 _bulk body，无需修改 encodeBulkBody
+- **mapping_compat_test 假 mapping 构造**：需构造 nested map[string]any 模拟 GET _mapping 响应，测试文件里可能已有 helper 复用
+
+**开发+测试估时**: **40 分钟**（struct 加字段 20min + 单测 20min）
+
+---
+
+### IDX-3 · `feat(file-extractor): scaffold cmd/file-extractor with Kafka consumer + type=8 filter + DLQ skeleton`
+
+#### 新增文件
+
+**`cmd/file-extractor/main.go`** (~130 行，仿 `cmd/es-indexer/main.go` 骨架)
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "os"
+    "os/signal"
+    "syscall"
+    "github.com/Mininglamp-OSS/octo-search-indexer/internal/fileextract"
+)
+
+func main() { /* log 初始化 + 信号处理 + run(ctx) */ }
+
+func run(ctx context.Context) error {
+    cfg, enabled := loadConfig()
+    if !enabled {
+        log.Printf("file-extractor: FILE_EXTRACTOR_ENABLED not true (or config missing); idling")
+        <-ctx.Done()
+        return nil
+    }
+    svc, err := fileextract.NewService(cfg)
+    if err != nil { return err }
+    defer svc.Close()
+    return svc.Run(ctx)
+}
+
+func loadConfig() (fileextract.ServiceConfig, bool) {
+    cfg := fileextract.ServiceConfig{
+        Brokers:       splitCSV(os.Getenv("KAFKA_BROKERS")),
+        Topic:         envOr("KAFKA_TOPIC", "octo.message.v1"),
+        DLQTopic:      envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.file-extract.dlq"),
+        GroupID:       envOr("KAFKA_GROUP_ID", "file-extractor"),
+        BatchSize:     envInt("EXTRACTOR_BATCH_SIZE", 50),
+        // Tika + OS + Download 相关配置 IDX-4 补，本 commit 只装骨架
+        ESAddresses:   splitCSV(os.Getenv("ES_ADDRESSES")),
+        ESIndex:       envOr("ES_INDEX", "octo-message"),
+        ESUsername:    os.Getenv("ES_USERNAME"),
+        ESPassword:    os.Getenv("ES_PASSWORD"),
+    }
+    enabled := strings.EqualFold(os.Getenv("FILE_EXTRACTOR_ENABLED"), "true") &&
+        len(cfg.Brokers) > 0 && len(cfg.ESAddresses) > 0
+    return cfg, enabled
+}
+
+// envOr / envInt / splitCSV: 复用 es-indexer/main.go 的实现（本 commit 里复制，
+// 阶段 4 加公用 pkg 时再抽）
+```
+
+**`internal/fileextract/config.go`** (~50 行)
+```go
+package fileextract
+
+import "time"
+
+type ServiceConfig struct {
+    Brokers       []string
+    Topic         string
+    DLQTopic      string
+    GroupID       string
+    BatchSize     int
+
+    // IDX-4 补充：TikaURL / DownloadTimeout / ExtractTimeout / MaxFileSize / MaxContentBytes ...
+    TikaURL         string  // http://localhost:9998 (sidecar)
+    DownloadTimeout time.Duration
+    ExtractTimeout  time.Duration
+    MaxFileSize     int64   // 20MB cutoff
+    MaxContentBytes int     // 256KB 截断
+    HTTPRetries     int     // 3
+
+    ESAddresses   []string
+    ESIndex       string
+    ESUsername    string
+    ESPassword    string
+}
+```
+
+**`internal/fileextract/service.go`** (~100 行，仿 `internal/consumer/service.go`)
+```go
+package fileextract
+
+import (
+    "context"
+    "fmt"
+    "log"
+)
+
+type Service struct {
+    proc    *Processor
+    source  *kafkaSource
+    dlqSink *kafkaDLQSink
+    // writer 在 IDX-4 引入
+}
+
+func NewService(cfg ServiceConfig) (*Service, error) {
+    source, err := newKafkaSource(...)
+    // ...
+    dlqSink, err := newKafkaDLQSink(...)
+    // ...
+    proc := NewProcessor(source, dlqSink, cfg)
+    return &Service{...}, nil
+}
+
+func (s *Service) Run(ctx context.Context) error { return s.proc.Run(ctx) }
+func (s *Service) Close() error { /* 关闭 source + dlqSink */ }
+```
+
+**`internal/fileextract/consumer.go`** (~150 行，仿 `internal/consumer/consumer.go` 简化版)
+```go
+package fileextract
+
+// Processor：拉批 → filter type=8 → 抽取 (IDX-4 stub) → OS update (IDX-4 stub) → DLQ 路由 → commit
+type Processor struct {
+    source  messageSource
+    dlqSink dlqSink
+    cfg     ServiceConfig
+}
+
+func (p *Processor) Run(ctx context.Context) error { /* 循环 fetchBatch + processBatch */ }
+
+func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) error {
+    for _, m := range batch {
+        msg, err := searchmsg.UnmarshalMessage(m.value)
+        if err != nil {
+            // 契约解析失败 → DLQ reason=parse_error
+            p.dlqSink.WriteDLQ(ctx, m.key, buildDLQEnvelope(m, "parse_error", err.Error()))
+            continue
+        }
+        contentType, ok := extractContentType(msg.RawPayload)  // 复用 buildraw.go decodeObjectUseNumber
+        if !ok || contentType != payloadTypeFile {  // != 8
+            continue  // 非文件消息，跳过（IDX-3 只到这一步，IDX-4 接抽取）
+        }
+        // IDX-3: 打日志占位，不做真正抽取
+        log.Printf("file-extractor: skip type=8 (extractor stub, waiting IDX-4): messageId=%s", msg.MessageID)
+    }
+    return p.source.CommitBatch(ctx, batch)
+}
+```
+
+**`internal/fileextract/kafka.go`** (~120 行)
+- 复制 `internal/consumer/kafka.go` 的 `kafkaSource` + `kafkaDLQSink` 实现（同 C4 提交语义：CommitInterval=0 + 只用 FetchMessage）
+- **不 import consumer 包**（避免循环依赖 + 保持 fileextract 独立性）
+
+**`internal/fileextract/dlq.go`** (~180 行，简化版 `internal/consumer/dlq.go`)
+- `dlqRecord` struct，含字段：`Reason / MessageID / Topic / Partition / Offset / URL / DetailErr / SpilledAt`
+- `DLQReason` 枚举常量（本 commit 定义齐 8 种，触发点在 IDX-4 补；**v3: v1.13 修复轮追加 2 种，合计 10 种**）：
+  ```go
+  const (
+      ReasonParseError    = "parse_error"       // Kafka 消息解不出 searchmsg
+      ReasonOversize      = "oversize"          // 文件 > MaxFileSize
+      ReasonBlacklistExt  = "blacklist_ext"     // 扩展名黑名单
+      ReasonDownloadFail  = "download_failed"   // HTTP GET 失败（重试耗尽）
+      ReasonExtractTimeout = "extract_timeout"  // Tika 抽取超时
+      ReasonEncrypted     = "encrypted"         // Tika EncryptedDocumentException
+      ReasonEmptyExtract  = "empty_extract"     // 抽出空串
+      ReasonExtractError  = "extract_error"     // 其他 Tika 异常
+      // === v3 (v1.13 修复轮) 新增 ===
+      ReasonRetryExhausted = "retry_exhausted"  // in-place bounded retry N 次未成功（Blocker #2）
+      ReasonOSPermanent    = "os_permanent"     // OS 写返 4xx (非 404/409/429) permanent (P2-2)
+  )
+  ```
+- 带 base64-膨胀 aware 的 value 截断阈值（复用 consumer/dlq.go 常量 700_000）
+
+**`internal/fileextract/metrics.go`** (~40 行)
+- 骨架 counter/timer 定义（阶段暂用 stdlib log 打，接 Prometheus 在阶段 7 独立任务）：
+  - `processedTotal / skippedNonFile / dlqTotal[reason] / extractDurationMs`
+
+#### 单测覆盖点
+
+**新增**：`cmd/file-extractor/main_test.go`
+- `TestLoadConfig_Disabled` — 未设 FILE_EXTRACTOR_ENABLED → enabled=false
+- `TestLoadConfig_MissingBrokers` — Enabled=true 但缺 KAFKA_BROKERS → enabled=false
+- `TestLoadConfig_Defaults` — 默认 topic/group/batch 等值
+
+**新增**：`internal/fileextract/consumer_test.go`
+- `TestProcessBatch_SkipNonFileMessages` — 构造 type=1/2/5 消息 → 应跳过不写 DLQ
+- `TestProcessBatch_UnmarshalError_ToDLQ` — 塞坏 JSON → 触发 parse_error DLQ
+- `TestProcessBatch_TypeFileGoesToExtractor` — type=8 消息（IDX-3 stub 版本）应命中日志占位分支
+
+**新增**：`internal/fileextract/dlq_test.go`
+- `TestDLQRecord_SerializationRoundtrip` — 构造 → marshal → unmarshal → 字段对齐
+- `TestDLQReason_Constants` — 8 种 reason 常量存在
+- `TestDLQValueTruncation` — 超 700KB Value 应被截断 + PayloadTruncated=true
+
+#### 可能的坑
+- **kafka-go rebalance 处理**：多副本 file-extractor 部署时，同 groupID 的实例会分 partition。file-extractor 拉了消息但抽取中的 rebalance 会导致该消息被另一 pod 重取 — **靠 OS partial update 幂等兜底**（同 doc 覆盖同字段，无副作用）。IDX-3 里不用特殊处理，IDX-4 补充说明
+- **type filter 早剪**：processBatch 里 non-file 消息立即 skip 是关键性能优化 — 非 type=8 消息占 99.3%，早剪能让 file-extractor 吞吐≈es-indexer 吞吐
+- **contentType 提取**：复用 buildraw.go 的 `decodeObjectUseNumber` + `extractType` — IDX-3 可以 import esindex 包直接调（消费者读 payload，是合理依赖）
+- **kafka 分组冲突**：`file-extractor` 是新 groupID，不抢 es-indexer 位点，两个消费者独立推进
+
+**开发+测试估时**: **2 小时**（4 个新 .go 文件骨架 + 3 个 test 文件；跟 consumer 包相似结构可 copy-adapt，主要工时在契约对齐 + test setup）
+
+---
+
+### IDX-4 · `feat(file-extractor): implement CDN download + Tika HTTP client + OS partial update`
+
+#### 新增文件
+
+**`internal/fileextract/download.go`** (~100 行)
+```go
+package fileextract
+
+import (
+    "context"
+    "fmt"
+    "io"
+    "net/http"
+    "time"
+)
+
+// downloadClient 从 CDN URL 拉文件 bytes。带超时 + 指数退避重试 + size cutoff。
+type downloadClient struct {
+    hc          *http.Client
+    maxSize     int64
+    retries     int
+    retryBackoff time.Duration
+}
+
+func newDownloadClient(cfg ServiceConfig) *downloadClient { /* ... */ }
+
+// Fetch: GET url → 读 body → 返 (bytes, contentType, error)
+// 错误分类：
+//   - HTTP 5xx / net.OpError / DNS 失败 → transient，触发重试
+//   - HTTP 4xx（非 429）→ permanent（DLQ reason=download_failed）
+//   - Content-Length > maxSize → permanent（DLQ reason=oversize）
+//   - 3 次重试耗尽 → permanent
+func (d *downloadClient) Fetch(ctx context.Context, url string) ([]byte, string, error) {
+    for attempt := 0; attempt <= d.retries; attempt++ {
+        body, ct, err := d.tryFetch(ctx, url)
+        if err == nil { return body, ct, nil }
+        if !isTransient(err) { return nil, "", err }
+        wait := d.retryBackoff * (1 << attempt) // 1s / 4s / 16s
+        select { case <-time.After(wait): case <-ctx.Done(): return nil, "", ctx.Err() }
+    }
+    return nil, "", fmt.Errorf("download exhausted retries: %s", url)
+}
+```
+
+> **🔴 v3 (v1.13 修复轮 Blocker #1 SSRF)**：download.go 入口 + Transport 层新增 **SSRF 双闸门**（v2 骨架未覆盖，reviewer 发现后修）：
+>
+> - **闸门 1 (`validateURL`)**：Fetch 入口前置校验 `url.Scheme` ∈ `AllowedDownloadSchemes`（默认 `["https"]`）+ `url.Hostname()` ∈ `AllowedDownloadHosts`（默认 `["cdn.deepminer.com.cn"]`）；不匹配立即返 `errDownloadFailed`（不重试，URL 不变重试无意义）
+> - **闸门 2 (`ssrfRestrictedDialer`)**：`http.Transport.DialContext` 挂 IP 校验层，resolve 后拒 private/link-local/loopback/metadata（`169.254.169.254`）/CGNAT `100.64/10`/IPv6 ULA `fc00::/7`；解析后**直接 dial 到 pinned IP** 避免 TOCTOU DNS rebinding
+> - **闸门 3 (`ssrfCheckRedirect`)**：`http.Client.CheckRedirect` hook，redirect 时重跑闸门 1，防跳板攻击（第一跳合法 → 302 到 metadata IP）
+> - **`SSRFAllowLoopback bool` cfg 字段**：**test-only** 开关，允许 httptest.NewServer 走 127.0.0.1；生产**必须 false**
+> - **cfg 新增字段**：`AllowedDownloadHosts` / `AllowedDownloadSchemes` / `SSRFAllowLoopback`；env `ALLOWED_DOWNLOAD_HOSTS` / `ALLOWED_DOWNLOAD_SCHEMES` future 扩展（切内网 COS 时）
+> - **不新增 DLQ reason**：SSRF 拦截走现有 `download_failed`（"下载被拒"语义已足够）
+>
+> 具体 diff + 14 条回归 test（含 metadata IP dialer 拒 / redirect 跳板拒 / IPv6 ULA / CGNAT 全网段覆盖）见 [`fix-plan.md` §2.1](./file-content-indexing-fix-plan.md#21-blocker-1--ssrf-防护max-判断) + `internal/fileextract/ssrf.go` + `ssrf_test.go`。
+
+> **⚠️ v3 (v1.13 修复轮 P2-6)**：download.go `tryFetch` 遇 4xx 返回的错从字符串 `"cdn permanent status <N>"` 改为 sentinel `errCDNPermanent`（`errors.Is` 分类）；`isPermanentDownloadErr` 改用 `errors.Is(err, errCDNPermanent)`，不再依赖 err.Error() 字符串（重构风险）。
+
+**`internal/fileextract/tika.go`** (~120 行)
+```go
+package fileextract
+
+import (
+    "bytes"
+    "context"
+    "fmt"
+    "io"
+    "net/http"
+    "strings"
+    "time"
+)
+
+// tikaClient 调 Tika Server 的 PUT /tika 端点，得纯文本。
+type tikaClient struct {
+    hc      *http.Client
+    baseURL string  // http://localhost:9998
+    timeout time.Duration
+    maxContentBytes int  // 256KB 截断
+}
+
+func newTikaClient(cfg ServiceConfig) *tikaClient { /* http.Client{ Timeout: cfg.ExtractTimeout } */ }
+
+// Extract 上传 file bytes，返回抽出的纯文本 + truncated 标记 + error
+// 错误分类（关键设计）：
+//   - HTTP 500 body 含 "EncryptedDocumentException" → 特殊错误 errEncrypted
+//   - HTTP 500 其他 → errExtractGeneric
+//   - HTTP 422 (unsupported media type) → errExtractGeneric（Tika 明确不支持）
+//   - context.DeadlineExceeded → errExtractTimeout
+//   - 抽出空串 → 上层触发 empty_extract（这里返 ("", false, nil) 不算错）
+//   - 抽出 > maxContentBytes → 截断 + truncated=true
+func (t *tikaClient) Extract(ctx context.Context, fileBytes []byte, filename string) (content string, truncated bool, err error)
+```
+
+> **⚠️ v3 (v1.13 修复轮 tika.go 修订汇总)**：
+>
+> - **P2-9 timeout ctx-driven**：`newTikaClient` 去掉 `http.Client{Timeout: cfg.ExtractTimeout}`（client-level timeout 与 ctx 独立，触发时 `ctx.Err()==nil` 被误分类 `errExtractGeneric`）；`Extract` 内改用 `perReqCtx, cancel := context.WithTimeout(ctx, t.timeout); defer cancel()` 驱动，err 分类改为 `errors.Is(perReqCtx.Err(), context.DeadlineExceeded) → errExtractTimeout`，同时判 `parentCtx.Err() != nil` 上抛（区分 SIGTERM 优雅退出 vs per-req 超时）
+> - **P2-4 unbounded read**：`io.ReadAll(resp.Body)` 加 `io.LimitReader(resp.Body, int64(t.maxContentBytes)+4)`，避免 Tika 谎报 body 大小时 OOM
+> - **P2-7 whitespace empty_extract**：`extractor.go` 上层判 `content == ""` 改为 `strings.TrimSpace(content) == ""`，scanned/empty PDF 常返 `"\n\n"` 类空白也归 `empty_extract`（老代码放行 → 无意义 doc 被误 commit）
+> - **P2-4 defer errcheck**：`defer resp.Body.Close()` 改 `defer func() { _ = resp.Body.Close() }()` 通过 CI Lint errcheck
+>
+> 具体 diff 见 [`fix-plan.md` §3](./file-content-indexing-fix-plan.md#3-p2-修复清单10-条) 表 P2-4/P2-7/P2-9。
+
+**`internal/fileextract/oswriter.go`** (~150 行)
+```go
+package fileextract
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "github.com/opensearch-project/opensearch-go/v3"
+    "github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// osWriter 只做一件事：给指定 messageId 的 doc 做 partial update，
+// 仅写 payload.file.content + payload.file.contentMeta。
+type osWriter struct {
+    client *opensearch.Client
+    index  string
+}
+
+func newOSWriter(cfg ServiceConfig) (*osWriter, error) { /* opensearch.NewClient(...) */ }
+
+// UpdateContent 用 _update API（partial merge doc），只更新 file.content + contentMeta。
+// 参数 retryOnConflict=3 缓解与主 doc 首次写入的乐观锁冲突。
+func (w *osWriter) UpdateContent(ctx context.Context, messageID string, content string, meta esindex.FileContentMeta) error {
+    body := map[string]any{
+        "doc": map[string]any{
+            "payload": map[string]any{
+                "file": map[string]any{
+                    "content":     content,
+                    "contentMeta": meta,
+                },
+            },
+        },
+        "doc_as_upsert": false,  // 关键：doc 不存在时不 upsert（避免造孤儿子文档；等主 doc 先落）
+    }
+    buf, _ := json.Marshal(body)
+    req := opensearchapi.UpdateReq{
+        Index:      w.index,
+        DocumentID: messageID,
+        Body:       bytes.NewReader(buf),
+        Params: opensearchapi.UpdateParams{RetryOnConflict: ptrInt(3)},
+    }
+    resp, err := w.client.Update(ctx, req)
+    if err != nil { return err }
+    if resp.StatusCode == 404 {
+        // 主 doc 还没落到 OS（es-indexer 还没消费到这条）— 让上层等下一轮 rebalance/重试
+        return errDocNotYet
+    }
+    // 其他 status 语义分类：2xx=OK，4xx=permanent，5xx=transient
+    return classifyOSStatus(resp.StatusCode)
+}
+```
+
+> **⚠️ v3 (v1.13 修复轮 P2-1)**：`classifyOSStatus`/`classifyOSErr` 必须**显式在 `>= 400` catch-all 之前拦下 `429`** 归 `errOSTransient`（否则 429 被误归 permanent 与 Blocker #2 silent skip 叠加造成 4xx 永久丢消息）。生产代码为 `case status == http.StatusTooManyRequests: return errOSTransient`，位置在 404 分支之后 / 500 分支之前，与 `download.go:117` CDN 429 处理对齐。
+
+**修改**：`internal/fileextract/service.go` — 加 downloadClient / tikaClient / osWriter 装配
+
+**修改**：`internal/fileextract/consumer.go::processBatch` — 把 IDX-3 stub 换成真实抽取流程。
+
+> **🔴 v3 (v1.13 修复轮 Blocker #2)**：下方**朴素 for-loop** 版本存在 **silent skip / data loss** 缺陷（kafka-go `FetchMessage` 在 fetch 时 `r.offset = m.message.Offset + 1`，err 上抛不 commit 后 reader 已本地 advance，后续 message commit 越过前面的失败 offset → 永久丢消息，非 rebalance 重取）。**生产代码已替换为 in-place bounded retry state machine**（照抄 `internal/consumer::processBatch`），核心结构：
+>
+> ```go
+> // v3 生产版：dispositions 三态 state machine + attemptOne 4-outcome + partitionCommitPoints
+> // 详见 internal/fileextract/{consumer.go,decision.go,backoff.go}，此处仅列关键骨架。
+> type itemDisposition int
+> const (
+>     dispTransient itemDisposition = iota  // 未终态，需继续 retry
+>     dispOK                                // 抽取 + OS 写成功
+>     dispDLQResolved                       // 已落 DLQ 终态
+> )
+>
+> type attemptOutcome int
+> const (
+>     outcomeOK        attemptOutcome = iota  // 成功
+>     outcomeDLQ                              // 已落 DLQ（永久失败）
+>     outcomeTransient                        // 需 caller 重试
+>     outcomeFatal                            // DLQ 写自身失败 → 硬停
+> )
+>
+> func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) error {
+>     n := len(batch)
+>     dispositions := make([]itemDisposition, n)
+>     attempts := make([]int, n)  // 每条独立 attempt 计数
+>     for i := range dispositions { dispositions[i] = dispTransient }
+>
+>     for {  // 循环直到全部条目终态
+>         if err := ctx.Err(); err != nil { return err }
+>         changed := false
+>         for i, m := range batch {
+>             if dispositions[i] != dispTransient { continue }
+>             // 达上限 → 强制 DLQ retry_exhausted，避免 partition 永久阻塞
+>             if attempts[i] >= p.cfg.MaxRetriesPerMessage {
+>                 if werr := p.writeDLQ(ctx, m, ReasonRetryExhausted, ...); werr != nil { return werr }
+>                 dispositions[i] = dispDLQResolved
+>                 changed = true; continue
+>             }
+>             // 退避（attempts[i]>0 才 sleep；ctx 感知）
+>             if attempts[i] > 0 {
+>                 if serr := p.sleep(ctx, expJitterBackoff(base, max, attempts[i])); serr != nil { return serr }
+>             }
+>             outcome, err := p.attemptOne(ctx, m)  // 单次尝试
+>             attempts[i]++
+>             switch outcome {
+>             case outcomeOK:        dispositions[i] = dispOK;          changed = true
+>             case outcomeDLQ:       dispositions[i] = dispDLQResolved; changed = true
+>             case outcomeTransient: /* 保持 transient，下轮再试 */
+>             case outcomeFatal:     return err  // DLQ 写失败 → 硬停
+>             }
+>         }
+>         if changed {
+>             // 按分区推进"连续成功前缀"commit（多分区独立，见 partitionCommitPoints）
+>             for _, point := range partitionCommitPoints(batch, dispositions) {
+>                 if err := p.source.Commit(ctx, point); err != nil { return err }
+>             }
+>         }
+>         if !hasTransient(dispositions) { return nil }  // 全终态
+>     }
+> }
+>
+> // attemptOne：把 v2 processBatch 里的抽取流程封装成单次尝试，返 4-outcome
+> func (p *Processor) attemptOne(ctx context.Context, m fetchedMessage) (attemptOutcome, error) {
+>     // ... parse / non-file skip / ExtractAndWrite ...
+>     if errors.Is(err, errOSPermanent) {  // v3 P2-2：OS 4xx → DLQ os_permanent 不重试
+>         if werr := p.writeDLQ(ctx, m, ReasonOSPermanent, ...); werr != nil {
+>             return outcomeFatal, werr
+>         }
+>         return outcomeDLQ, nil
+>     }
+>     if errors.Is(err, errDocNotYet) { /* p.metrics.IncDocNotYet() */ }
+>     // errDocNotYet / errOSTransient / 其他 transient 错 → 交给 state machine 重试
+>     return outcomeTransient, nil
+> }
+> ```
+>
+> **配套新增文件**（生产代码分层）：
+> - `internal/fileextract/decision.go` — `itemDisposition` 三态 + `hasTransient` + `partitionCommitPoints`（照抄 `internal/consumer::partitionCommitPoints`，多分区独立推进前缀，杜绝跨分区 commit 越过 transient）
+> - `internal/fileextract/backoff.go` — `expJitterBackoff(base, max, attempt)` + `sleepCtx(ctx, d)`（参数化 max，允许 cfg 覆盖默认 60s 上限）
+>
+> **配套 config 新增字段**：`MaxRetriesPerMessage` (默认 10) / `TransientBackoffBase` (默认 1s) / `TransientBackoffMax` (默认 60s)。
+>
+> **配套 extractorService interface**：`Processor.extractor` 从 `*Extractor` 换成 interface `extractorService{ExtractAndWrite(...)}`，生产传 `*Extractor`，测试注入 mock。
+>
+> 详细 diff + 11 条回归 test（含 Jerry-Xin 建议的 offset 100/101/102 场景 + 多分区独立推进场景）见 [`fix-plan.md` §2.2](./file-content-indexing-fix-plan.md#22-blocker-2--consumer-数据丢失主人拍板方案-a) + `internal/fileextract/retry_test.go`。
+
+**（以下为 v2 老版 for-loop 骨架，仅供 review 追溯原设计意图，非生产代码）**：
+```go
+if contentType == payloadTypeFile {
+    payload := extractFilePayload(msg.RawPayload)  // 从 raw 取 url/name/ext/size
+    if !isExtractable(payload.Extension) {
+        // 黑名单扩展名，跳过（不写 DLQ，这是设计正常路径）
+        continue
+    }
+    if payload.Size > cfg.MaxFileSize {
+        p.writeDLQ(m, ReasonOversize, ...)
+        continue
+    }
+    // 1. download
+    bytes, _, err := p.download.Fetch(ctx, payload.URL)
+    if err != nil { p.writeDLQ(m, ReasonDownloadFail, err); continue }
+    // 2. extract
+    start := time.Now()
+    content, truncated, err := p.tika.Extract(ctx, bytes, payload.Name)
+    extractMs := time.Since(start).Milliseconds()
+    if err != nil {
+        switch {
+        case errors.Is(err, errEncrypted): p.writeDLQ(m, ReasonEncrypted, err)
+        case errors.Is(err, errExtractTimeout): p.writeDLQ(m, ReasonExtractTimeout, err)
+        default: p.writeDLQ(m, ReasonExtractError, err)
+        }
+        continue
+    }
+    if content == "" {
+        p.writeDLQ(m, ReasonEmptyExtract, nil)
+        continue
+    }
+    // 3. os partial update
+    meta := esindex.FileContentMeta{
+        ExtractedAt: time.Now().Unix(),
+        Extractor:   "tika/3.3.0",
+        Truncated:   truncated,
+        ExtractMs:   extractMs,
+    }
+    if err := p.oswriter.UpdateContent(ctx, msg.MessageID, content, meta); err != nil {
+        if errors.Is(err, errDocNotYet) {
+            // 主 doc 未落 → 本 message 暂不 commit 位点，让 kafka 下轮再取
+            // 简化：这里直接 return err（外层 backoff 后重跑整批）
+            return err
+        }
+        // 其他 OS 错误 → transient 重试或 DLQ
+    }
+}
+```
+
+#### 单测覆盖点
+
+**新增**：`internal/fileextract/download_test.go`
+- `TestFetch_Success` — httptest.Server 返 200 → bytes 正确
+- `TestFetch_5xxRetryThenSuccess` — 前两次 500，第三次 200 → 抽取成功
+- `TestFetch_5xxRetryExhausted` — 三次都 500 → DLQ 触发 err
+- `TestFetch_ContentLengthOversize` — Content-Length > MaxFileSize → 立即 oversize
+- `TestFetch_ContextCancelled` — ctx 取消 → 立即返 ctx.Err
+
+**新增**：`internal/fileextract/tika_test.go`
+- `TestExtract_Success` — httptest 模拟 Tika 返纯文本 → content OK truncated=false
+- `TestExtract_ContentTruncatedAt256KB` — 返 300KB → 截到 256KB + truncated=true
+- `TestExtract_EncryptedDocument500Body` — httptest 返 500 body 含 "EncryptedDocumentException" → 返 errEncrypted
+- `TestExtract_TimeoutExceeded` — httptest sleep 40s，client timeout 30s → 返 errExtractTimeout
+- `TestExtract_UnsupportedMedia422` — 返 422 → 返 errExtractGeneric
+- `TestExtract_EmptyBody` — 返 200 空 body → content="" err=nil (让上层判)
+
+**新增**：`internal/fileextract/oswriter_test.go`
+- `TestUpdateContent_Success` — httptest OS 返 200 → nil err
+- `TestUpdateContent_404_DocNotYet` — OS 返 404 → 返 errDocNotYet
+- `TestUpdateContent_409_VersionConflict` — OS 返 409 → 走 retry_on_conflict 由 OS 内部处理，本地不重试；返 nil
+- `TestUpdateContent_RequestBodyShape` — 拦截请求 body 断言 `doc.payload.file.{content,contentMeta}` 字段正确嵌套 + `doc_as_upsert=false`
+
+**扩展**：`internal/fileextract/consumer_test.go`
+- `TestProcessBatch_FileMessage_EndToEnd` — 用 mock download/tika/oswriter 组一遍 e2e
+- `TestProcessBatch_Encrypted_ToDLQ` — 模拟 Tika 抛 encrypted → DLQ reason=encrypted
+- `TestProcessBatch_Oversize_SkipDownload` — 大于 MaxFileSize → 不下载直接 DLQ oversize
+- `TestProcessBatch_BlacklistExt_SkipCleanly` — .mp4 消息 → 跳过不写 DLQ 不 log 错
+
+#### 可能的坑
+- **Tika HTTP 500 body 判 EncryptedDocumentException**：Tika Server 返错时 body 是 Java stack trace 纯文本；判断靠字符串 contains "EncryptedDocumentException"。**风险**：Tika 版本升级 body 格式变化导致判断失效 — 加 unit test 用真实 Tika body 采样字符串锁死这个契约，升 Tika 主版本时同步 review
+- **OS partial update 时序**：file-extractor 消费同一 topic 但独立 group，es-indexer 可能还没消费到主 doc → OS `_update` 返 404。**降级策略**：`errDocNotYet` 触发本批重试（Kafka rebalance 会重新取），最终追平 es-indexer 后成功。**风险**：如果 file-extractor 消费速度长期快于 es-indexer，大量重试；缓解：file-extractor 开工前 sleep 5s 等 es-indexer 抢先跑（但更好方案是加个"预检查" query 或直接接受重试代价）
+- **retry_on_conflict=3**：OS 内部处理 version 冲突，通常够。如果 backfill Job 也在同时写同一 doc，可能超过 3 次；本 PR 里 file-extractor 和 backfill 时序错开（backfill 在 file-extractor 稳定 24h 后跑），不会撞车
+- **HTTP client 复用**：单例 `http.Client{ Transport: ..., Timeout: ... }`（stdlib 推荐做法）；不用 `google/go-tika` 库（多一层依赖 + wrapper 薄）
+- **byte 拷贝内存放大**：Tika HTTP PUT 需把整份文件放请求 body，20MB × 并发 10 = 200MB 峰值内存 — Deploy memory limit 至少 512MB 起
+- **黑名单/白名单扩展名判断**：filename 用 `path.Ext(name)` 取；同时校对 payload.file.extension 字段（Kafka 消息里有）— 优先用 extension 字段，兜底 filename 后缀
+- **contentType 不识别的 msg**：processBatch 里 `extractContentType` 返 (0, false) 视作跳过，不进 DLQ（非文件消息本身合法）
+
+**开发+测试估时**: **5-6 小时**（3 个新 pkg 文件 + 3 个 test 文件 + consumer.go 改造 + service.go 装配；这是最重 commit）
+
+---
+
+### IDX-5 · `feat(backfill): add cmd/file-content-backfill one-shot job`
+
+#### 新增文件
+
+**`cmd/file-content-backfill/main.go`** (~200 行，仿 `cmd/backfill/main.go` 骨架但**源改成 OS scroll**)
+```go
+package main
+
+import (
+    "context"
+    "flag"
+    "log"
+    "os"
+    "os/signal"
+    "syscall"
+    "time"
+    "github.com/Mininglamp-OSS/octo-search-indexer/internal/fileextract"
+    fbf "github.com/Mininglamp-OSS/octo-search-indexer/internal/filebackfill"
+)
+
+func main() { /* flag 解析 + 信号处理 + run() */ }
+
+func run() error {
+    var (
+        esAddrs   = flag.String("es", envOr("BACKFILL_ES", "http://localhost:9200"), "OS addresses")
+        esIndex   = flag.String("es-index", envOr("BACKFILL_ES_INDEX", "octo-message"), "OS index (alias)")
+        // ... esUser / esPass / tikaURL 
+        rate      = flag.Float64("rate", 50, "extraction rate limit (docs/s)")
+        scrollSize = flag.Int("scroll-size", 500, "OS scroll batch size")
+        checkpoint = flag.String("checkpoint", "", "checkpoint file (empty=in-memory)")
+        timeout   = flag.Duration("timeout", 2*time.Hour, "overall timeout")
+    )
+    flag.Parse()
+
+    // 装配：downloadClient + tikaClient + osWriter 复用 internal/fileextract/*
+    // 加 osReader（新增，只做 scroll 查询）+ rateLimiter（复用 internal/backfill/ratelimit.go 或复制）
+    runner := fbf.NewRunner(fbf.Config{
+        Source: osReader,       // scroll query type=8 且 content 缺失
+        Extract: extractClient, // 复用 fileextract.Extractor
+        Rate: rate,
+    })
+    return runner.Run(ctx)
+}
+```
+
+**`internal/filebackfill/source.go`** (~120 行)
+```go
+package filebackfill
+
+// osScrollSource 用 OS scroll API 遍历 type=8 且 payload.file.content 不存在的 doc
+type osScrollSource struct {
+    client *opensearch.Client
+    index  string
+    size   int
+    scrollTTL time.Duration
+}
+
+// Next 返回下一批 {messageID, filePayload}，直到没有为止返 io.EOF
+// Query DSL:
+//   {
+//     "query": {
+//       "bool": {
+//         "filter": [{"term":{"payload.type":8}}],
+//         "must_not": [{"exists":{"field":"payload.file.content"}}]
+//       }
+//     },
+//     "_source": ["messageId","payload.file"]
+//   }
+func (s *osScrollSource) Next(ctx context.Context) ([]sourceDoc, error) { /* ... */ }
+```
+
+**`internal/filebackfill/runner.go`** (~150 行)
+```go
+package filebackfill
+
+// Runner 串起：scroll source → 限速 → 复用 fileextract.processOne → OS partial update → 进度日志
+type Runner struct {
+    source    *osScrollSource
+    extractor *fileextract.Extractor   // 抽出 IDX-4 processBatch 逻辑成可复用 Extractor
+    limiter   *rateLimiter
+    // ...
+}
+
+func (r *Runner) Run(ctx context.Context) error { /* 循环 Next + 逐条 extract + 打进度 */ }
+```
+
+**`internal/filebackfill/ratelimit.go`** — 复用 internal/backfill/ratelimit.go 实现（直接 copy 或 refactor 抽公用 pkg，本 PR 里 **直接 copy** 保持修改边界最小）
+
+**`internal/filebackfill/checkpoint.go`** — 复用 internal/backfill/checkpoint.go 模式（scroll_id 持久化到文件，恢复时从上次 scroll_id 续跑；简化：MVP 阶段可以先不做 checkpoint，123K 文件 40 分钟能跑完，即便中断重跑也只多消耗一次抽取时间；本 commit 加简化 in-memory 版，checkpoint 文件版留待后续 PR 增强）
+
+#### 单测覆盖点
+
+**新增**：`internal/filebackfill/source_test.go`
+- `TestOSScrollSource_QueryShape` — 拦截 OS 请求 body 断言 filter/must_not/exists 语义
+- `TestOSScrollSource_Pagination` — mock OS 返 3 页 → 全部消费
+- `TestOSScrollSource_EmptyResult_ReturnsEOF` — 空结果 → io.EOF
+
+**新增**：`internal/filebackfill/runner_test.go`
+- `TestRunner_HappyPath` — 3 条 doc → 全部抽取成功
+- `TestRunner_RateLimitHonored` — 限 10 docs/s，100 条 → 应耗 ~10s（tick 计时验证）
+- `TestRunner_PartialFailure` — 3 条里 1 条 encrypted → 2 成功 1 DLQ，Job 不整体失败
+- `TestRunner_ContextCancelled` — ctx.Cancel → 立即优雅退出
+
+**新增**：`cmd/file-content-backfill/main_test.go`
+- `TestRun_FlagsRequired` — 缺 esAddrs → 返 error
+- `TestRun_Defaults` — 默认 rate/scrollSize/timeout 值
+
+#### 可能的坑
+- **共用 fileextract.processOne 需要 refactor**：IDX-4 里 `processBatch` 是 consumer 内嵌逻辑，为了 backfill 复用需要抽成独立可测函数（比如 `fileextract.Extractor.Extract(ctx, msgID, filePayload) error`）。IDX-4 里就应该考虑复用性，IDX-5 里如果发现耦合太紧要小改 IDX-4（review 时可能反馈）
+- **OS scroll 长时间开着**：默认 scroll TTL 5min；123K 文件 × 200ms/抽取 = 40min，需要在每批之间刷新 scroll TTL 或改用 search_after（更现代）。**推荐用 search_after + PIT (point-in-time)** 而非老 scroll API（OpenSearch 3.x 建议）
+- **限速与并发的关系**：限速 50 RPS 是单实例；一次性 Job 单副本跑，不用担心多副本互相冲突
+- **backfill 时机**：主 doc 一定已存在（backfill 是回填历史，不是新数据），所以 UpdateContent 不会 404
+- **失败重跑**：如果 Job 中途挂了，重跑时 scroll query `must_not exists payload.file.content` 会自动跳过已抽取的 doc（幂等自然）— 不需要复杂 checkpoint 逻辑
+- **一次性 K8s Job 部署**：本 commit 只出 Go 代码，YAML 在 codex 部署仓 OPS-2 独立任务
+
+**开发+测试估时**: **3-4 小时**（IDX-4 已建好复用基础的话工时集中在 scroll source + runner；如果 IDX-4 没抽 Extractor 复用点，这里需要 refactor 加 1 小时）
+
+---
+
+## §3 关键设计决策
+
+### 3.1 Tika HTTP client 用哪个 Go 库？
+**决策**：**stdlib `net/http` 直调**。
+
+**理由**：
+- Tika HTTP API 极简（PUT /tika + header + body），wrap 一层没意义
+- `google/go-tika` 已 3+ 年无更新（本地未验证但社区活跃度低），依赖风险高于收益
+- stdlib http.Client 支持 timeout / context / connection reuse 齐全，够用
+
+**代码位置**：`internal/fileextract/tika.go`
+
+### 3.2 OS partial update 用 `_update` 还是 `_update_by_query`？
+**决策**：**用 `_update`（by docID）**。
+
+**理由**：
+- 每条 Kafka 消息对应一个明确的 messageID → `_update/<id>` 精准命中
+- `_update_by_query` 是批量语义（一次改 N 条匹配 query 的 doc），不适合单条 update
+- `retry_on_conflict=3` 参数处理与主 doc 首次写入的乐观锁冲突（OS 内部 retry，本地无需重试逻辑）
+- `doc_as_upsert=false` 避免造孤儿子文档（主 doc 未落时报 404 而不是 upsert 出无父的 content-only doc）
+
+**代码位置**：`internal/fileextract/oswriter.go::UpdateContent`
+
+### 3.3 Kafka 消息处理并发模型
+**决策**：**每 partition 单 goroutine（kafka-go consumer group 默认）+ 批内串行处理**。
+
+**理由**：
+- 现有 `internal/consumer` 就是这套模型，保持一致低风险
+- Tika 抽取是 IO/CPU 混合，批内并行的收益要跟 Tika sidecar 并发能力匹配 — Tika 默认 thread pool = CPU × 2；单 pod 里 file-extractor 单 goroutine 串行 = Tika 一次一个请求，简单且 Tika 侧无争抢
+- 未来如果吞吐不够，通过**扩 file-extractor Deploy 副本数**扩容（Kafka 自动 rebalance），而不是加批内并发
+- 简化排障：一条消息处理一次抽取一次 update，日志一目了然
+
+**替代方案**（不采用）：批内 worker pool 并行抽取 N 条。**否决理由**：加复杂度但对小规模消息（几百 QPS）无收益
+
+### 3.4 Backfill Job 通过 OS scroll 还是 Kafka 重放？
+**决策**：**OS scroll (推荐 search_after + PIT) 遍历，不走 Kafka**。
+
+**理由**：
+- Kafka 消息保留期有限（默认 7 天），历史 123K 消息大多已过期
+- OS scroll 直接查 `type=8 且 content 缺失` 精准命中回填目标，无需过滤
+- 重跑幂等自动（`must_not exists` 自动跳过已抽取的 doc）
+- 走 Kafka 会污染 file-extractor consumer group 位点（一次性 Job 混进日常 consumer 里不干净）
+
+**代码位置**：`internal/filebackfill/source.go`
+
+### 3.5 file-extractor 与 backfill 复用抽取逻辑
+**决策**：IDX-4 里把抽取核心逻辑抽成 `fileextract.Extractor` 独立 struct（`Extract(ctx, msgID, filePayload) error`），consumer.go 和 filebackfill/runner.go 都调它。
+
+**理由**：DRY + 单测更集中；避免 IDX-5 里重复 IDX-4 的 download/tika/oswriter 装配代码
+
+---
+
+## §4 单测覆盖清单（汇总）
+
+| Commit | 测试文件 | 关键 case 数 |
+|---|---|---|
+| IDX-1 | 无（改 JSON/Markdown） | 0 |
+| IDX-2 | `doc_test.go`（扩展）+ `mapping_compat_test.go`（扩展） | 5 |
+| IDX-3 | `main_test.go`（新）+ `consumer_test.go`（新）+ `dlq_test.go`（新） | 8 |
+| IDX-4 | `download_test.go`（新）+ `tika_test.go`（新）+ `oswriter_test.go`（新）+ `consumer_test.go`（扩） | 20 |
+| IDX-5 | `source_test.go`（新）+ `runner_test.go`（新）+ `main_test.go`（新） | 10 |
+| **合计** | 11 个测试文件 | **~43 case** |
+
+**跑测命令**：
+```bash
+cd ~/Project/Mininglamp-OSS/octo-search-indexer
+go test ./...
+go test -race ./internal/fileextract/... ./internal/filebackfill/...  # 竞态
+go test -cover ./internal/fileextract/... ./internal/filebackfill/... # 覆盖率
+```
+
+**覆盖率目标**：新增包 line coverage ≥ 80%（现有 internal/consumer 是 ~85%，对齐）
+
+---
+
+## §5 回滚方案
+
+### 5.1 单个 commit revert
+- **IDX-5 revert**：删除 `cmd/file-content-backfill` + `internal/filebackfill/` → 只损失 backfill 能力，不影响增量抽取
+- **IDX-4 revert**：file-extractor 退回 stub 状态（跑但不实际抽取，全 skip）→ 增量抽取停摆，OS 里已抽取的 content 不受影响
+- **IDX-3 revert**：删除 `cmd/file-extractor` + `internal/fileextract/` → file-extractor Deploy 缺 binary，需要同时 revert 部署 YAML（在 codex 仓，不在本 PR）
+- **IDX-2 revert**：FilePayload 回退到 5 字段 → 已写 content 的 doc _source 里字段依然存在（OS 不 care）+ mapping 里 content 字段依然存在（无用不占多少空间）— **无害保留**
+- **IDX-1 revert**：mapping.json 回退 → **mapping.json 与 live mapping 不一致**（live 里已有 content 字段，embed 里没了）→ 启动断言 mapping_compat 会通过（fail-closed 检的是 embed→live，不是反向）— **实际上 revert IDX-1 无副作用但也无价值**（live mapping 不可逆）
+
+### 5.2 整个 PR revert
+```bash
+git revert -m 1 <merge-commit-sha>  # 如果走 merge commit
+# 或
+git checkout main; git reset --hard <pre-branch-sha>  # 危险，慎用
+```
+
+Revert 后：
+- 代码回到 pre-branch 状态
+- **已 PUT 到 OS 的 mapping 保留**（新字段不消失，OS mapping add-only）
+- **已抽取的 content 数据保留**（OS 里 doc 的 payload.file.content 字段依然存在）
+- 未来若要重新上线，只需要重新 apply 本 PR 即可（幂等）
+
+### 5.3 已 PUT mapping 的**不可逆性**（关键提示）
+OpenSearch 3.x mapping 新增字段是**不可逆操作**：
+- 一旦 `PUT _mapping` 添加了 `payload.file.content` + `payload.file.contentMeta`，无法通过 API 删除
+- 只能通过 **reindex** 到新 backing index + 切换 alias 才能"消除"字段
+- 但字段存在但不写入是零开销的（IK 分词器不会自动填内容）
+
+**结论**：mapping 变更是**一次性单向决策**。IDX-1 里 commit message + PR description 显式警告这一点，主人拍板前确认。
+
+### 5.4 部署顺序（v3 新增，v1.13 修复轮 Blocker #3 引入依赖）
+
+🔴 **v1.13 修复轮 Blocker #3 (es-indexer scripted_upsert) 引入**：**es-indexer 升级（含 script update）必须先于 file-extractor 上线**。
+
+**原因**：
+- Blocker #3 修复前，es-indexer 用 `_bulk index` full-replace 写主 doc → 每次 redeliver（rebalance/restart/retry）会覆盖 file-extractor 通过 partial `_update` 写的 `payload.file.content` + `contentMeta`
+- Blocker #3 修复后，es-indexer 改用 `_bulk update` + `scripted_upsert` + Painless 保留 `preservedFilePaths` 里的字段（`payload.file.content` + `contentMeta`），redeliver 时不再覆盖
+
+**test 环境正确顺序**：
+```
+Step 0  |  确认 mapping v1.12 已在 test（现状已上线，2026-06-27）
+Step 1  |  es-indexer 升级 test（含 Commit 11 script update）→ 观察 ≥ 1 天
+        |  · gating：DLQ 无暴增 / OS 5xx 率 < 0.1% / p99 latency 复测 script vs index 差异
+Step 2  |  file-extractor 首次 apply test（含 Commit 12/13/14）→ 观察 ≥ 3 天
+        |  · gating：抽取成功率 / DLQ 分布 / 无 SSRF 拦截误报 / OS content 字段抽验
+Step 3  |  ✅ → prod 部署同顺序
+```
+
+**prod 环境顺序**：同 test 顺序（mapping v1.12 已 2026-06-27 上线，从 Step 1 开始）；prod reader 已在 2026-06-29 接入 v1.7.1。
+
+**若 es-indexer 后于 file-extractor 上线**：老 es-indexer 会覆盖 file-extractor 写的 content → Blocker #3 修复失效 → 触发原 bug。
+
+**回滚触发条件 + 步骤**：见 [`fix-plan.md` §7](./file-content-indexing-fix-plan.md#7-部署顺序合并后)。
+
+---
+
+## §6 Max 需要在 PR review 前做的事
+
+### 6.1 IDX-1 前
+- ✅ **已完成**：主人决策 #2 已拍板"改 mapping.json 但不 PUT"
+- ✅ **v3 已完成**：mapping v1.12 已在 test 与 prod 上线（2026-06-27），本 PR 不需要再 PUT mapping
+- **待做**：跟 OS admin 提前打招呼，说明 test 环境 mapping PUT 计划（IDX-1 PR merge 后择时 apply）— 走 tech-deploy.md 里改 OS mapping 的红线路径 → **v3 备注**：v1.12 mapping 已 2026-06-27 完成 PUT，本条待做项失效
+
+### 6.2 IDX-4 前
+- **🔴 硬要求（Max review v2 §2）**：test 环境**必须**预先起 Tika sidecar Deploy（`apache/tika:3.3.0.0` minimal 镜像 165MB 压缩），不是 optional。理由：dmwork/local-dev-stack 缺 tika，本地 compose 30-60min 不划算；file-extractor 是新服务部到 test 环境抽真实文件更贴近生产。IDX-4 dev cycle = 本地跑单测 + push test 分支镜像跑 e2e。**由 Max 负责在 IDX-4 开发前起好 Tika Deploy**。
+
+### 6.3 IDX-5 前
+- **待做**：跑一次 OS aggregation 拿 type=8 avg file size：
+  ```json
+  GET prod-octo-message-read/_search
+  {
+    "size": 0,
+    "query": {"term": {"payload.type": 8}},
+    "aggs": {
+      "avg_size": {"avg": {"field": "payload.file.size"}},
+      "sum_size": {"sum": {"field": "payload.file.size"}}
+    }
+  }
+  ```
+  验证 v2 §11 假设 avg 5MB 是否准确；如果实际 avg 20MB → 回灌 CDN 流量估算翻 4 倍到 ~2.4TB，需重估账单
+
+### 6.4 Push PR 前的最后 checklist
+- [ ] 5 个 commit 消息符合 conventional-commits 格式
+- [ ] `go test ./...` 全绿
+- [ ] `go build ./...` 全绿
+- [ ] 分支已 rebase 到最新 main
+- [ ] docs/ 下 feasibility + tool-comparison + implementation 三份文档都在本 PR 里（或已 merge）
+- [ ] PR description 用 §1.4 模板填齐
+
+---
+
+## §7 (b) 设计时发现的技术风险 / 未决问题（比 v2 更实施层）
+
+1. ~~**file-extractor 与 es-indexer 时序竞态**（IDX-4 §3.3 已讨论）— 新消息进 Kafka 后，file-extractor 可能比 es-indexer 先抽完 → OS `_update` 返 404。**MVP 策略（v2 收敛）**：`errDocNotYet` 触发本批 Kafka rebalance 自然重试 + IDX-4 加 `EXTRACT_STARTUP_DELAY_SECONDS=5` config 缓解启动瞬间竞态。**局限**：只治启动瞬间，稳态下 es-indexer 重启 30s 依然会撞 404。**Phase 2 备选方案**（观察 prod DLQ `errDocNotYet` 触发率超阈值后启用）：塞独立 Kafka retry topic `octo.message.v1.file-extract.retry{,.prod}`，5s 后重放 — 需要多一个 topic + 消费逻辑，MVP 不做。~~
+
+**🔴 v3 (v1.13 修复轮 Blocker #2) 反转**：v2 "MVP 走 5s delay + Kafka rebalance 自然重试" **被 reviewer 反驳且方案已换**。
+
+- **反驳依据**（yujiawei review + `comment-0` 校正）：kafka-go `Reader.FetchMessage` 在 fetch 时执行 `r.offset = m.message.Offset + 1`（reader.go 源码），err 上抛不 commit 后 reader **已经本地 advance**，没有 seek-back 语义。下一 `FetchMessage` 拿的是**下一 offset**，前面失败的 offset 一旦下一条成功 commit 就被 kafka group 高水位**永久越过** → **silent skip / data loss**，不是"rebalance 重取"。
+- **v3 新方案**：**in-place bounded retry state machine**（照抄 `internal/consumer::processBatch` 模式，见本文档 v3 §2 IDX-4 processBatch 段）
+  - `dispositions` 三态 + `attemptOne` 4-outcome
+  - `MaxRetriesPerMessage=10` + backoff 1s→60s（指数 + 满抖动 + ctx-cancel 感知）
+  - 达上限 → 强制 DLQ `retry_exhausted`（避免 partition 永久阻塞）
+  - `partitionCommitPoints` 每分区独立推进"连续可越过前缀"，杜绝跨分区 commit 越过 transient
+- **`ExtractStartupDelay` 语义保留**：仍作为启动瞬间竞态的**兜底缓解**（sleep 5s 让 es-indexer 抢先跑），稳态竞态由 in-place retry 兜底
+- **Phase 2 备选 (independent retry topic)**：仍作为**规模扩展**方案备选（如果 in-place retry 长期占用 partition slot 影响吞吐，可改成 in-place retry N 次不成功 → 塞 retry topic 而非 DLQ retry_exhausted）；MVP v1.13 不做
+- **回归测试**：11 条覆盖 offset 100/101/102 skip 场景、多分区独立推进、429 transient、errOSPermanent DLQ、retry_exhausted DLQ 等；见 `internal/fileextract/retry_test.go`
+
+2. **Tika HTTP 500 body 解析脆弱性**（IDX-4 已讨论）— 用字符串 contains "EncryptedDocumentException" 区分错误类型。**风险**：Tika 版本升级/patch 改 body 格式 → 判断失效 → 所有 encrypted 文件被误判为 extract_error → DLQ reason 统计失真。**缓解**：IDX-4 单测里用真实 Tika 3.3.0 采样 body 字符串锁死；升 Tika 版本时同步 review
+
+3. **OS `_update` 语义 vs bulk 语义不一致**（IDX-4）— 主流程用 `_bulk` 批量，file-extractor 用 `_update` 单条。**风险**：`_update` 单条 RTT 高，123K 回灌 40min 假设成立需 avg 200ms/请求；如果 OS 慢查询 > 500ms/请求 → 回灌变 2 小时。**缓解**：实测阶段 1 上线后如果发现慢，切 `_bulk update actions`（`_bulk` 支持 update action，语义相同批量提交）
+
+4. **黑名单/白名单扩展名 corner case**（IDX-4）— 文件名可能没扩展名 or 扩展名与内容不符（用户改名）。**决策**：优先信任 `payload.file.extension` 字段（Kafka 消息里有，是 octo-server 上传时磁数存的），fallback `path.Ext(name)`；两个都空 → 默认走白名单（尝试抽取）而不是跳过（宁抽多不漏）
+
+5. **backfill 与 file-extractor 同时跑的冲突**（IDX-5）— 主人决策"backfill 在 file-extractor 稳定 24h 后跑"避免了这个问题。**风险**：如果紧急情况提前跑 backfill，两者同时 update 同一 doc 会触发 version 冲突 → retry_on_conflict=3 通常够用。**缓解**：backfill Job 里加 flag `-skip-if-content-exists`（scroll query 已经带 `must_not exists content` 天然满足，无需额外 flag）
+
+6. **单 PR 5 commit 的 review 疲劳**（元层面）— 单 PR 累计 ~1500-2000 行新增 + 修改（估算）— review 需要 1-2 小时集中精力。**建议**：Max review 时按 §1.4 模板"先看 IDX-1 mapping.json"的顺序进入，避免直接看 IDX-4 迷失在 DLQ 分支里
+
+---
+
+## §8 (c) 每个 commit 的开发+测试估时（v2 修订）
+
+| Commit | 开发估时 | 测试估时 | 合计 |
+|---|---|---|---|
+| IDX-1 | 15min | 5min（无代码） | **20min** |
+| IDX-2 | 20min | 20min | **40min** |
+| IDX-3 | 1h | 1h | **2h** |
+| IDX-4 | **5-6h**（v2 上调，Max review） | **3-4h**（v2 上调） | **8-10h** ⚠️ |
+| IDX-5 | 2h | 1.5h | **3.5h** |
+| **合计** | ~9-10h | ~6-7h | **~13-15h ≈ 2 工作日** |
+
+**timebox（v2 修订）**：IDX-4 开发超 **6h** 或测试超 **4h** 回来对齐范围（v1 是 4h/3h）。
+
+---
+
+## §9 (d) 动工前需要 Max/主人补充的信息
+
+**必须**（阻塞开工）：
+- 无 — 主人 3 个决策已全部拍板（reader 并行 / backfill 一次性 K8s Job / file-extractor 独立 Deploy）；本任务书假设已确认
+
+**建议**（不阻塞但影响准确度）：
+1. **prod type=8 avg file size** —— 影响 §11 CDN 流量估算准确度（§6.3 已列步骤）
+2. **是否有 monorepo dev 环境** —— 本地 e2e 联调需要 kafka + opensearch + tika 三件套，如果 dmwork 有现成 docker-compose 快 30 分钟；如果没有，IDX-4 开发时需要自己 compose 起
+3. **Tika 镜像选型** —— 默认按 §5 feasibility 决策用 `apache/tika:3.3.0.0` minimal (~165MB 压缩)；full 版 (~333MB) 需要吗（本期不做 OCR，minimal 就够）— 主人如无异议默认 minimal
+
+---
+
+## §10 完成后交付清单
+
+- (a) 任务书路径：`~/Project/Mininglamp-OSS/octo-search-indexer/docs/file-content-indexing-implementation.md`（本文件）
+- (b) 实施层未决问题：§7 6 条
+- (c) 时间估算：§8 合计 ~11h ≈ 1.5 工作日
+- (d) 动工前信息缺口：§9 无阻塞项，3 条建议项
+
+**待 Max review 通过后**，按 IDX-1→IDX-5 顺序开工，每 commit 单测通过再进下一步。**全部 5 commit 完成 + 本地 e2e 跑通后再 push GitHub**（主人已拍板）。
+
+---
+
+### §10.v3 v1.13 修复轮完成事实（2026-07-02 追加）
+
+v2 IDX-1→IDX-5 5 commit 于 2026-07-01 本地完成 + 首推 PR #46 于 2026-07-02 收到 4 位 reviewer CHANGES_REQUESTED，v1.13 修复轮追加 4 commit：
+
+- **fix-plan 文档**：`docs/file-content-indexing-fix-plan.md`（796 行 / 49KB，2026-07-02 主人 sig-off + Max review 5 点判断落档）
+- **修复轮 commit（未 push）**：
+  ```
+  2f973f0 fix: P2 cleanup + CI lint (Tika/backfill/mapping-compat/sentinel/errcheck)
+  0b754aa fix(file-extractor): SSRF host allowlist + private-IP block (Blocker #1)
+  51a7e25 fix(file-extractor): in-place bounded retry + DLQ 429/permanent (Blocker #2 + P2-1 + P2-2)
+  2535448 fix(esindex): scripted_upsert to preserve file-extractor written fields (Blocker #3)
+  ```
+- **修复覆盖**：
+  - 3 blocker（Blocker #1 SSRF / Blocker #2 in-place retry / Blocker #3 script update）
+  - 10 P2（429 分类 / errOSPermanent DLQ / backfill timeout vs signal / Tika LimitReader / Truncated *bool / sentinel err / whitespace empty_extract / backfill scroll retry / Tika ctx timeout / file-extractor mapping-compat）
+  - CI Lint 16 issues（15 errcheck + 1 staticcheck）
+- **新增 test**：37 条（Blocker #3 7 + Blocker #2 10 + Blocker #1 14 + P2 5 + P2-5 增补 1）；`go vet + build + test + test -race` 15 package 全绿
+- **分支状态**：`feat/file-content-indexing` 5 commits ahead of `origin/main`（1 原 feature + 4 修复），未 push；等主人 push sig-off → 走 squash + push PR
+
+**代码层详细 diff**：见 `docs/file-content-indexing-fix-plan.md` §2 (blocker 详解) + §3 (10 P2 表) + §6 (CI Lint) + §7 (部署顺序)。

--- a/docs/file-content-indexing-rereview.md
+++ b/docs/file-content-indexing-rereview.md
@@ -1,0 +1,228 @@
+# File Content Indexing — v1.13 修复轮独立复审报告
+
+> Reviewer: cc-octo（独立 fresh-context 视角，非修复轮作者）
+> Date: 2026-07-02
+> 范围: `feat/file-content-indexing` 分支相对 `origin/main` (`0970dd8`) 领先的 5 commit 中，除 first commit `9f2ffa8`（已在 PR #46 里 review 过）之外的：
+> - `b327642` docs: sync implementation.md v3 with fix-round changes
+> - `2f973f0` fix: P2 cleanup + CI lint
+> - `0b754aa` fix(file-extractor): SSRF host allowlist + private-IP block (Blocker #1)
+> - `51a7e25` fix(file-extractor): in-place bounded retry + DLQ 429/permanent (Blocker #2 + P2-1 + P2-2)
+> - `2535448` fix(esindex): scripted_upsert to preserve file-extractor written fields (Blocker #3)
+
+## §0 总判定
+
+**APPROVE WITH NITS**
+
+3 个 blocker 修复方向正确、代码扎实、回归 test 覆盖足够，逻辑上均经受得住反面构造。10 P2 逐条落地、CI Lint 清理。发现的问题都在 §2 应修（P2）与 §3 nits 层面，**无 §1 严重问题需修**；但 §6 e2e 未验点较多（Painless script、OS 3.6 兼容、prod DNS SSRF 路径等），push GitHub 前 Max 需确认 e2e 计划。
+
+## §1 严重问题（BLOCK — 必须修才能 push）
+
+**无**。
+
+三个 blocker 修复的核心正确性（silent skip 消除 / SSRF 双闸门 / preserve script）我都做了反面构造，均未构造出破坏的输入：
+
+- **Blocker #2**：模拟 batch=[100(OK),101(transient),102(OK)] → commit 顺序确定；forced DLQ 后 disposition 变 dispDLQResolved 触发 partitionCommitPoints 前缀推进；无 silent skip。
+- **Blocker #1**：模拟 URL 走 metadata IP、URL host 走白名单外域、redirect 到 evil host、CGNAT/IPv6-ULA/link-local IP — 均被闸门 1 或闸门 2 拒绝；TOCTOU 由 dial 时 resolve + 用 resolved IP 直连闭合。
+- **Blocker #3**：模拟 doc 已存在（file-extractor 已写 content）+ es-indexer redeliver 场景 → savedContent/Meta 保留 → 全量替换 → 恢复；模拟 type=1 text 消息 doc（无 file 字段）→ savedContent=null → 不进恢复分支 → 不凭空写 payload.file。
+
+## §2 应修问题（P2 — 强烈建议但不 block push）
+
+### §2.1 `cmd/file-extractor/main.go:101-119` `loadConfig` 未把 v1.13 新增 config field 挂到 env
+
+**问题**：`ServiceConfig` v1.13 新增 6 个字段全部 hardcode 走 default，`loadConfig` 未从 env 读取：
+- `MaxRetriesPerMessage` / `TransientBackoffBase` / `TransientBackoffMax`（Blocker #2 引入）
+- `AllowedDownloadHosts` / `AllowedDownloadSchemes` / `SSRFAllowLoopback`（Blocker #1 引入）
+
+**影响**：生产要调 SLA（比如把 MaxRetries 从 10 降到 5）或 future 切内网 COS 扩展 host 白名单时，只能改代码 + 走整个发版流程；不是 hot-config。commit 0b754aa message 明确写"future 切内网 COS 时通过 env ALLOWED_DOWNLOAD_HOSTS 扩展"，但 env 挂载没跟上。
+
+**严重性理由**：功能上正确（default 与生产需求一致），但**违背文档承诺** + 运维/演进灵活性降低。SSRFAllowLoopback 尤其危险：future 若因某种 test/debug 需要临时打开，因 env 未挂载会诱导直接改代码 push——比 env 开关的可审计性差。
+
+**建议修法**：`loadConfig` 追加：
+```go
+MaxRetriesPerMessage:  envInt("EXTRACTOR_MAX_RETRIES_PER_MESSAGE", 10),
+TransientBackoffBase:  time.Duration(envInt("EXTRACTOR_TRANSIENT_BACKOFF_BASE_MS", 1000)) * time.Millisecond,
+TransientBackoffMax:   time.Duration(envInt("EXTRACTOR_TRANSIENT_BACKOFF_MAX_MS", 60000)) * time.Millisecond,
+AllowedDownloadHosts:  splitCSV(os.Getenv("ALLOWED_DOWNLOAD_HOSTS")),
+AllowedDownloadSchemes: splitCSV(os.Getenv("ALLOWED_DOWNLOAD_SCHEMES")),
+// SSRFAllowLoopback 显式**不挂 env**（生产绝不该打开），加注释说明测试专用只能通过 test cfg 注入
+```
+
+---
+
+### §2.2 `internal/fileextract/consumer.go:193-197` `ReasonRetryExhausted` DLQ 记录缺失 `messageID` + `fp`
+
+**问题**：`processBatch` 强制 DLQ 时调 `writeDLQ(ctx, m, ReasonRetryExhausted, "", nil, ...)` — 传入 `messageID=""` + `fp=nil`。DLQ 记录里 `MessageID / FileURL / FileExt / FileSize` 全空。
+
+**影响**：运维查 DLQ 排障 retry_exhausted 类记录时，只能通过 Kafka `Key`（原生是 messageID 字节）反查源，或去解 `Value` bytes JSON 找 messageID —— 不如同批次 `os_permanent`（正常 attemptOne 路径填 messageID+fp）好排障。回灌工具要多写一层解析。
+
+**严重性理由**：不是数据丢失（Key + Value 都在），但**运维体验下降 + DLQ record schema 一致性受损**。processBatch 层不解析 msg 是为了减少重复工作，可以接受，但这块**应加注释显式说明**"messageID/fp 空是有意为之，回灌用 Kafka Key 反查"。
+
+**建议修法**（二选一，任一 OK）：
+1. **(推荐)** 在 processBatch retry-exhaust 分支之前 lazy-unmarshal 一次拿 messageID/fp 传给 writeDLQ；避免每次 attemptOne 重复解析可以缓存在 batch 结构里（`batch[i].parsedMsg` 或类似）。
+2. 保持现状 + 在 dlq.go 加醒目注释 + writeDLQ 里 messageID 空时从 `m.Key` fallback 填 `MessageID: string(m.Key)`（Kafka key = messageID 是本项目约定）。
+
+---
+
+### §2.3 `internal/fileextract/download.go:180-184` `isPermanentDownloadErr` 保留字符串 `strings.Contains` 兜底，违背 P2-6 fix 声称
+
+**问题**：P2-6 commit message + doc v3 changelog #6 均声称"用 sentinel + errors.Is，无字符串耦合"。实际代码：
+```go
+if errors.Is(err, errCDNPermanent) {
+    return true
+}
+return strings.Contains(err.Error(), "cdn permanent status")
+```
+sentinel 优先 + 字符串兜底。注释说"兼容旧路径"，但整个 codebase 里现在只有 `tryFetch` 一处产生这类 err，且已改 sentinel — 没有"外部构造 err 字符串"的实际来源。
+
+**影响**：doc-code inconsistency（doc 说"重构风险已消除"，代码里字符串匹配依然是重构风险）。若未来有人重构 `errCDNPermanent.Error()` 的字符串（例如加 i18n），依赖字符串兜底的路径会静默把 4xx 归成 transient，就是 P2-6 声称已消除的 bug 复现。
+
+**严重性理由**：目前无实际 bug（sentinel 分支已覆盖所有生产路径），但**违背 P2-6 fix 的初衷 + doc/code 不一致**。属于代码卫生问题。
+
+**建议修法**：删掉 `strings.Contains` 兜底行，只留 sentinel 判断；本轮 test `TestIsPermanentDownloadErr_UsesSentinel` line 33-36 里"legacy string-form"这条 case 也一起删。或者，如果确有必要保留字符串兜底，请在 commit message / doc v3 changelog 里改口径为"sentinel 优先 + legacy 字符串兜底（future 可清）"。
+
+---
+
+### §2.4 `internal/esindex/scripted_upsert_test.go:74-98` `TestPreservePainless_ContainsAllPreservedPaths` 契约锁死方向弱、单向
+
+**问题**：契约 test 只按 `preservedFilePaths` 里每条 path 取叶字段名（"content" / "contentMeta"），断言 `strings.Contains(preservePainless, leaf)`。有两个弱点：
+- **假阳性风险**：叶字段名是通用英文词（"summary" / "content" / "meta"），可能凭空 match 到 script 里的 comment 或不相关代码，误 pass。
+- **单向锁死**：只检查"数组里的字段都在 script 里"，不检查"script 里 preserve 目标必须都在数组里"（有反向断言但只查了"payload" + "file" 顶层，粒度太粗）。若有人手工在 script 里加个 preserve `summary` 但没加到 `preservedFilePaths` 数组，test 会 pass。
+
+**影响**：contract test 的价值是"防漂移"，双向断言才是真的锁死。目前的 test 只挡"改数组不改 script"这一方向，反向不管。低概率但真会出现的 case：someone 加 script preserve field 忘记登记到数组 → 未来 review 那个字段是不是要保留时无源可查。
+
+**严重性理由**：不是当前 bug（当前 preserve 字段和数组完全对齐），是 test 质量问题。修复成本很低。
+
+**建议修法**：
+1. 反向断言：从 script 里抽出所有 `ctx._source.payload.file.<X>` 出现的 X（可以用简单 regex `ctx\._source\.payload\.file\.(\w+)`），要求每个 X 都是 `preservedFilePaths` 里某 path 的叶字段名。
+2. 或用更结构化的替代：把 `preservePainless` 参数化成 Go 模板，从 `preservedFilePaths` 生成，从根本上锁死（改动量大，权衡）。
+
+---
+
+### §2.5 `internal/fileextract/consumer.go:266-281` `attemptOne` 在 `ctx.Canceled` 时误分类为 `outcomeTransient`
+
+**问题**：当 ctx cancel 发生在 attemptOne 内部（例如 download 中 `select case <-ctx.Done()`），extractor 层返回 `ctx.Err()`；attemptOne line 266 判 err 非 nil，走 line 268 `errors.Is(err, errOSPermanent)` false → line 276 `errors.Is(err, errDocNotYet)` false → 落到 line 280 `return outcomeTransient, nil`。
+
+**影响**：
+- ctx.Canceled 被视为 transient → 该条目 `dispositions[i]` 保持 transient + `attempts[i]++`。
+- 下一轮 processBatch 开头 line 182 `ctx.Err() != nil` 检测到并 `return err`；Run 层 line 107 判 `ctx.Err() != nil` 返 nil 优雅退出。
+- **正确性无损**（不会 silent skip，未 commit 的 offset 保持未 commit，K8s 重启后从旧 offset 重取），但 metrics 层面 `attempts[i]++` 虚增；若 ctx cancel 恰好发生在最后一条消息、且这条一直被视为 transient 直到最终真的走完 max retries，会浪费 DLQ 空间。
+
+**严重性理由**：**不是数据丢失、不是 blocker**；是"ctx cancel 应尽早分流"的 nice-to-have。改动成本极小。
+
+**建议修法**：attemptOne 在检测 err 时先判 ctx.Err：
+```go
+if err != nil {
+    if ctx.Err() != nil {
+        return outcomeTransient, nil // 保持 disposition，让 processBatch 外层 ctx check 优雅退出
+        // 或者更明确：新增 outcomeCanceled 类型，让 processBatch 立刻 return nil
+    }
+    if errors.Is(err, errOSPermanent) { ... }
+    ...
+}
+```
+或添加 outcome case 显式处理 canceled。
+
+---
+
+### §2.6 `internal/fileextract/ssrf_test.go` 缺 IPv4-mapped IPv6 用例断言
+
+**问题**：`TestIsBlockedIP_CoversAllTargets` 只测了纯 IPv4 (`169.254.169.254`) 和纯 IPv6 (`fe80::1` / `fc00::1`) 场景。没测 IPv4-mapped-in-IPv6 形式（`::ffff:169.254.169.254` / `::ffff:10.0.0.1`）。
+
+**分析**：Go stdlib `net.IP.IsLinkLocalUnicast()` 内部先 `To4()`，所以 `::ffff:169.254.169.254` 会被判为 link-local → `isBlockedIP` 会返 true。**功能上是对的**。但没 test 覆盖，属于攻击面盲点：一旦 Go stdlib 行为变化（极小概率）或者未来自己重写 isBlockedIP 时不当心，会引入回归。
+
+**严重性理由**：**当前无 bug**（Go 行为正确），test 补充成本很低。
+
+**建议修法**：在 blocked 列表补 3-4 条 IPv4-mapped 用例（`::ffff:169.254.169.254`、`::ffff:10.0.0.1`、`::ffff:127.0.0.1`）+ 断言拦截。
+
+## §3 Nits（可选跟进）
+
+### §3.1 `internal/fileextract/backoff.go:37` `rand.Int63n` 无显式 seed
+
+Go 1.20+ 全局 rand 自动 seed，行为正确。已有 `//nolint:gosec` 注释说明"抖动非安全用途"。建议进一步注释一行"依赖 Go 1.20+ 自动 seed"，避免读者以为需要 seed。
+
+### §3.2 `internal/esindex/writer.go:336-344` `encodedSingleDocSize` 上限估算稍保守
+
+新估算公式 `80 + preservePainless_len + 2×docJSON + 120 + 2`；实际单 doc `_bulk` body 结构 `action_line + body_line` 约为 `50 + 60 + preservePainless_len + 2×docJSON`。估算比实际略大 (~100 bytes/doc)，会让 `subBatchEnd` 切子批稍激进（每子批少几条）。**不是 bug**，效率略降但保守方向正确。若关注可精细化到 `+ 50 + 60`（省 ~90 bytes overhead）。
+
+### §3.3 `internal/fileextract/consumer.go:298-308` `processOne` 兼容 wrapper 只供 test 用
+
+生产路径全走 processBatch，`processOne` 是老 test 兼容层（consumer_test.go 里断言）。commit 51a7e25 增改 210 行的 test 里若已经全用 processBatch，可以考虑删掉 `processOne` + `errTransientNeedsRetry` sentinel 收敛代码面。若保留请在注释里加一行"仅测试用，生产别调"（已经有类似措辞但可以更醒目）。
+
+### §3.4 `internal/esindex/writer.go:161-186` `preservePainless` script 常量的多行字符串反引号缩进
+
+script 里的 `if / else / def savedContent = null;` 块用 2-space 缩进但 Painless 支持任意空白 — 视觉上略乱，可以整成一致 2-space。**无功能影响**。
+
+## §4 v1.13 修复轮验收（3 blocker + 10 P2 逐条确认）
+
+| 编号 | 状态 | 证据 & 备注 |
+|---|---|---|
+| **Blocker #1 SSRF** | ✅ Confirmed | `ssrf.go:118-148` 双闸门（validateURL + ssrfRestrictedDialer + ssrfCheckRedirect）；`isBlockedIP` 覆盖 RFC1918/loopback/link-local/metadata/CGNAT/IPv6-ULA 全部；231 行 test 覆盖 scheme/host/direct IP/metadata/redirect；反面构造未突破。P2 见 §2.6（IPv4-mapped IPv6 test 补齐）。 |
+| **Blocker #2 in-place retry** | ✅ Confirmed | `consumer.go:172-243` state machine 正确；`decision.go:43-72` partitionCommitPoints 多分区独立前缀；410 行 retry_test.go 覆盖 transient→OK / retry_exhausted / 429 / os_permanent / 多分区独立 / DLQ 写失败 fatal / ctx cancel 快退。反面：offset 100/101/102 场景验证 commit 顺序单调。P2 见 §2.2（DLQ 缺 messageID）+ §2.5（ctx.Canceled 误分类）。 |
+| **Blocker #3 scripted_upsert** | ✅ Confirmed | `writer.go:132-186` script + retry_on_conflict=3；`writer.go:465-490` mapBulkResults 改 "update" key；218 行 scripted_upsert_test.go 覆盖 action 编码 / preserve script 常量 / derivatives / 老 "index" key 响应触发 transient / doc size 估算膨胀。反面：type=1 text 消息 doc 不会凭空生 payload.file；已存在 doc 保留 content/contentMeta 后 params.doc 全量替换正确。P2 见 §2.4（contract test 弱）。 |
+| **P2-1 429 → errOSTransient** | ✅ Confirmed | `oswriter.go:115-117`，位置在 `>= 500` 之前、`>= 400` catch-all 之前，顺序正确；`retry_test.go:173-198` 覆盖。 |
+| **P2-2 errOSPermanent → DLQ** | ✅ Confirmed | `consumer.go:268-275`，`ReasonOSPermanent` 常量在 `dlq.go:37`；`retry_test.go:200-223` 覆盖不重试 + DLQ + metric。 |
+| **P2-3 backfill DeadlineExceeded vs SIGTERM** | ✅ Confirmed | `filebackfill/runner.go:97-146` 三个 ctx check 点都区分 `DeadlineExceeded` → `ErrTimeoutIncomplete` vs `Canceled` → nil；`runner_test.go:278-303` 覆盖三条路径（HappyPath / Canceled / DeadlineExceeded / RealError）。 |
+| **P2-4 Tika io.LimitReader** | ✅ Confirmed | `tika.go:110-112`，上限 `maxContentBytes+4`；`p2_test.go:161-186` 用 100KB body + 1KB cfg 断言 truncate。 |
+| **P2-5 Truncated `*bool`** | ✅ Confirmed（部分） | `esindex/doc.go:154` 改为 `*bool`；`extractor.go:105` 传 `&truncated`；分析确认 nil 被 omitempty、非 nil (true/false) 都会 marshal 出来。**但缺一条显式回归 test**：`TestFileContentMeta_TruncatedFalseSerializes` 在 doc changelog 里提到但我在 test 文件里找不到（`p2_test.go` 里不覆盖此项 case，`file_content_test.go` 未 grep 到）；建议加一条断言 `json.Marshal(FileContentMeta{Truncated: &f})` 里 `"truncated":false` 显式出现。 |
+| **P2-6 sentinel errCDNPermanent** | ⚠️ Partial | sentinel 建立 + `isPermanentDownloadErr` 优先走 `errors.Is`；**但保留了 `strings.Contains` 兜底**，违背 P2-6 fix 声称的"无字符串耦合"。见 §2.3。 |
+| **P2-7 empty_extract TrimSpace** | ✅ Confirmed | `extractor.go:96-100` 用 `strings.TrimSpace(content) == ""`；`p2_test.go:48-106` 覆盖 4 case（空串/换行/空格/混合空白）+ 断言 OS 未 hit。 |
+| **P2-8 backfill scroll nextWithRetry** | ✅ Confirmed | `filebackfill/runner.go:154-176` bounded backoff 3 次（500ms→4s，指数）+ ctx aware；EOF/ctx err 直接返不 retry。运行时逻辑正确。**test 覆盖弱**：runner_test.go 里未见 nextWithRetry 专用 test（只有 real error propagate 的 TestRun_SourceRealError），建议补一条断言 "transient err retry 3 次后成功"。 |
+| **P2-9 Tika ctx-driven timeout** | ✅ Confirmed | `tika.go:80-82` per-request `context.WithTimeout(ctx, t.timeout)`；`tika.go:97-107` 通过 `parentCtx.Err() != nil` 区分 parent cancel vs per-request DeadlineExceeded；`p2_test.go:108-157` 覆盖两条路径（per-req timeout → errExtractTimeout；parent cancel → context.Canceled）。 |
+| **P2-10 file-extractor startup mapping-compat** | ✅ Confirmed | `cmd/file-extractor/main.go:62-97` 主流程前调 `AssertLiveMappingCompatible`；`esindex/mapping_compat.go:44-45` 已列 `payload.file.content` + `payload.file.contentMeta.extractedAt` 到 `requiredMappingFieldPaths`；缺字段 → loud crash 让 K8s 重启告警。 |
+| **CI Lint 16 issues** | ⏳ 未本地跑 | `defer func() { _ = resp.Body.Close() }()` 在 download.go/tika.go/source.go 里已加，符合 errcheck；其他 15 issues 未逐一 verify（工具需 `golangci-lint run --new-from-patch=<base>` 或 PR push 后看 Job）。建议 Max 侧 push 前本地跑一次 `golangci-lint run --timeout=5m ./...` 拿全量结果附 PR。 |
+
+## §5 亮点（不虚吹，≤5 条）
+
+1. **`decision.go` + `partitionCommitPoints`**（`consumer.go:230` 调用）：一步到位处理多分区 offset 独立推进，杜绝"分区 A 卡住时分区 B 的高 offset commit 越过 A 未终态 offset"的隐性丢消息，而不是先出简化单分区版本再迭代。fix-plan §8 #1 识别的问题在 Blocker #2 修复里直接解掉，认知负载低。
+2. **`ssrf.go` 双闸门 + `isBlockedIP` 显式列 CGNAT (100.64.0.0/10) + IPv6 ULA (fc00::/7)**：Go stdlib `IsPrivate()` 只覆盖 RFC 1918，作者显式扩展这两个 SSRF 高危段，覆盖 attacker 常用的绕过点。
+3. **`writer.go` `preservePainless` 用 `ctx.op == 'create'` 分流**：正确处理 `scripted_upsert` 语义（doc 不存在时 script 必须主动填 `ctx._source = params.doc`，否则会造 empty doc）；这是很容易踩坑的点。
+4. **`tika.go` P2-9 `parentCtx` vs `reqCtx` 区分**：在 err 分类里保留 `parentCtx` 引用来判 parent cancel，是 Go 里 ctx-driven timeout 的经典优雅写法。老代码用 `http.Client.Timeout` 是典型坑，这个 fix 从根子上处理。
+5. **`retry_test.go` `TestProcessBatch_OffsetPrefixCommit_101FailsFirstAttempt`**：显式构造 100/101/102 三条消息，101 前 2 次 transient 第 3 次 OK，断言"中间过程 commit 不越过 101、最终 commit 到 102"，直接对应 Blocker #2 的核心 fear scenario。
+
+## §6 未验证但 e2e 层需关注
+
+代码 review 只能确认代码路径，以下需要在 test / prod 环境跑一遍才能定论：
+
+1. **Painless script 在 OS 3.6 (dmwork-test/prod 实际部署版本) 的语法兼容性**
+   代码里的 script 用 `def / instanceof Map / .get() / new HashMap()` — 都是 Painless 官方支持语法。但**没有真跑一次 `_bulk` 验证 script cache hit、执行开销、`ctx.op` 分支正确工作**。建议 e2e：test 环境 mock 一条 message → 走 es-indexer 写入 → 再走 file-extractor partial update → 再让 es-indexer redeliver 同 _id → 断言 OS 里 payload.file.content 未被覆盖。
+
+2. **429 rate-limit 真触发路径**
+   代码里 `classifyOSErr` 加 429 分支，但 OS 什么时候返 429？需要压测（bulk 写入超过 `search.max_open_scroll_context` 或类似 threshold）观察真实响应。若从未真触发，P2-1 修的是"理论上正确的分类"，但触发条件未验。
+
+3. **SSRF metadata IP 真拦截**
+   test 里 mock resolver 返 IP + 走 dialer 层拒；生产 DNS 环境（DNS/host resolution 差异）、redirect chain 中间 CDN 302 到 metadata 域的真实 SSRF payload 未验。**建议**：test 环境部署后手工造一条 payload.file.url=`https://169.254.169.254/...` 消息进 Kafka，看 file-extractor 是否拒 + 走 download_failed DLQ。
+
+4. **Truncated *bool 清 stale true 的真回归**
+   代码分析确认 `*bool + omitempty` 的 marshal 行为正确，但缺一条 e2e：先写 truncated=true → 后重抽 truncated=false → 查 OS `_source` 确认 truncated 字段值确实变了（partial update deep merge 语义在 OS 3.6 上实际行为）。
+
+5. **backfill scroll TTL 5 min 在实际 17M docs 上是否够**
+   一批 500 doc × 50 RPS = 10s/batch，17M / 500 = 34K batch → 单机 Job 完整回填 ~95 hour；即使 scroll TTL 每次 continue 都续期，也需要长跑 Job 不 crash。建议 e2e 先跑一个小样本（10K docs）看 scroll 会不会中途过期。
+
+6. **retry_exhausted 长期 backoff 的 partition 阻塞影响**
+   MaxRetries=10 + base=1s max=60s → 单条最坏 ~10 min 阻塞该 partition 里后续 offset。若某 CDN URL 长期返 500 → 该分区 SLA 下降到 10 min/条。需要监控 metric 观察实际 retry_exhausted 触发频率是否可接受。
+
+## §7 Review 方法论
+
+**读取顺序**（约 75 min）：
+1. (5 min) `git log --stat` / `git show --stat` 摸清 5 commit 变更范围与文件行数分布，识别核心文件。
+2. (25 min) 并行读 Blocker 核心文件：`ssrf.go` + `consumer.go` + `decision.go` + `backoff.go` + `writer.go`(esindex) + `download.go`；每读完一段做反面构造思考（TOCTOU / silent skip / preserve edge case）。
+3. (15 min) 并行读 P2 相关：`oswriter.go` + `tika.go` + `extractor.go` + `dlq.go` + `mapping_compat.go` + `filebackfill/{runner,source}.go` + `cmd/file-extractor/main.go` + `esindex/doc.go`（FileContentMeta 定义）+ `config.go`。
+4. (15 min) 并行读关键 test：`retry_test.go` + `ssrf_test.go` + `scripted_upsert_test.go` + `p2_test.go` + `runner_test.go`；核对 test 覆盖 vs commit 声称。
+5. (5 min) `docs/file-content-indexing-implementation.md` v3 changelog 段 vs 代码实际状态对齐检查（识别 doc-code inconsistency）。
+6. (10 min) 综合分析 + 写本文档；反复推敲 §1 是否真"无严重"（若有 blocker 修复留 bug 不能 approve）。
+
+**跳过 / 未深读**：
+- `filebackfill/rate_limiter.go`（本轮未改）
+- `internal/consumer/*`（Blocker #2 pattern 源头，只对比结构不逐行读）
+- `esindex/{mapping/octo-message.json, buildraw.go}`（本轮未改）
+- 未跑 `go test ./...` 本地实测（信任 commit message 声称 37 test 全绿；生产 push 前 CI 会跑一遍）。
+- 未跑 `golangci-lint run`；CI Lint 16 issues 只按代码目视核对，未全量 verify。
+
+**反面构造 / 攻击面思考**（关键路径）：
+- SSRF：能否构造 URL 绕过双闸门？（scheme 大小写、URL encoding、redirect chain、DNS 双重返回、IPv4-mapped IPv6）— 全部未突破。
+- Blocker #2：能否构造 batch 让 partition silent skip 或永久阻塞？（transient 消息卡首、retry_exhausted 后 offset 越过、ctx cancel 时机、DLQ 写失败）— 全部收敛于 forced DLQ 或 fatal fast-return。
+- Blocker #3：能否构造 doc 让 script 抹掉不该抹的字段或凭空造字段？（type=1 无 file、type=8 首次上、type=8 redeliver）— 保留分支只在 saved 非 null 时触发，非 null 前提是原 doc 有 payload.file.content —— 逻辑闭合。
+
+---
+
+**最终判定**：**APPROVE WITH NITS** — 3 blocker 修复方向和执行都靠谱，无 push blocker。§2 六条 P2 建议 Max 派回 cc-octo 消化后再 push（10-30 min 工作量）；若时间紧可以 push GitHub 后在 PR review 里作为 comment 提出，本轮修复轮质量本身 sig-off。§6 e2e 未验点较多，push 后 test 环境部署 e2e 计划需 Max 拉齐。

--- a/docs/file-extractor-tool-comparison.md
+++ b/docs/file-extractor-tool-comparison.md
@@ -1,0 +1,368 @@
+# File Extractor Tool Comparison
+
+> Author: cc-octo · Date: 2026-06-30 · Status: Draft for review
+> Companion doc to `file-content-indexing-feasibility.md`（主文档 §5 抽取工具选型的深入版）
+> Scope: 只调研 + 写文档，不改代码 / commit / build。
+> 输入命题: 主文档 v1 钦定 Apache Tika 论证太薄；主人要求对比多方案后再定。
+
+---
+
+## 0. 结论（一句话 + 3 论据）
+
+**阶段 1 用 Apache Tika Server (HTTP sidecar 模式)，阶段 2 视扫描版 PDF 占比决定要不要引入 MinerU 兜底。**
+
+三论据：
+1. **本项目搜索目标是"关键词命中 + 短片段高亮"**（IK 分词器进倒排即可），不是"结构化 RAG / 表格结构复原"—— Tika 的"纯文本抽取"输出正好匹配需求；docling/MinerU 的"高保真 markdown + 表格结构"是过度投入
+2. **格式覆盖广度**：白名单 19 种可抽取格式（pdf/doc/docx/xls/xlsx/ppt/pptx/txt/csv/rtf/odt/ods/md/html/htm/json/xml/yaml/yml），Tika 一个引擎全覆盖，无需为 Office/纯文本各写一份适配层
+3. **JVM 成本可控**：Tika 3.x server 单副本 -Xmx1g，镜像 ~500MB (minimal) / ~1.5GB (full)，跑在独立 Deploy 里跟 file-extractor 主容器隔离，Tika OOM 只重启 sidecar 不影响主流
+
+**Tika 不合适的翻盘情形**（本项目未触发）：
+- 需要保留表格结构复原 → docling / MinerU 胜
+- 主体是扫描版中文 PDF → MinerU 胜（业务侧待实测占比）
+- 追求极致轻量镜像（< 100MB）→ Go 原生胜（但格式覆盖差，运维成本转嫁开发）
+
+---
+
+## 1. Apache Tika 深入
+
+### 1.1 部署三形态
+
+| 形态 | 描述 | 推荐? | 理由 |
+|---|---|---|---|
+| **(a) Tika Server (HTTP)** | `apache/tika:3.3.0.0` 镜像，`--server` 模式监听 9998，`PUT /tika` 上传 bytes 得纯文本 | ✅ **推荐** | 长驻 JVM 无冷启动、支持并发、健康检查简单、K8s sidecar 天然契合、失败隔离清楚 |
+| (b) Tika App CLI | 每次 fork `java -jar tika-app.jar`，短命进程 | ❌ | JVM 冷启动 1-2s，每份文件抽取成本高 3-5 倍；无并发；生产环境反模式 |
+| (c) Tika Core lib 嵌入 Go | JNI / gRPC bridge 直接调 tika-core | ❌ | Go 无 JNI 生态；起 gRPC bridge 等于自己造 (a) 的翻版；无价值 |
+
+**(a) 内部工作流**：
+```
+file-extractor (Go) --curl--> Tika Server (JVM sidecar, 9998)
+                              |
+                              +-- PDFParser (依赖 Apache PDFBox)
+                              +-- OOXMLParser (docx/xlsx/pptx)
+                              +-- OldExcelParser (xls, POI-HSSF)
+                              +-- HWPFParser (doc, POI-HWPF)
+                              +-- RTFParser (纯 Java)
+                              +-- TextExtractor (txt/csv/md)
+                              +-- HtmlParser (jsoup)
+                              +-- ODFParser (odt/ods)
+                              +-- (可选) TesseractOCRParser (OCR)
+```
+
+Sources: [apache/tika Docker Hub](https://hub.docker.com/r/apache/tika), [tika-docker GitHub](https://github.com/apache/tika-docker)
+
+### 1.2 格式覆盖真实清单（本项目白名单 19 种）
+
+| 扩展 | Tika 解析器 | 支持度 | 依赖 | 备注 |
+|---|---|---|---|---|
+| .pdf | PDFParser (Apache PDFBox 3.x) | ✅ | 无 | 中文需字体嵌入；扫描版需 OCR 见 §1.4 |
+| .doc | HWPFParser (Apache POI) | ✅ | 无 | OLE2 老格式，稳定 |
+| .docx | OOXMLParser (POI) | ✅ | 无 | 表格/文本混排 OK |
+| .xls | OldExcelParser (POI-HSSF) | ✅ | 无 | 老 xls |
+| .xlsx | OOXMLParser (POI) | ✅ | 无 | 大 xlsx 可能慢，见 §1.7 |
+| .ppt | HSLFParser (POI) | ✅ | 无 | |
+| .pptx | OOXMLParser (POI) | ✅ | 无 | |
+| .txt | TextExtractor | ✅ | 无 | 编码检测 (juniversalchardet)，UTF-8/GBK 自动识别 |
+| .csv | TextExtractor | ✅ | 无 | |
+| .rtf | RTFParser | ✅ | 无 | 纯 Java 实现 |
+| .odt / .ods | ODFParser | ✅ | 无 | OpenDocument |
+| .md | TextExtractor (fallback) | ⚠️ | 无 | Tika 不专门解 markdown，走纯文本读取，md 语法符号会保留 |
+| .html / .htm | HtmlParser (jsoup) | ✅ | 无 | 剥 tag 取纯文本 |
+| .json / .xml / .yaml / .yml | TextExtractor (fallback) | ⚠️ | 无 | 无语义解析，纯文本读取（对全文搜足够） |
+
+**结论**：19 种全覆盖，无缺口。⚠️ 标记的 5 种（md/json/xml/yaml/yml）是纯文本读取而非语义解析，对"关键词搜索"场景这是**优点不是缺点**（保留原始 token 可搜）。
+
+Sources: [Tika Supported Formats](https://tika.apache.org/3.3.0/formats.html)
+
+### 1.3 中文表现
+
+**已知问题（历史）**：
+- [TIKA-2080](https://issues.apache.org/jira/browse/TIKA-2080)：Tika 1.13 版本 PDFParser 对中日文有"每字符被替换为行首字符"的 bug — **已在 2.x/3.x 修复**，本项目用 3.3.0 不受影响
+- 字体嵌入问题：中文 PDF 若未嵌入 CJK 字体（少见），会出现乱码 unmapped Unicode。metadata 字段 `pdf:containsNonEmbeddedFont` + `pdf:overallPercentageUnmappedUnicodeChars` 可预检
+- 多层 PDF（图层叠加）文本顺序可能错乱 — 影响相邻字符组合，但**不影响关键词单个 token 命中**
+
+**结论**：日常业务 PDF（Office 导出、财报、合同、扫描版排版正常）Tika 3.x 表现可用。**扫描版 PDF 需要开 OCR**（默认关闭）。
+
+Sources: [TIKA-2080](https://issues.apache.org/jira/browse/TIKA-2080), [Tika Troubleshooting Wiki](https://cwiki.apache.org/confluence/display/TIKA/Troubleshooting+Tika), [Chinese PDF pain points](https://cwiki.apache.org/confluence/display/tika/ComparisonTikaAndPDFToText201811)
+
+### 1.4 加密 / 密码保护
+
+- `EncryptedDocumentException` 触发条件：
+  - PDF owner password / user password 保护
+  - Office 文档 (docx/xlsx/pptx) 打开密码
+  - 加密的 OOXML zip 包
+- **API 传密码**：Tika Server 支持 header `Password: <pwd>` 传解密密码；file-extractor 无法预知每个文件密码，实际使用中直接 catch 该异常 → DLQ `reason=encrypted`
+- Tika 客户端 Java API：`ParseContext.set(PasswordProvider.class, ...)`（本项目 Go 侧不直接用，走 HTTP header 兜底）
+
+Sources: [Tika PDF Password Protection](https://cwiki.apache.org/confluence/display/TIKA/PDFParser+(Apache+PDFBox))
+
+### 1.5 扫描版 PDF (OCR)
+
+**默认行为**：Tika **不做 OCR**，扫描版 PDF 抽取返回空串或极少文本
+**启用 OCR 需要**：
+- 用 `apache/tika:3.3.0.0-full` 镜像（预装 Tesseract 5.x + 语言包）
+- 环境变量 `TESSERACT_OCR_PATH` 指向 tesseract 二进制
+- 语言包需 `chi_sim`（简体）+ `chi_tra`（繁体）额外下载或 build 时装
+- Tika `OCR_STRATEGY` 可选：`AUTO / NO_OCR / OCR_ONLY / OCR_AND_TEXT_EXTRACTION`
+- 性能损耗：OCR 每页 ~1-3 秒（vs 无 OCR ~10ms/页），单机吞吐掉一个数量级
+
+**Tika + Tesseract 中文 OCR 实测口径未找到公开 benchmark**，只有 [个人 gist 示例](https://gist.github.com/Heilum/af7dcc1fa26762ea459648e4d6a68fd1) 证明技术可行
+
+**本项目建议**：阶段 1 用 minimal 镜像不装 OCR，扫描版 PDF 走 DLQ `reason=empty_extract`。阶段 2 根据业务侧扫描版占比决定是否切 full 镜像或走 MinerU 兜底（§4.4）。
+
+Sources: [Tika OCR docs](https://cwiki.apache.org/confluence/display/TIKA/TikaOCR), [TIKA-2844](https://issues.apache.org/jira/browse/TIKA-2844)
+
+### 1.6 性能基准
+
+**公开 benchmark 稀缺**（社区共识：Tika 性能强依赖文档类型，通用数字意义不大）
+
+**社区经验值**（未找到 2025 权威数字，标为**待实测**）：
+- 纯文本 (txt/md/json)：~500-1000 docs/s（IO 主导）
+- Office 简单文档 (docx <100KB)：~50-100 docs/s
+- PDF 10MB 无 OCR：~1-5 docs/s
+- PDF 扫描版 + OCR：~0.1-0.5 pages/s
+
+**本项目预估**：
+- 假设 QPS 峰值 100 docs/s（远超实际 IM 文件上传峰值）
+- Tika sidecar 单副本足够；如需扩容起 3 副本 = 300 docs/s buffer
+- **等 test 环境搭起后跑真实业务 PDF 拿实测数据**
+
+Sources: [CogStack tika-service benchmark notes](https://github.com/CogStack/tika-service/blob/master/README.md)
+
+### 1.7 JVM 依赖成本
+
+| 指标 | 值 | 备注 |
+|---|---|---|
+| 镜像大小 (minimal) | ~500-700MB | Tika 3.3.0.0 无 OCR / GDAL |
+| 镜像大小 (full) | ~1.5-2GB | 含 Tesseract + 部分语言包 |
+| 启动时间 | ~10-15s | JVM 冷启动 + Tika 初始化 |
+| 内存 baseline | ~300MB | 空载 JVM |
+| 推荐 -Xmx | 1g | 处理 100MB 上限文件；小文件场景可降到 512m |
+| 并发模型 | thread pool (默认 CPU × 2) | HTTP handler 每请求 1 线程 |
+| **重要 flag** | `--spawnChild` (2.x+ 默认开) | 抽取跑在 fork child JVM，父进程崩溃自恢复 |
+
+**OOM 兜底**：Tika 2.x+ 走 pipes-async 模式，单文件 OOM 只 kill child，不带崩 server。生产实践加健康检查清 `/tmp` 孤儿文件。
+
+Sources: [Apache mailing list on OOM best practices](https://lists.apache.org/thread/nsxz14twh7hq20dvcs2pvb311sho6gqk), [tongwang/tika-server tuning](https://hub.docker.com/r/tongwang/tika-server)
+
+### 1.8 稳定性坑（3 个真实生产事故 pattern）
+
+1. **MP4Parser OOM** — 视频文件抽 metadata 触发老 MP4 库 OOM，Tika team 已知计划替换。**缓解**：白名单不含 mp4（本项目白名单已排除媒体格式，天然免疫）
+2. **PDFBox 特定 PDF 无限循环** — 有些 malformed PDF 让 PDFBox 陷入循环，靠 Tika `--spawnChild` + tikaServerTaskTimeoutMillis 超时兜底
+3. **`/tmp` 磁盘塞满** — 大批量抽取产生临时文件，Tika 不总清理彻底；生产环境加 healthcheck 定期清 `/tmp` 或用 tmpfs
+
+Sources: [Apache Tika mailing list](https://lists.apache.org/thread/nsxz14twh7hq20dvcs2pvb311sho6gqk)
+
+---
+
+## 2. 候选方案对比
+
+### 2.1 Docling (IBM Research)
+
+**介绍**：IBM DS4SD 2024 年开源的文档转换框架，用 DocLayNet (layout) + TableFormer (table) 深度学习模型输出高保真 markdown。2025 年 10 月推出 Granite-Docling-258M VLM 模型，支持 Chinese 但**标注为 experimental**。2026 年初捐给 Linux Foundation。
+
+**部署形态**：Python venv，pip install docling（安装体积 ~1GB+ 含模型权重），无 GPU 也能跑（CPU 慢），跟 file-extractor 集成走 HTTP / subprocess CLI
+
+**集成方式**：`docling <input> --output md` CLI，或起 Python HTTP 服务 wrapper
+
+**中文实测**：Granite-Docling 中文标为 experimental，IBM 官方说明"not yet enterprise-validated"。Procycons 2025 benchmark 只测英文文档
+
+**性能**：1 页 ~6.28s，50 页 ~65s，**线性增长**（vs LlamaParse 6s 常数）；PDF 表格 94%+ 结构准确
+
+**适用性打分（本项目）**：3/5 — 输出质量高但**过度**投入（本项目搜索不需要 markdown 结构）+ 中文实验性 + Python 生态外挂
+
+Sources: [PDF Extraction Benchmark 2025](https://procycons.com/en/blogs/pdf-data-extraction-benchmark/), [Docling GitHub](https://github.com/docling-project/docling), [IBM Granite-Docling](https://www.ibm.com/new/announcements/granite-docling-end-to-end-document-conversion), [Docling arxiv paper](https://arxiv.org/html/2501.17887v1)
+
+---
+
+### 2.2 unstructured.io
+
+**介绍**：Python 库 + 商用 API，主打 RAG 数据管道，支持 64+ 文件类型 + 50+ source/destination connectors。定位是"一站式 ETL"而非"最精"
+
+**部署形态**：`pip install unstructured[all-docs]` 装全格式约 500MB；商用 Serverless API 起步 $1/1000 pages
+
+**集成方式**：Python HTTP wrapper，或调 Serverless API（云依赖）
+
+**中文实测**：文档未见专门中文 benchmark，Nov 2025 Unstructured 自家 benchmark 声称"format-agnostic table 0.844"，未拆分语言
+
+**性能**：Procycons 2025 评价"简单 table 100%，复杂 table 75%"，速度中等，需 post-processing
+
+**适用性打分（本项目）**：2/5 — 定位是"pipeline"，本项目已经用 Kafka 做 pipeline，不需要再套一层；商用 API 有云依赖不符本项目自建原则
+
+Sources: [Unstructured benchmark blog](https://unstructured.io/blog/unstructured-leads-in-document-parsing-quality-benchmarks-tell-the-full-story), [Procycons benchmark](https://procycons.com/en/blogs/pdf-data-extraction-benchmark/), [Chonkie/Docling/Unstructured comparison](https://www.thinkdeeply.ai/post/a-comparative-analysis-of-data-pre-processing-frameworks-for-retrieval-augmented-generation-chonkie)
+
+---
+
+### 2.3 MinerU (Shanghai AI Lab, OpenDataLab)
+
+**介绍**：上海人工智能实验室 OpenDataLab 团队开源的复杂 PDF 提取工具，含 PaddleOCR + StructEqTable + 自研 layout 模型。MinerU 2.5 (2025 年底) 是 1.2B VLM 参数 SOTA，在 OmniDocBench 上 90.67 分，超过 Gemini 2.5 Pro
+
+**部署形态**：Python + GPU 强烈推荐（A100 上 2.12 pages/s；CPU 慢 10 倍以上），pip install magic-pdf（安装体积 ~2GB 含模型），镜像 build 后 ~5-8GB
+
+**集成方式**：CLI (`magic-pdf convert`)，或起 HTTP wrapper；file-extractor 走 subprocess
+
+**中文实测**：**中文 CJK 场景王者**。Ocean-OCR benchmark 中文 F1 0.965、edit distance 0.082。社区共识"没有其他工具能在中文/日文/韩文 layout detection 上打过 MinerU"。表格结构复原用 TableMaster+StructEqTable，公式转 LaTeX。**限制**：初期只测中英，2025 扩展到 109 语种但非中英仍待验证；复杂表格行列偶有错
+
+**性能**：A100 GPU 上 2.12 pages/s；无 GPU 环境 ~0.1-0.5 pages/s（推理密集）
+
+**适用性打分（本项目）**：
+- 阶段 1: **1/5** — GPU 硬依赖 + 镜像巨大 + 输出高保真结构不匹配本项目"关键词命中"需求
+- 阶段 2（如果扫描版中文 PDF 占比 > 20%）: **5/5** — 中文扫描版无出其右
+
+Sources: [MinerU GitHub](https://github.com/opendatalab/MinerU), [MinerU2.5 arxiv](https://ar5iv.labs.arxiv.org/html/2409.18839), [MinerU 2.5 benchmark blog](https://neurohive.io/en/state-of-the-art/mineru2-5-open-source-1-2b-model-for-pdf-parsing-outperforms-gemini-2-5-pro-on-benchmarks/), [12 Open-Source PDF Parsing Tools Comparison](https://liduos.com/en/posts/ai-develope-tools-series-2-open-source-doucment-parsing/)
+
+---
+
+### 2.4 Go 原生组合
+
+**介绍**：Go 生态各格式独立库拼装。核心库：
+- `pdfcpu/pdfcpu` — PDF 操作，抽文本弱
+- `dslipak/pdf` / `ledongthuc/pdf` — 纯 Go PDF 文本抽取（中文支持一般）
+- `unidoc/unipdf` — 商业级 PDF 库（AGPL 或商业 license，本项目慎用）
+- `qax-os/excelize` — xlsx，很成熟
+- `richardlehane/mscfb` + `unidoc/unioffice` — Office 老格式
+- `blackfriday` — markdown 解析
+- `microcosm-cc/bluemonday` — HTML 剥 tag
+
+**部署形态**：编译进 file-extractor Go 二进制，无外部依赖，镜像 ~50MB
+
+**集成方式**：直接函数调用
+
+**中文实测**：`ledongthuc/pdf` 对中文 PDF 有已知问题（字体表映射不完整）。Office 系列成熟度尚可
+
+**适用性打分（本项目）**：2/5
+- 优点：镜像最小、无 JVM/Python、部署最快
+- 缺点：**格式覆盖靠拼装** — 19 种白名单需要至少 6-8 个库，每种维护 + 升级路径独立；PDF 中文支持不如 Tika PDFBox 成熟；老格式 (.doc/.xls/.ppt) 靠 unidoc 商业库或功能受限的 open source
+- 决策：**除非**"必须无 JVM/Python 依赖"的极端约束，否则不划算
+
+Sources: [ledongthuc/pdf](https://github.com/ledongthuc/pdf), [pdfcpu](https://github.com/pdfcpu/pdfcpu), [unidoc/unipdf license](https://github.com/unidoc/unipdf)
+
+---
+
+### 2.5 LibreOffice headless
+
+**介绍**：`soffice --headless --convert-to txt <file>`，粗暴但覆盖 Office 全家 + PDF 出 → txt
+
+**部署形态**：`libreoffice` 镜像 ~1.5GB，subprocess 调 `soffice` CLI
+
+**集成方式**：subprocess exec
+
+**中文实测**：LibreOffice 中文 PDF 转 txt 效果尚可，但 layout 复杂时顺序错乱严重
+
+**适用性打分（本项目）**：2/5 — 覆盖全但**每次 fork soffice 进程冷启动 2-5s**、并发差、稳定性坑多（LibreOffice server mode 也非常规选择）；不如 Tika 长驻 JVM
+
+Sources: [LibreOffice CLI docs](https://help.libreoffice.org/latest/en-US/text/shared/guide/start_parameters.html)
+
+---
+
+### 2.6 云 API 方案（一句话）
+
+- **AWS Textract / Azure Document Intelligence / 阿里云文档智能**：托管、按 page 计费、中文 OK，**本项目不用** — 数据出境合规 + 云 API 依赖，与"自建 IM"定位冲突
+
+---
+
+## 3. 决策矩阵
+
+五维打分（1=差 / 5=优）：
+
+| 候选 | 覆盖率 | 中文效果 | 部署难度 (低=好) | 资源占用 (低=好) | 维护成本 (低=好) | **综合** | **适用阶段** |
+|---|---|---|---|---|---|---|---|
+| **Apache Tika Server** | 5 | 4 | 4 | 3 | 4 | **20/25** | ✅ 阶段 1 |
+| Docling | 4 | 3 (实验) | 3 | 2 | 3 | 15/25 | 备选 |
+| unstructured.io | 5 | 3 | 3 | 2 | 3 | 16/25 | 不推荐 |
+| MinerU | 3 (PDF 强，其他弱) | 5 | 2 | 1 (GPU) | 2 | 13/25 | ✅ 阶段 2 兜底 |
+| Go 原生 | 3 | 2 | 5 | 5 | 2 | 17/25 | 特殊约束下备选 |
+| LibreOffice headless | 4 | 3 | 3 | 2 | 3 | 15/25 | 不推荐 |
+
+**分支决策**：
+- **默认路径**：Tika Server (§1)
+- **如果扫描版中文 PDF 占比 > 20%**：Tika (主) + MinerU (扫描版兜底，double-parse)
+- **如果部署环境完全无 JVM 允许**（不太可能）：Go 原生组合，接受覆盖率下降
+- **如果业务扩到 RAG / 表格结构复原需求**：切 Docling
+
+---
+
+## 4. MVP 阶段建议
+
+### 4.1 阶段 1 (本次上线，~2 周)
+- **主抽取引擎**：Apache Tika Server 3.3.0.0 minimal 镜像
+- **OCR**：不开
+- **形态**：file-extractor Go 主容器 + Tika JVM sidecar（同 Pod，emptyDir 共享临时盘）
+- **扫描版 PDF**：Tika 返空 → DLQ `reason=empty_extract`
+- **加密 PDF/Office**：`EncryptedDocumentException` → DLQ `reason=encrypted`（Java 侧异常 → HTTP 500 → Go 侧 catch reason 字符串写 DLQ）
+
+### 4.2 阶段 2 决策点
+上线 2 周后统计：
+- DLQ `reason=empty_extract` 占 type=8 总量比例
+- DLQ `reason=encrypted` 占比
+- 用户搜索中"预期能命中但没命中"投诉率
+
+**分支决策**：
+| 情况 | 动作 |
+|---|---|
+| `empty_extract` < 10% | 阶段 2 不做 OCR，成本收益比不合适 |
+| `empty_extract` 10-30% | 切 Tika full 镜像开 Tesseract OCR（成本 +内存 500MB + 抽取变慢） |
+| `empty_extract` > 30%，且业务侧确认多为中文扫描版 | 上 MinerU 作为**兜底 pipeline**：Tika 抽出为空的文件转发 MinerU 补抽 |
+| encrypted > 5% | 与 PRD 讨论"能否引导用户去密码 / 声明政策不搜密码文件" |
+
+### 4.3 双方案共存必要性
+- **不需要 Tika + docling 共存**：功能重叠，docling 不填 Tika 的坑
+- **可能需要 Tika + MinerU 共存**：MinerU 专攻扫描版中文，Tika 处理原生 PDF/Office，非重叠 — 值得做但**阶段 1 不做**，等实证数据
+
+### 4.4 切换成本
+- 阶段 1 → 阶段 2 只加 sidecar，不改 file-extractor 主流逻辑（多加一个 fallback client 调 MinerU 补抽）
+- mapping / reader 完全不动
+- Kafka topic / consumer group 完全不动
+- 只加 Deploy，切换是**可撤销**的（关掉 MinerU sidecar 回到纯 Tika 无副作用）
+
+---
+
+## 5. 未决问题（要主人 / Max 拍板）
+
+1. **prod type=8 里扫描版 PDF 占比未知** — 需 Max 从跳板抽 100 个真实业务 PDF，肉眼判"文本原生 vs 扫描"占比，决定阶段 2 是否上 MinerU
+2. **阶段 1 是否直接用 Tika full 镜像预留 OCR 能力** — full 镜像大 1GB 但开 OCR 只改 config；建议**用 minimal**，需要 OCR 时切镜像即可（K8s image rollout 分钟级）
+3. **file-extractor + Tika sidecar 部署单元** — 建议同 Pod 双容器（sidecar pattern，共享 emptyDir）；替代方案独立 Deploy + Service（Tika 服务化，可复用给其他消费方）—— 阶段 1 单 Pod 更省事
+
+---
+
+## 6. 给 Max 的回执清单
+
+- (a) **文档路径**：`~/Project/Mininglamp-OSS/octo-search-indexer/docs/file-extractor-tool-comparison.md`
+- (b) **最终推荐**：Apache Tika Server (HTTP sidecar 模式) 作为阶段 1 主引擎；阶段 2 视扫描版 PDF 实际占比引入 MinerU 兜底
+- (c) **3 个关键论据**：
+  1. 本项目搜索场景 = "关键词命中 + 短片段高亮"，Tika 纯文本输出正好匹配（docling/MinerU 的 markdown/表格复原是过度投入）
+  2. 19 种白名单格式一个引擎全覆盖，Go 原生组合需 6-8 库拼装维护成本失控
+  3. JVM 成本可控 — Tika 3.x sidecar minimal 500MB + Xmx 1g，独立容器隔离，OOM 只崩 sidecar
+- (d) **翻盘理由**：**没有发现 Tika 在本项目场景不合适的强证据**。MinerU 中文场景更强但 GPU 硬依赖 + 输出高保真结构不匹配需求；docling 中文标 experimental 不能用；unstructured 定位是 ETL pipeline，本项目已有 Kafka pipeline 不需要；Go 原生格式覆盖差不划算
+
+---
+
+## 附录 A: 参考资料汇总
+
+**Apache Tika**:
+- [apache/tika Docker Hub](https://hub.docker.com/r/apache/tika)
+- [tika-docker GitHub](https://github.com/apache/tika-docker)
+- [Tika Troubleshooting Wiki](https://cwiki.apache.org/confluence/display/TIKA/Troubleshooting+Tika)
+- [Tika PDF vs pdftotext Comparison](https://cwiki.apache.org/confluence/display/tika/ComparisonTikaAndPDFToText201811)
+- [TIKA-2080 Chinese PDF bug (fixed)](https://issues.apache.org/jira/browse/TIKA-2080)
+- [TIKA-2844 OCR strategy](https://issues.apache.org/jira/browse/TIKA-2844)
+- [Apache Tika OOM best practices mailing list](https://lists.apache.org/thread/nsxz14twh7hq20dvcs2pvb311sho6gqk)
+- [CogStack tika-service benchmark notes](https://github.com/CogStack/tika-service/blob/master/README.md)
+- [Chinese OCR with Tika + Tesseract gist](https://gist.github.com/Heilum/af7dcc1fa26762ea459648e4d6a68fd1)
+
+**Docling**:
+- [Docling GitHub](https://github.com/docling-project/docling)
+- [Docling arxiv paper](https://arxiv.org/html/2501.17887v1)
+- [IBM Granite-Docling announcement](https://www.ibm.com/new/announcements/granite-docling-end-to-end-document-conversion)
+- [Granite-Docling 258M InfoQ](https://www.infoq.com/news/2025/10/granite-docling-ibm/)
+
+**MinerU**:
+- [MinerU GitHub](https://github.com/opendatalab/MinerU)
+- [MinerU arxiv paper](https://ar5iv.labs.arxiv.org/html/2409.18839)
+- [MinerU 2.5 benchmark](https://neurohive.io/en/state-of-the-art/mineru2-5-open-source-1-2b-model-for-pdf-parsing-outperforms-gemini-2-5-pro-on-benchmarks/)
+
+**综合对比**:
+- [PDF Data Extraction Benchmark 2025 - Procycons](https://procycons.com/en/blogs/pdf-data-extraction-benchmark/)
+- [12 Open-Source PDF Parsing Tools Evaluated - Meursault](https://liduos.com/en/posts/ai-develope-tools-series-2-open-source-doucment-parsing/)
+- [Unstructured benchmark blog](https://unstructured.io/blog/unstructured-leads-in-document-parsing-quality-benchmarks-tell-the-full-story)
+- [Chonkie/Docling/Unstructured RAG comparison](https://www.thinkdeeply.ai/post/a-comparative-analysis-of-data-pre-processing-frameworks-for-retrieval-augmented-generation-chonkie)
+- [Best Open-Source PDF-to-Markdown Tools 2026](https://themenonlab.blog/blog/best-open-source-pdf-to-markdown-tools-2026)

--- a/internal/esindex/doc.go
+++ b/internal/esindex/doc.go
@@ -122,12 +122,45 @@ type VideoPayload struct {
 }
 
 // FilePayload 镜像 reader Doc.Payload.File（payload.file.{caption,name,extension} 可搜 + url/size）。
+//
+// v1.12：新增 Content + ContentMeta 两字段，配套 cmd/file-extractor 独立服务抽取的文件正文写入
+// （path: internal/fileextract → OS partial _update 只覆盖 payload.file.content + contentMeta，
+// 不动其他字段）。Content 走 mapping IK 分词器 + `_source.excludes` 排除 —— 搜命中走倒排，
+// _source 不膨胀（详见 internal/esindex/mapping/README.md v1.12）。
 type FilePayload struct {
-	URL       string `json:"url,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Caption   string `json:"caption,omitempty"`
-	Size      int64  `json:"size,omitempty"`
-	Extension string `json:"extension,omitempty"`
+	URL         string           `json:"url,omitempty"`
+	Name        string           `json:"name,omitempty"`
+	Caption     string           `json:"caption,omitempty"`
+	Size        int64            `json:"size,omitempty"`
+	Extension   string           `json:"extension,omitempty"`
+	Content     string           `json:"content,omitempty"`     // v1.12
+	ContentMeta *FileContentMeta `json:"contentMeta,omitempty"` // v1.12
+}
+
+// FileContentMeta 是 file-extractor 抽取过程元信息（v1.12）。指针类型 + omitempty 保证未抽取
+// 的 file doc 该子对象缺席，与 mapping "contentMeta" object 默认无子字段兼容（IDX-2）。
+//
+// 字段语义：
+//   - ExtractedAt: 抽取时刻（epoch second），对应 mapping date+epoch_second
+//   - Extractor:   抽取器标识字符串（例 "tika/3.3.0"），mapping keyword
+//   - Truncated:   Content 是否被截到 file-extractor 配置的 MaxContentBytes（256KB 默认）
+//   - ExtractMs:   Tika 抽取耗时（毫秒），mapping long
+//
+// v1.13 P2-5：Truncated 从 bool 改成 *bool，避免 omitempty + zero-value 使 truncated=true→false
+// 的重抽取无法把字段从 stale true 清除（partial _update 语义下 field 缺失 = OS 保留旧值）。
+// Round-4 nit TKT-5 (yujiawei review)：ExtractMs 同 pattern 改成 *int64，让 0ms 抽取
+// （极快或空 doc）能显式序列化 `"extractMs":0` 而非被 omitempty 剪掉；partial _update 可以
+// 把 stale 非零值清零。语义上区分"未设置"(nil) vs "本次抽取耗时 0ms"(*0)。
+// Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2)：Status + Reason tombstone 字段，permanent-fail
+// 时 file-extractor 写入 Status="unextractable" + Reason=<dlq_reason>，配合 backfill scroll
+// query `must_not term status=unextractable` 避免 rerun 重复 DLQ。成功抽取时不写这两个字段。
+type FileContentMeta struct {
+	ExtractedAt int64   `json:"extractedAt,omitempty"`
+	Extractor   string  `json:"extractor,omitempty"`
+	Truncated   *bool   `json:"truncated,omitempty"`
+	ExtractMs   *int64  `json:"extractMs,omitempty"` // Round-4 TKT-5：ptr matches Truncated pattern
+	Status      *string `json:"status,omitempty"`    // Round-3 Blocker B tombstone
+	Reason      *string `json:"reason,omitempty"`    // Round-3 Blocker B tombstone reason
 }
 
 // MergeForwardPayload 镜像 reader Doc.Payload.MergeForward（合并转发，type=11）。

--- a/internal/esindex/file_content_test.go
+++ b/internal/esindex/file_content_test.go
@@ -1,0 +1,175 @@
+package esindex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// boolPtr 是 v1.13 P2-5 后 Truncated 变 *bool 的构造辅助。
+func boolPtr(b bool) *bool { return &b }
+
+// int64Ptr 是 Round-4 TKT-5 后 ExtractMs 变 *int64 的构造辅助（同 boolPtr pattern）。
+func int64Ptr(v int64) *int64 { return &v }
+
+// TestFilePayload_ContentSerialization v1.12：FilePayload 带 Content + ContentMeta 后，
+// 序列化字段名/嵌套/类型逐字段对齐 mapping octo-message.json 的 payload.file 段。
+func TestFilePayload_ContentSerialization(t *testing.T) {
+	fp := &FilePayload{
+		URL:       "https://cdn.deepminer.com.cn/im-test-xming/chat/2026Q2.pdf",
+		Name:      "2026Q2.pdf",
+		Extension: ".pdf",
+		Size:      131072,
+		Content:   "第二季度营收增长 15%，净利润 5000 万元",
+		ContentMeta: &FileContentMeta{
+			ExtractedAt: 1727712345,
+			Extractor:   "tika/3.3.0",
+			Truncated:   nil, // v1.13 P2-5：*bool nil → 走 omitempty 不落盘（bool 零值语义）
+			ExtractMs:   int64Ptr(187),
+		},
+	}
+	b, err := json.Marshal(fp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	// 校验字段名严格对齐 mapping 声明（大小写/驼峰锁死）。
+	for _, want := range []string{
+		`"url":`, `"name":`, `"extension":`, `"size":`,
+		`"content":"第二季度营收增长 15%，净利润 5000 万元"`,
+		`"contentMeta":{`,
+		`"extractedAt":1727712345`,
+		`"extractor":"tika/3.3.0"`,
+		`"extractMs":187`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("marshal missing %q; got: %s", want, s)
+		}
+	}
+	// Truncated=nil 走 omitempty 不落盘。
+	if strings.Contains(s, `"truncated":`) {
+		t.Errorf("truncated=nil should be omitted by omitempty; got: %s", s)
+	}
+}
+
+// TestFilePayload_EmptyContentOmitted Content="" + ContentMeta=nil 时字段被 omitempty 剪掉，
+// 保证 file-extractor 未跑（或抽出空串走 DLQ 未回写）的 doc _source 里不出现 content/contentMeta。
+func TestFilePayload_EmptyContentOmitted(t *testing.T) {
+	fp := &FilePayload{
+		URL:       "https://cdn.deepminer.com.cn/x.pdf",
+		Name:      "x.pdf",
+		Extension: ".pdf",
+		Size:      1024,
+	}
+	b, err := json.Marshal(fp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if strings.Contains(s, `"content":`) {
+		t.Errorf("empty Content must be omitted; got: %s", s)
+	}
+	if strings.Contains(s, `"contentMeta":`) {
+		t.Errorf("nil ContentMeta must be omitted; got: %s", s)
+	}
+}
+
+// TestFileContentMeta_TruncatedTrue Truncated=&true 时字段落盘（非 nil ptr 不被 omitempty 剪掉），
+// 保证运维可以从 _source 里读到 "本条 content 被截断"。
+func TestFileContentMeta_TruncatedTrue(t *testing.T) {
+	m := &FileContentMeta{
+		ExtractedAt: 1,
+		Extractor:   "tika/3.3.0",
+		Truncated:   boolPtr(true),
+		ExtractMs:   int64Ptr(30000),
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"truncated":true`) {
+		t.Errorf("truncated=true must be present; got: %s", s)
+	}
+}
+
+// TestFileContentMeta_TruncatedFalseSerializes v1.13 P2-5 回归：*bool false 要显式落盘，
+// 让 partial _update 能把 stale true 清成 false（老 bool+omitempty 无法做到）。
+func TestFileContentMeta_TruncatedFalseSerializes(t *testing.T) {
+	m := &FileContentMeta{
+		ExtractedAt: 1,
+		Extractor:   "tika/3.3.0",
+		Truncated:   boolPtr(false),
+		ExtractMs:   int64Ptr(30000),
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"truncated":false`) {
+		t.Errorf("truncated=false must be explicitly serialized (P2-5), got: %s", s)
+	}
+}
+
+// TestFileContentMeta_RoundTrip 序列化/反序列化 round-trip：字段名/类型全对齐。
+func TestFileContentMeta_RoundTrip(t *testing.T) {
+	orig := &FileContentMeta{
+		ExtractedAt: 1727712345,
+		Extractor:   "tika/3.3.0",
+		Truncated:   boolPtr(true),
+		ExtractMs:   int64Ptr(187),
+	}
+	b, err := json.Marshal(orig)
+	if err != nil { // v1.13 CI lint errcheck
+		t.Fatalf("marshal: %v", err)
+	}
+	var back FileContentMeta
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// *bool / *int64 不能直接比较，逐字段核（v1.13 P2-5 + Round-4 TKT-5）
+	if back.ExtractedAt != orig.ExtractedAt || back.Extractor != orig.Extractor {
+		t.Errorf("round-trip mismatch on primitives: got %+v want %+v", back, *orig)
+	}
+	if back.Truncated == nil || orig.Truncated == nil || *back.Truncated != *orig.Truncated {
+		t.Errorf("round-trip mismatch on Truncated ptr: got %v want %v", back.Truncated, orig.Truncated)
+	}
+	if back.ExtractMs == nil || orig.ExtractMs == nil || *back.ExtractMs != *orig.ExtractMs {
+		t.Errorf("round-trip mismatch on ExtractMs ptr: got %v want %v", back.ExtractMs, orig.ExtractMs)
+	}
+}
+
+// TestFileContentMeta_ExtractMsZeroSerializes Round-4 TKT-5 回归：*int64(&0) 要显式落盘
+// `"extractMs":0`，让 partial _update 能把 stale 非零值清零（老 int64+omitempty 无法做到）。
+func TestFileContentMeta_ExtractMsZeroSerializes(t *testing.T) {
+	m := &FileContentMeta{
+		ExtractedAt: 1,
+		Extractor:   "tika/3.3.0",
+		ExtractMs:   int64Ptr(0),
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"extractMs":0`) {
+		t.Errorf("extractMs=0 must be explicitly serialized (TKT-5, same as Truncated *bool P2-5), got: %s", s)
+	}
+}
+
+// TestFileContentMeta_ExtractMsNilOmitted Round-4 TKT-5 回归：*int64 nil 走 omitempty
+// 不落盘（区分"未设置" vs "本次 0ms"）。
+func TestFileContentMeta_ExtractMsNilOmitted(t *testing.T) {
+	m := &FileContentMeta{
+		ExtractedAt: 1,
+		Extractor:   "tika/3.3.0",
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"extractMs":`) {
+		t.Errorf("nil ExtractMs must be omitted by omitempty; got: %s", string(b))
+	}
+}

--- a/internal/esindex/mapping/README.md
+++ b/internal/esindex/mapping/README.md
@@ -1,10 +1,80 @@
-# octo-message index mapping (v1.11 — reader-aligned)
+# octo-message index mapping (v1.12 — file content indexing)
 
 `octo-message.json` is the **canonical index mapping + analyzer** the `es-indexer`
 writes against, embedded into the binary (`//go:embed`). The index must be
 **pre-created manually** with this mapping (plus ISM/lifecycle policy, shards/replicas
 and aliases) — `esindex.EnsureIndex` only **verifies the index exists** at startup and
 **refuses to start** if it is missing (auto-create intentionally disabled, see issue #29).
+
+## v1.12 文件正文全文检索（file content indexing）
+
+v1.12 在 `payload.file` 下新增两个字段，配套 `cmd/file-extractor` 独立服务抽取的文件正文写入：
+
+- `payload.file.content` (text, IK 分词) — Tika 抽出的文件正文纯文本。用 IK 双分析器
+  保持与 `payload.text.content` 同口径（index-time `ik_max_word` / query-time `ik_smart`）。
+  搜索时走倒排索引直接命中并支持 highlight。
+  > **v1.13 变更**：早期版本曾用 `mappings._source.excludes: ["payload.file.content"]`
+  > 剔除该字段以节省 _source 体积，但与 v1.13 Blocker #3 scripted_upsert preserve 语义
+  > 冲突（script 从 `ctx._source` 读取 content 保留字段时永远读到 null → preserve 分支不生效
+  > → es-indexer redeliver 覆盖 file-extractor 写入的 content）。**已删除** `_source.excludes`
+  > 声明；`mapping_compat.go` 的 `forbiddenSourceExcludes` 启动断言额外拦截 live index 若
+  > 残留旧 excludes 的部署顺序错误（loud crash）。详见 `docs/file-content-indexing-*.md` v3。
+- `payload.file.contentMeta.{extractedAt, extractor, truncated, extractMs, status, reason}` (object) —
+  抽取元信息，便于运维观察抽取延迟 / 覆盖率 / 截断率 / **永久不可抽取 tombstone**。子字段类型：
+  - `extractedAt` — 抽取时刻 (epoch second, date)
+  - `extractor`   — 抽取器标识 (keyword, 如 "tika/3.3.0")
+  - `truncated`   — content 是否被截到 MaxContentBytes (boolean)
+  - `extractMs`   — Tika 抽取耗时 (long, 毫秒)
+  - `status`      — **v1.13 Round-3 Blocker B**：permanent-fail tombstone 标记 (keyword，
+     当前唯一取值 `"unextractable"`)。写入者为 `internal/fileextract/oswriter.go`
+     `WriteTombstone`；由 `internal/filebackfill/source.go` scroll query `must_not term
+     contentMeta.status=unextractable` 消费，防 backfill Job rerun 无限重复 DLQ 同一永久
+     失败文件。**只有 permanent 类 DLQ reason 才写**（见 `extractor.go` `tombstoneReasons`
+     白名单，Round-4 Should-Fix）；transient 类（`download_failed` / `extract_timeout`）
+     保留 backfill 兜底能力，不写 tombstone。
+  - `reason`      — **v1.13 Round-3 Blocker B**：status=`unextractable` 时携带的具体 DLQ
+     reason (keyword，如 `blacklist_ext` / `oversize` / `encrypted` / `empty_extract` /
+     `extract_error`)，便于运维分类查询与排障。
+
+写入契约：由独立 `cmd/file-extractor` 服务通过 OS `_update` partial update 只更新
+`payload.file.content` + `payload.file.contentMeta`，不动主 doc 其他字段（父 doc 由
+`cmd/es-indexer` 主流程写入）。file-extractor 消费同一 Kafka topic 但独立 consumer group
+`file-extractor`（不抢 es-indexer 位点）。
+
+> **v1.13 Round-3 Blocker A**：`cmd/es-indexer` 主写入路径从 `_bulk index` 改为
+> `_bulk update + scripted_upsert`（`retry_on_conflict=3`）以保留 file-extractor 的写入
+> 字段；`isPermanentStatus` 已把 409 `version_conflict` 归为 transient（并发写者耗尽内部
+> retry 后仍返 409 时由 caller 重试，不再 silent 甩 DLQ）。
+
+> `payload.file.content` + `payload.file.contentMeta.{extractedAt, status, reason}`
+> 都已纳入 `mapping_compat.go` 启动断言集（fail-closed），live mapping 缺字段 or
+> `_source.excludes` 残留旧配置直接拒启动 loud crash。
+
+**⚠️ 不可逆警告**：`PUT _mapping` 添加 `payload.file.content` + `contentMeta.*` 字段后**不可逆**
+——OS 3.x mapping 字段只能通过 reindex + 切换 alias 才能移除。合并前 sig-off 意味着接受
+该单向决策。详见 `docs/file-content-indexing-feasibility.md` v2 §7 / §5 回滚方案。
+
+**部署 runbook**：live index 若已有旧 `_source.excludes: ["payload.file.content"]`（v1.12 版
+mapping），必须在滚 v1.13+ pod **之前** admin `PUT _mapping` 清 excludes + 加
+`contentMeta.status/reason` 字段，否则 `AssertLiveMappingCompatible` loud crash 拒启动
+（feature 非 bug）。两处 mapping 变动 idempotent + reversible，合并成一次 PUT 更清爽：
+
+```json
+PUT /octo-message/_mapping
+{
+  "_source": { "excludes": [] },
+  "properties": {
+    "payload": { "properties": { "file": { "properties": { "contentMeta": {
+      "properties": {
+        "status": { "type": "keyword", "ignore_above": 32 },
+        "reason": { "type": "keyword", "ignore_above": 64 }
+      }
+    }}}}}
+  }
+}
+```
+
+详见 `docs/file-content-indexing-feasibility.md`（v2 §7）+ `docs/file-content-indexing-implementation.md`（v2）+ `docs/file-extractor-tool-comparison.md`（Tika 选型论证）。
 
 ## v1.11 subSeq 排序 tiebreaker（配套 B2 虚拟子文档）
 

--- a/internal/esindex/mapping/octo-message.json
+++ b/internal/esindex/mapping/octo-message.json
@@ -79,7 +79,19 @@
               "name":      { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
               "caption":   { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
               "size":      { "type": "long" },
-              "extension": { "type": "keyword", "ignore_above": 32 }
+              "extension": { "type": "keyword", "ignore_above": 32 },
+              "content":   { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
+              "contentMeta": {
+                "type": "object",
+                "properties": {
+                  "extractedAt": { "type": "date", "format": "epoch_second" },
+                  "extractor":   { "type": "keyword", "ignore_above": 32 },
+                  "truncated":   { "type": "boolean" },
+                  "extractMs":   { "type": "long" },
+                  "status":      { "type": "keyword", "ignore_above": 32 },
+                  "reason":      { "type": "keyword", "ignore_above": 64 }
+                }
+              }
             }
           },
           "mergeForward": {

--- a/internal/esindex/mapping_compat.go
+++ b/internal/esindex/mapping_compat.go
@@ -36,6 +36,20 @@ var requiredMappingFieldPaths = []string{
 	"virtual",
 	// v1.11：subSeq 排序第三键 tiebreaker（search_after 不丢同 tuple 兄弟）。
 	"subSeq",
+	// v1.12：文件正文全文检索（file content indexing）。
+	// - payload.file.content 是 file-extractor 独立服务通过 OS _update partial 写入的字段。
+	// - payload.file.contentMeta.extractedAt 采样 contentMeta object 一个子字段代表整个对象
+	//   （flatten 只到 leaf field，逐 leaf 断言过重；断言存在 extractedAt 即证 contentMeta object
+	//   已声明 properties）。
+	"payload.file.content",
+	"payload.file.contentMeta.extractedAt",
+	// Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2)：contentMeta 新增 status + reason 字段供
+	// permanent-fail tombstone 写入（extractor 层，dlqReason 非空时写 status="unextractable"）。
+	// 与 backfill source.go scroll query `must_not term status=unextractable` 配合，防 rerun
+	// 重复 DLQ 已知永久失败文件。mapping 缺这两字段则 dynamic:strict 会 4xx 拒 tombstone 写入
+	// → 启动期 loud crash 让运维先 PUT mapping 再滚 pod。
+	"payload.file.contentMeta.status",
+	"payload.file.contentMeta.reason",
 }
 
 // requiredDisabledObjectPaths 是必须以 enabled:false object 形态存在的留底字段（payloadRaw）。
@@ -43,13 +57,33 @@ var requiredMappingFieldPaths = []string{
 // 存在该键且 enabled==false」断言。
 var requiredDisabledObjectPaths = []string{"payloadRaw"}
 
+// forbiddenSourceExcludes 是 live mapping `_source.excludes` **不能包含**的字段路径。
+//
+// 🔴 v1.13 Blocker #3 复发教训：老 mapping 曾写 `"_source": {"excludes": ["payload.file.content"]}`
+// 剔除 content 从 `_source`。但 v1.13 Blocker #3 修复引入 scripted_upsert Painless script 从
+// `ctx._source.payload.file.content` 读**已存在的 content** 做 preserve —— 字段被 excludes 剔除
+// 后 `ctx._source` 里永远读到 null，preserve 分支永不执行，redeliver 时 content 仍被覆盖。
+// 修复方向：mapping 去掉 excludes（本 embed mapping 已删）+ 本断言 fail-closed 拦住 live index
+// 尚残留的旧 excludes（deployed mapping 若未同步更新会被启动期 loud crash 挡住）。
+//
+// 未来 file-extractor 扩 preserve 字段时**同步扩本清单**：任何 preservedFilePaths 里的路径都必须
+// 保证不被 `_source.excludes` 剔除，否则 scripted_upsert preserve 语义直接失效。
+var forbiddenSourceExcludes = []string{
+	"payload.file.content",
+	"payload.file.contentMeta",
+}
+
 // AssertLiveMappingCompatible 启动期 fail-closed 断言：GET 目标索引 live mapping，校验本期所有
 // 新字段路径齐备（可索引字段 + payloadRaw enabled:false object）。缺任一 → 返回 error，调用方
 // 据此拒启动（loud crash），绝不静默向 dynamic:strict 索引灌 4xx。
 //
-// 🔴 与 EnsureIndex 的存在性校验**互相独立、不打架**（eng-review §4 额外发现）：EnsureIndex 只判
-// 索引是否存在（存在即放行，缺失则拒启动）；本断言只校验**字段路径齐备**，缺字段才 loud crash。
-// 即「索引存在」放行，「字段缺失」才拒启动——二者方向不冲突。
+// v1.13 Blocker #3 复发 fix（P2-2）：增加 `_source.excludes` 校验——若 live mapping 里 excludes
+// 包含 forbiddenSourceExcludes 任一路径（scripted_upsert preserve 依赖字段），loud crash。
+//
+// 🔴 与 EnsureIndex 的存在性校验**互相独立、不打架**（eng-review §4 额外发现 + PR #29 fail-fast）：
+// EnsureIndex 只判索引是否存在（存在即放行，缺失则拒启动）；本断言只校验**字段路径齐备 +
+// _source.excludes 干净**，缺字段 or excludes 污染才 loud crash。即「索引存在」放行，
+// 「字段缺失 / excludes 挡 preserve」才拒启动——二者方向不冲突。
 func (w *osWriter) AssertLiveMappingCompatible(ctx context.Context) error {
 	return assertLiveMappingCompatible(ctx, w.client, w.index)
 }
@@ -92,13 +126,50 @@ func assertLiveMappingCompatible(ctx context.Context, client *opensearchapi.Clie
 			missing = append(missing, p+" (enabled:false object)")
 		}
 	}
-	if len(missing) > 0 {
+	// v1.13 Blocker #3 复发 fix (P2-2)：校验 `_source.excludes` **不含**保留字段路径。
+	// live mapping 若残留旧 excludes（部署未同步），scripted_upsert preserve 会从 ctx._source 读到
+	// null → preserve 失效 → redeliver 覆盖 file-extractor 写的字段。loud crash 拦下。
+	var polluted []string
+	for _, p := range forbiddenSourceExcludes {
+		if sourceExcludesContains(entry.Mappings, p) {
+			polluted = append(polluted, p)
+		}
+	}
+	if len(missing) > 0 || len(polluted) > 0 {
 		sort.Strings(missing)
-		return fmt.Errorf("esindex: mapping-compat FAILED for index %q — live mapping is missing required field paths %v; "+
-			"run `make migrate-forward` to add them before starting (refusing to ingest into a dynamic:strict index that "+
-			"would 4xx every bulk item)", index, missing)
+		sort.Strings(polluted)
+		msg := fmt.Sprintf("esindex: mapping-compat FAILED for index %q", index)
+		if len(missing) > 0 {
+			msg += fmt.Sprintf(" — missing required field paths %v", missing)
+		}
+		if len(polluted) > 0 {
+			msg += fmt.Sprintf(" — _source.excludes contains %v which breaks scripted_upsert preserve "+
+				"(Blocker #3 revive; run migrate-forward to remove these excludes)", polluted)
+		}
+		msg += "; refusing to ingest into a mis-configured index"
+		return fmt.Errorf("%s", msg)
 	}
 	return nil
+}
+
+// sourceExcludesContains 报告 live mapping 的 `_source.excludes` 数组里是否含 path。
+// mappings 是 `client.Indices.Mapping.Get` 返回的 entry.Mappings 原始 JSON（顶层是 mappings 对象），
+// 我们只关心 `_source.excludes` 数组是否含指定字段路径。excludes 缺失（未设 _source）时返 false。
+func sourceExcludesContains(mappings json.RawMessage, path string) bool {
+	var top struct {
+		Source struct {
+			Excludes []string `json:"excludes"`
+		} `json:"_source"`
+	}
+	if err := json.Unmarshal(mappings, &top); err != nil {
+		return false
+	}
+	for _, e := range top.Source.Excludes {
+		if e == path {
+			return true
+		}
+	}
+	return false
 }
 
 // mappingNode 是 OS mapping 树的最小递归形态：一个节点可能有 properties（子字段）、

--- a/internal/esindex/mapping_compat_test.go
+++ b/internal/esindex/mapping_compat_test.go
@@ -115,3 +115,255 @@ func TestMappingCompat_PayloadRawMustBeDisabled(t *testing.T) {
 		t.Fatal("payloadRaw declared as an enabled object must FAIL (must be enabled:false BLOB)")
 	}
 }
+
+// TestMappingCompat_MissingFileContentFails v1.12：live mapping 缺 payload.file.content →
+// 断言失败（保证 file-extractor 写入前 live mapping 已升级）。
+func TestMappingCompat_MissingFileContentFails(t *testing.T) {
+	// 完整 v1.11 mapping（含 payloadRaw + mergeForward + richText + virtual/subSeq）+
+	// payload.file 只声明 v1.11 之前 5 字段，**缺** content + contentMeta。
+	props := `{
+		"messageId":{"type":"long"},
+		"parentMessageId":{"type":"long"},
+		"parentPayloadType":{"type":"integer"},
+		"virtual":{"type":"boolean"},
+		"subSeq":{"type":"integer"},
+		"payload":{"type":"object","properties":{
+			"type":{"type":"integer"},
+			"file":{"type":"object","properties":{
+				"url":{"type":"keyword"},"name":{"type":"text"},"caption":{"type":"text"},
+				"size":{"type":"long"},"extension":{"type":"keyword"}}},
+			"mergeForward":{"type":"object","properties":{"msgs":{"type":"object","properties":{
+				"from":{"type":"keyword"},"timestamp":{"type":"date","format":"epoch_second"}}}}},
+			"richText":{"type":"object","properties":{"searchText":{"type":"text"}}}
+		}},
+		"payloadRaw":{"type":"object","enabled":false}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "payload.file.content") {
+		t.Fatalf("missing payload.file.content must fail naming the path, got %v", err)
+	}
+}
+
+// TestMappingCompat_MissingFileContentMetaFails v1.12：live mapping 有 content 但缺 contentMeta.extractedAt
+// → 断言失败（保证 contentMeta object 已声明 properties，file-extractor 才能写 extractedAt/extractor/etc.）。
+func TestMappingCompat_MissingFileContentMetaFails(t *testing.T) {
+	props := `{
+		"messageId":{"type":"long"},
+		"parentMessageId":{"type":"long"},
+		"parentPayloadType":{"type":"integer"},
+		"virtual":{"type":"boolean"},
+		"subSeq":{"type":"integer"},
+		"payload":{"type":"object","properties":{
+			"type":{"type":"integer"},
+			"file":{"type":"object","properties":{
+				"url":{"type":"keyword"},"name":{"type":"text"},"caption":{"type":"text"},
+				"size":{"type":"long"},"extension":{"type":"keyword"},
+				"content":{"type":"text"}}},
+			"mergeForward":{"type":"object","properties":{"msgs":{"type":"object","properties":{
+				"from":{"type":"keyword"},"timestamp":{"type":"date","format":"epoch_second"}}}}},
+			"richText":{"type":"object","properties":{"searchText":{"type":"text"}}}
+		}},
+		"payloadRaw":{"type":"object","enabled":false}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "payload.file.contentMeta.extractedAt") {
+		t.Fatalf("missing payload.file.contentMeta.extractedAt must fail naming the path, got %v", err)
+	}
+}
+
+// TestRequiredMappingFieldPaths_IncludesV112Fields v1.12：明确覆盖 requiredMappingFieldPaths
+// 常量包含新加两条路径（配 IDX-2 加字段动作 + IDX-4 file-extractor 上线前置校验）。
+func TestRequiredMappingFieldPaths_IncludesV112Fields(t *testing.T) {
+	want := map[string]bool{
+		"payload.file.content":                 true,
+		"payload.file.contentMeta.extractedAt": true,
+	}
+	found := map[string]bool{}
+	for _, p := range requiredMappingFieldPaths {
+		if want[p] {
+			found[p] = true
+		}
+	}
+	for p := range want {
+		if !found[p] {
+			t.Errorf("requiredMappingFieldPaths missing v1.12 path %q", p)
+		}
+	}
+}
+
+// liveMappingBodyWithExcludes 包装 properties + _source.excludes（v1.13 Blocker #3 复发回归）。
+func liveMappingBodyWithExcludes(t *testing.T, propsJSON string, excludes []string) string {
+	t.Helper()
+	excJSON, err := json.Marshal(excludes)
+	if err != nil {
+		t.Fatalf("marshal excludes: %v", err)
+	}
+	return `{"octo-message":{"mappings":{"dynamic":"strict","_source":{"excludes":` + string(excJSON) + `},"properties":` + propsJSON + `}}}`
+}
+
+// TestMappingCompat_SourceExcludesContentFails 🔴 v1.13 Blocker #3 复发回归 (P2-2)：live mapping
+// `_source.excludes` 里含 payload.file.content → scripted_upsert preserve 语义失效
+// （script 从 ctx._source 读永远 null）→ AssertLiveMappingCompatible 必须 loud crash。
+func TestMappingCompat_SourceExcludesContentFails(t *testing.T) {
+	var embedded struct {
+		Mappings struct {
+			Properties json.RawMessage `json:"properties"`
+		} `json:"mappings"`
+	}
+	if err := json.Unmarshal(IndexMappingJSON(), &embedded); err != nil {
+		t.Fatalf("parse embedded mapping: %v", err)
+	}
+	rt := &mappingTransport{body: liveMappingBodyWithExcludes(t, string(embedded.Mappings.Properties), []string{"payload.file.content"})}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil {
+		t.Fatal("expected loud crash for _source.excludes containing payload.file.content, got nil")
+	}
+	if !strings.Contains(err.Error(), "_source.excludes contains") {
+		t.Errorf("error must mention _source.excludes pollution, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "payload.file.content") {
+		t.Errorf("error must name the offending path, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Blocker #3 revive") {
+		t.Errorf("error must reference Blocker #3 revive for operator context, got %v", err)
+	}
+}
+
+// TestMappingCompat_SourceExcludesContentMetaFails 同上但针对 contentMeta（forbiddenSourceExcludes
+// 覆盖 preservedFilePaths 全集，防漂移）。
+func TestMappingCompat_SourceExcludesContentMetaFails(t *testing.T) {
+	var embedded struct {
+		Mappings struct {
+			Properties json.RawMessage `json:"properties"`
+		} `json:"mappings"`
+	}
+	if err := json.Unmarshal(IndexMappingJSON(), &embedded); err != nil {
+		t.Fatalf("parse embedded mapping: %v", err)
+	}
+	rt := &mappingTransport{body: liveMappingBodyWithExcludes(t, string(embedded.Mappings.Properties), []string{"payload.file.contentMeta"})}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "payload.file.contentMeta") {
+		t.Fatalf("expected loud crash for excludes containing contentMeta, got %v", err)
+	}
+}
+
+// TestMappingCompat_SourceExcludesUnrelatedPasses excludes 里含**其他**未在 forbiddenSourceExcludes
+// 里的字段（未来若加过滤字段）不阻止启动。
+func TestMappingCompat_SourceExcludesUnrelatedPasses(t *testing.T) {
+	var embedded struct {
+		Mappings struct {
+			Properties json.RawMessage `json:"properties"`
+		} `json:"mappings"`
+	}
+	if err := json.Unmarshal(IndexMappingJSON(), &embedded); err != nil {
+		t.Fatalf("parse embedded mapping: %v", err)
+	}
+	rt := &mappingTransport{body: liveMappingBodyWithExcludes(t, string(embedded.Mappings.Properties), []string{"someOtherField"})}
+	w := mappingWriter(t, rt)
+	if err := w.AssertLiveMappingCompatible(context.Background()); err != nil {
+		t.Fatalf("unrelated excludes must not block, got %v", err)
+	}
+}
+
+// TestMappingCompat_ForbiddenExcludesCoversPreservedPaths **契约锁死**：forbiddenSourceExcludes
+// 必须覆盖 preservedFilePaths 全集。future 加 preserve 字段时不更新 forbidden 列表 → CI 挂。
+func TestMappingCompat_ForbiddenExcludesCoversPreservedPaths(t *testing.T) {
+	forbidden := make(map[string]bool, len(forbiddenSourceExcludes))
+	for _, p := range forbiddenSourceExcludes {
+		forbidden[p] = true
+	}
+	for _, p := range preservedFilePaths {
+		if !forbidden[p] {
+			t.Errorf("preservedFilePaths %q must also be in forbiddenSourceExcludes (else scripted_upsert preserve silently fails)", p)
+		}
+	}
+}
+
+// TestEmbeddedMapping_NoSourceExcludes 内嵌 mapping 本身**不能**再声明 `_source.excludes`
+// （Blocker #3 复发 fix：已彻底移除该配置；防未来某人无意加回）。
+func TestEmbeddedMapping_NoSourceExcludes(t *testing.T) {
+	var top struct {
+		Mappings struct {
+			Source *struct {
+				Excludes []string `json:"excludes"`
+			} `json:"_source,omitempty"`
+		} `json:"mappings"`
+	}
+	if err := json.Unmarshal(IndexMappingJSON(), &top); err != nil {
+		t.Fatalf("parse embedded mapping: %v", err)
+	}
+	if top.Mappings.Source != nil && len(top.Mappings.Source.Excludes) > 0 {
+		t.Fatalf("embedded mapping must NOT declare _source.excludes (Blocker #3 revive gate); got %v", top.Mappings.Source.Excludes)
+	}
+}
+
+// TestMappingCompat_MissingTombstoneStatusFails 🔴 Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2)：
+// live mapping 缺 payload.file.contentMeta.status → tombstone 写入会因 dynamic:strict 4xx →
+// permanent-fail 文件无 tombstone → backfill rerun 重复 DLQ。启动期 loud crash 拦下部署顺序错。
+func TestMappingCompat_MissingTombstoneStatusFails(t *testing.T) {
+	// 含所有必需字段 **except** contentMeta.status
+	props := `{
+		"messageId":{"type":"long"},
+		"channelId":{"type":"keyword"},
+		"timestamp":{"type":"date","format":"epoch_second"},
+		"parentMessageId":{"type":"long"},
+		"parentPayloadType":{"type":"integer"},
+		"virtual":{"type":"boolean"},
+		"subSeq":{"type":"integer"},
+		"payload":{"properties":{
+			"mergeForward":{"properties":{"msgs":{"properties":{"from":{"type":"keyword"},"timestamp":{"type":"date"}}}}},
+			"richText":{"properties":{"searchText":{"type":"text"}}},
+			"file":{"properties":{
+				"content":{"type":"text"},
+				"contentMeta":{"properties":{
+					"extractedAt":{"type":"date"},
+					"reason":{"type":"keyword"}
+				}}
+			}}
+		}},
+		"payloadRaw":{"enabled":false,"type":"object"}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "payload.file.contentMeta.status") {
+		t.Fatalf("expected loud crash naming missing contentMeta.status field, got %v", err)
+	}
+}
+
+// TestMappingCompat_MissingTombstoneReasonFails 同上但缺 contentMeta.reason。
+func TestMappingCompat_MissingTombstoneReasonFails(t *testing.T) {
+	props := `{
+		"messageId":{"type":"long"},
+		"channelId":{"type":"keyword"},
+		"timestamp":{"type":"date","format":"epoch_second"},
+		"parentMessageId":{"type":"long"},
+		"parentPayloadType":{"type":"integer"},
+		"virtual":{"type":"boolean"},
+		"subSeq":{"type":"integer"},
+		"payload":{"properties":{
+			"mergeForward":{"properties":{"msgs":{"properties":{"from":{"type":"keyword"},"timestamp":{"type":"date"}}}}},
+			"richText":{"properties":{"searchText":{"type":"text"}}},
+			"file":{"properties":{
+				"content":{"type":"text"},
+				"contentMeta":{"properties":{
+					"extractedAt":{"type":"date"},
+					"status":{"type":"keyword"}
+				}}
+			}}
+		}},
+		"payloadRaw":{"enabled":false,"type":"object"}
+	}`
+	rt := &mappingTransport{body: liveMappingBody(props)}
+	w := mappingWriter(t, rt)
+	err := w.AssertLiveMappingCompatible(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "payload.file.contentMeta.reason") {
+		t.Fatalf("expected loud crash naming missing contentMeta.reason field, got %v", err)
+	}
+}

--- a/internal/esindex/richtext_derive_test.go
+++ b/internal/esindex/richtext_derive_test.go
@@ -304,12 +304,13 @@ func TestRichTextDerivatives_ClampOversizeWidthHeight(t *testing.T) {
 	}
 }
 
-// mkBulkResp 构造一个 _bulk 响应（每个 status 一项 index action）。
+// mkBulkResp 构造一个 _bulk 响应（每个 status 一项 update action）。
+// v1.13：动作行从 index 换 update（Blocker #3 scripted_upsert fix）。
 func mkBulkResp(statuses ...int) *opensearchapi.BulkResp {
 	resp := &opensearchapi.BulkResp{}
 	for _, st := range statuses {
 		item := opensearchapi.BulkRespItem{Status: st}
-		resp.Items = append(resp.Items, map[string]opensearchapi.BulkRespItem{"index": item})
+		resp.Items = append(resp.Items, map[string]opensearchapi.BulkRespItem{"update": item})
 	}
 	return resp
 }

--- a/internal/esindex/scripted_upsert_test.go
+++ b/internal/esindex/scripted_upsert_test.go
@@ -1,0 +1,218 @@
+package esindex
+
+// scripted_upsert_test.go — Blocker #3 修复回归 test（v1.13）。
+// 目标：验证 es-indexer 的 _bulk update+scripted_upsert 写法能：
+//   1. 首次写入（doc 不存在，走 upsert）：全量落 params.doc，无 preserve 需求
+//   2. 重复写入（doc 已存在）：保留 file-extractor 写的 payload.file.content + contentMeta，
+//      其他字段可被 es-indexer 覆盖
+//   3. 请求 body 编码正确（含 preserve 字段路径、script lang=painless、scripted_upsert=true）
+//   4. Painless script 常量含 preservedFilePaths 列出的字段路径（未来扩字段防漂移）
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// TestBulk_UpdateActionEncoding 单条 doc 编码：action 行必须 update + retry_on_conflict=3，
+// body 必须含 scripted_upsert=true + script.lang=painless + params.doc + upsert。
+func TestBulk_UpdateActionEncoding(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotBody = readAll(r.Body)
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"update":{"_id":"901","status":201}}]}`), nil
+	})
+	w := newTestWriter(t, rt)
+	if _, err := w.Bulk(context.Background(), []searchmsg.Message{msg("901", "hello")}); err != nil {
+		t.Fatalf("Bulk: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(gotBody, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (action + body), got %d: %s", len(lines), gotBody)
+	}
+	// 校验动作行 JSON 结构
+	var action bulkActionLine
+	if err := json.Unmarshal([]byte(lines[0]), &action); err != nil {
+		t.Fatalf("parse action line: %v", err)
+	}
+	if action.Update.ID != "901" {
+		t.Fatalf("action._id must be message_id, got %q", action.Update.ID)
+	}
+	if action.Update.RetryOnConflict != 3 {
+		t.Fatalf("action.retry_on_conflict must be 3 (align with file-extractor oswriter), got %d", action.Update.RetryOnConflict)
+	}
+	// 校验 body 行 JSON 结构
+	var body bulkUpdateBody
+	if err := json.Unmarshal([]byte(lines[1]), &body); err != nil {
+		t.Fatalf("parse body line: %v", err)
+	}
+	if !body.ScriptedUpsert {
+		t.Fatalf("body.scripted_upsert must be true")
+	}
+	if body.Script.Lang != "painless" {
+		t.Fatalf("body.script.lang must be 'painless', got %q", body.Script.Lang)
+	}
+	if body.Script.Source != preservePainless {
+		t.Fatalf("body.script.source must == preservePainless const")
+	}
+	if _, ok := body.Script.Params["doc"]; !ok {
+		t.Fatalf("body.script.params must contain 'doc' key")
+	}
+	// upsert 段必须与 params.doc 同源（同一 Doc 结构）
+	if body.Upsert.MessageID != 901 {
+		t.Fatalf("body.upsert must carry same doc (messageId=901), got %d", body.Upsert.MessageID)
+	}
+}
+
+// TestPreservePainless_ContainsAllPreservedPaths Painless script 常量必须**明确提及**
+// preservedFilePaths 列出的所有字段路径。未来 file-extractor 扩字段时，要么同步扩 script
+// 常量 + 更新 preservedFilePaths + 本 test 通过；要么本 test 失败提醒改动方同步。
+func TestPreservePainless_ContainsAllPreservedPaths(t *testing.T) {
+	// preservedFilePaths 里的 "payload.file.content" / "payload.file.contentMeta"，
+	// 需在 painless script 里能识别（用 field name 后缀断言，避免路径 delimiter 差异）。
+	for _, p := range preservedFilePaths {
+		// 取最后一级字段名（例如 "payload.file.content" → "content"）
+		parts := strings.Split(p, ".")
+		leaf := parts[len(parts)-1]
+		if !strings.Contains(preservePainless, leaf) {
+			t.Fatalf("preservePainless must reference field %q (from preservedFilePaths %q); if you added a preserved path, update the script or drop the path", leaf, p)
+		}
+	}
+	// 反向：script 里出现的 preserve 目标字段名必须都在 preservedFilePaths（防 script 悄悄多 preserve）。
+	// 这里只做最基本的保底：script 必须显式 preserve payload.file
+	if !strings.Contains(preservePainless, "payload") || !strings.Contains(preservePainless, "file") {
+		t.Fatalf("preservePainless must reference 'payload' + 'file' path (preserve target)")
+	}
+	// script 必须处理 ctx.op == 'create' 分支
+	if !strings.Contains(preservePainless, "ctx.op == 'create'") {
+		t.Fatalf("preservePainless must handle scripted_upsert create branch (ctx.op == 'create')")
+	}
+	// script 必须处理 ctx._source = params.doc（全量替换）
+	if !strings.Contains(preservePainless, "ctx._source = params.doc") {
+		t.Fatalf("preservePainless must do full-replace ctx._source = params.doc")
+	}
+}
+
+// TestPreservedFilePaths_NotEmpty preservedFilePaths 常量非空（防被误清）。
+func TestPreservedFilePaths_NotEmpty(t *testing.T) {
+	if len(preservedFilePaths) == 0 {
+		t.Fatalf("preservedFilePaths must not be empty (Blocker #3 fix relies on this)")
+	}
+	// 必含 file.content 路径（file-extractor 的核心写入字段）
+	seenContent := false
+	for _, p := range preservedFilePaths {
+		if strings.HasSuffix(p, ".content") {
+			seenContent = true
+			break
+		}
+	}
+	if !seenContent {
+		t.Fatalf("preservedFilePaths must include a path ending with '.content' (file-extractor writes payload.file.content)")
+	}
+}
+
+// TestBulk_ScriptPreservesContent_MockedResponse 模拟一次 bulk 写入：doc 结构本身不带 content
+// (buildraw 逻辑：es-indexer 主流程不填 payload.file.content)，但发出的请求 body 里 script
+// 常量已包含 preserve 逻辑 —— 由 OS 端 painless script 在真实 update 时执行 preserve。
+// 本 test 覆盖：请求 body **一致地**发送 script（不因 doc 没 content 而短路），
+// 让 OS 端 script 有条件 preserve 已有 content。
+func TestBulk_ScriptPreservesContent_MockedResponse(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotBody = readAll(r.Body)
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"update":{"_id":"902","status":200}}]}`), nil
+	})
+	w := newTestWriter(t, rt)
+	// text 消息（type=1）—— buildraw 分支不填 payload.file.*，doc 里不会出现 payload.file 段。
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("902", "content-not-set")})
+	if err != nil || !res[0].OK {
+		t.Fatalf("Bulk: err=%v res=%+v", err, res)
+	}
+	// 断言 body 无 payload.file 段（text 消息本无 file 字段；es-indexer 也无权写 file.content）
+	if strings.Contains(gotBody, `"file":`) {
+		t.Fatalf("es-indexer body must NOT carry payload.file segment for text msg, got: %s", gotBody)
+	}
+	// 断言 script 常量已发送 (依赖 OS 端 painless 保留已有 content)
+	if !strings.Contains(gotBody, `savedContent`) {
+		t.Fatalf("script must send preserve logic (savedContent keyword) so OS side preserves existing content, got: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `savedMeta`) {
+		t.Fatalf("script must send preserve logic (savedMeta keyword) so OS side preserves existing contentMeta, got: %s", gotBody)
+	}
+}
+
+// TestBulk_DerivativesUsePreserveScript 富文本虚拟子文档也必须走 scripted_upsert。
+// 富文本 doc 派生的子 doc（例如 image block）与父 doc 同批写入，也可能被 file-extractor
+// 覆盖 content（未来富文本嵌 file block 时），故子 doc 也走 preserve script。
+func TestBulk_DerivativesUsePreserveScript(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotBody = readAll(r.Body)
+		return jsonResp(200, `{"took":1,"errors":false,"items":[
+			{"update":{"_id":"1000","status":201}},
+			{"update":{"_id":"1000-rt1","status":201}}
+		]}`), nil
+	})
+	w := osWriterFor(t, rt)
+	parent := Doc{
+		MessageID: 1000, ChannelID: "g", ChannelType: 2,
+		Derivatives: []Doc{
+			{MessageID: 1000, ChannelID: "g", ChannelType: 2, idOverride: "1000-rt1", Virtual: true},
+		},
+	}
+	if _, err := w.BulkDocs(context.Background(), []Doc{parent}); err != nil {
+		t.Fatalf("BulkDocs: %v", err)
+	}
+	// body 应该有 2 组 (action, body) 行 — 父 + 子都走 update+scripted_upsert
+	// 每组 body 都含 scripted_upsert=true
+	scriptedUpsertCount := strings.Count(gotBody, `"scripted_upsert":true`)
+	if scriptedUpsertCount != 2 {
+		t.Fatalf("expected 2 scripted_upsert entries (parent + derivative), got %d in body: %s", scriptedUpsertCount, gotBody)
+	}
+	// 每组 action 都是 update
+	updateCount := strings.Count(gotBody, `"update":{"_id":`)
+	if updateCount != 2 {
+		t.Fatalf("expected 2 update actions (parent + derivative), got %d", updateCount)
+	}
+}
+
+// TestBulk_ResponseUpdateKeyParsed mock OS 返回 items[i]["update"]，writer 必须能正确读 status。
+// 老版本 items[i]["index"] 应该 fail（无 "update" 字段 → transient status=0）。
+func TestBulk_ResponseUpdateKeyParsed(t *testing.T) {
+	// 用旧 "index" key 模拟响应格式漂移（应触发 transient，不静默当成功）
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"777","status":201}}]}`), nil
+	})
+	w := newTestWriter(t, rt)
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("777", "x")})
+	if err != nil {
+		t.Fatalf("Bulk: %v", err)
+	}
+	if res[0].OK || res[0].Status != 0 {
+		t.Fatalf("response with wrong action key ('index' vs 'update') must be transient not OK, got %+v", res[0])
+	}
+	if res[0].Err == nil || !strings.Contains(res[0].Err.Error(), "no update action") {
+		t.Fatalf("expected error mentioning 'no update action', got %v", res[0].Err)
+	}
+}
+
+// TestBulk_LargeDocSizeEstimateUpdated encodedSingleDocSize 反映 update body 膨胀。
+// 老估算 ≈ doc size + overhead；新估算 ≈ 2×doc + script const + overhead。
+// 若估算未跟着改，subBatchEnd 会按小值切子批，导致单批实际 > threshold 被 OS 413。
+func TestBulk_LargeDocSizeEstimateUpdated(t *testing.T) {
+	d := Doc{MessageID: 1, ChannelID: "g", ChannelType: 2, PayloadRaw: json.RawMessage([]byte(`{"a":"` + strings.Repeat("x", 1<<20) + `"}`))}
+	docJSON, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	estimated := encodedSingleDocSize(d)
+	// 新估算至少 = 2 * doc + script const（不含 overhead）
+	minExpected := 2*len(docJSON) + len(preservePainless)
+	if estimated < minExpected {
+		t.Fatalf("encodedSingleDocSize=%d must reflect update body doubling (>=2×docJSON+script=%d)", estimated, minExpected)
+	}
+}

--- a/internal/esindex/writer.go
+++ b/internal/esindex/writer.go
@@ -77,10 +77,20 @@ func (r BulkItemResult) Permanent() bool {
 
 // isPermanentStatus 判定 HTTP 状态码是否为「永久错误」（毒丸，进 DLQ）。
 // 4xx 表示请求本身有问题（如 mapping 冲突、文档格式非法），重试无意义 → permanent。
-// 例外：429 Too Many Requests 是限流，属 transient（退避重试）。
+// 例外：
+//   - 429 Too Many Requests：OS 限流，属 transient（退避重试）。
+//   - 409 Conflict：optimistic-concurrency 冲突（v1.13 Blocker #3 修引入 scripted_upsert +
+//     retry_on_conflict=3 后新暴露）。3 次内部重试耗尽仍报 409 时属 transient，caller 应重试；
+//     误归 permanent 会把主 doc silent 甩进 DLQ + 前进 offset → 主 doc 不落 search（Round-3
+//     Blocker A / Jerry-Xin #1 / yujiawei P1）。与 sibling fileextract/oswriter.go:112-114
+//     的 409 处理对齐。
+//
 // 5xx / 0（网络/批级失败）属 transient。
 func isPermanentStatus(status int) bool {
 	if status == http.StatusTooManyRequests { // 429
+		return false
+	}
+	if status == http.StatusConflict { // 409 — Round-3 Blocker A fix
 		return false
 	}
 	return status >= 400 && status < 500
@@ -128,11 +138,77 @@ func NewWriter(cfg Config) (Writer, error) {
 }
 
 // bulkActionLine / bulkDocLine 构成 _bulk NDJSON 的每条两行：动作行 + 文档行。
-// 用 index 动作（非 create）实现 upsert：同 _id 重复投递覆盖同一 doc，幂等去重。
+//
+// 🔴 v1.13（Blocker #3 fix）：从 `index` 动作换成 `update` + `scripted_upsert`。
+// 原因：file-extractor 通过 partial _update 写 payload.file.content + contentMeta；es-indexer
+// 若走 `index` full-replace，redeliver（rebalance/restart/retry）时会**覆盖** file-extractor
+// 写的字段。改 scripted_upsert：doc 不存在 → upsert 全量写；doc 存在 → 走 preservePainless
+// 从 ctx._source 保留 preservedFilePaths 里的字段再全量替换。retry_on_conflict=3 与
+// file-extractor 一致，缓解两 writer 并发写冲突。
 type bulkActionLine struct {
-	Index struct {
-		ID string `json:"_id"`
-	} `json:"index"`
+	Update struct {
+		ID              string `json:"_id"`
+		RetryOnConflict int    `json:"retry_on_conflict"`
+	} `json:"update"`
+}
+
+// preservedFilePaths 是 es-indexer scripted_upsert 更新 doc 时**必须保留、不被覆盖**
+// 的字段路径清单——由 file-extractor 通过 partial _update 拥有写入权。若 es-indexer 走
+// full-replace 会抹掉这些字段（Blocker #3 原 bug）。preservePainless 常量按本清单实现
+// preserve 逻辑；未来 file-extractor 扩字段时**同步扩本清单 + 更新 script 常量 + test 断言**。
+var preservedFilePaths = []string{
+	"payload.file.content",
+	"payload.file.contentMeta",
+}
+
+// preservePainless 是 scripted_upsert 的 Painless script 常量。
+//   - ctx.op == 'create'（doc 不存在，走 upsert）：直接用 params.doc 全量赋值，无 preserve 需求
+//   - 否则（doc 已存在）：先从 ctx._source 保存 preservedFilePaths 字段 → 用 params.doc 全量
+//     替换 ctx._source → 恢复保留字段
+//
+// script 是**参数化常量**（本字符串每次一样，只有 params.doc 变），OS script cache 会 hit。
+// 语法针对 OS 3.x Painless，兼容 nested Map 访问 + null 判定。
+const preservePainless = `
+if (ctx.op == 'create') {
+  ctx._source = params.doc;
+} else {
+  def savedContent = null;
+  def savedMeta = null;
+  if (ctx._source.containsKey('payload') && ctx._source.payload instanceof Map) {
+    def f = ctx._source.payload.get('file');
+    if (f instanceof Map) {
+      savedContent = f.get('content');
+      savedMeta = f.get('contentMeta');
+    }
+  }
+  ctx._source = params.doc;
+  if (savedContent != null || savedMeta != null) {
+    if (!ctx._source.containsKey('payload') || !(ctx._source.payload instanceof Map)) {
+      ctx._source.payload = new HashMap();
+    }
+    if (!ctx._source.payload.containsKey('file') || !(ctx._source.payload.file instanceof Map)) {
+      ctx._source.payload.file = new HashMap();
+    }
+    if (savedContent != null) { ctx._source.payload.file.content = savedContent; }
+    if (savedMeta != null) { ctx._source.payload.file.contentMeta = savedMeta; }
+  }
+}
+`
+
+// bulkUpdateBody 是一条 doc 的 update + scripted_upsert body（第二行）。
+// script.params.doc 与 upsert 均携带同一 doc：前者供 script 执行 preserve+replace，
+// 后者供 OS 在 doc 不存在时初始化。scripted_upsert=true 让 upsert 分支也走 script（ctx.op=='create'）。
+type bulkUpdateBody struct {
+	Script         scriptBlock `json:"script"`
+	Upsert         Doc         `json:"upsert"`
+	ScriptedUpsert bool        `json:"scripted_upsert"`
+}
+
+// scriptBlock 是 Painless script + 参数。
+type scriptBlock struct {
+	Lang   string         `json:"lang"`
+	Source string         `json:"source"`
+	Params map[string]any `json:"params"`
 }
 
 // Bulk 把一批 Kafka 契约消息转成 reader 可读 Doc 后以 _bulk 幂等写入 ES。
@@ -265,13 +341,16 @@ func encodedDocSize(d Doc) int {
 }
 
 // encodedSingleDocSize 估算单条 doc（不含其 Derivatives）在 _bulk body 里的字节。
+// v1.13 scripted_upsert 后 body 膨胀 ~2x（script 常量 + params.doc + upsert），此估算按新
+// 结构算：动作行 (~80 字节 update+retry_on_conflict) + script 常量 + 2×doc JSON + 结构开销。
 func encodedSingleDocSize(d Doc) int {
 	docJSON, err := json.Marshal(d)
 	if err != nil {
 		return 0
 	}
-	// 动作行约 ~40 字节（{"index":{"_id":"<id>"}}）+ 文档行 + 2 换行；动作行用 id 长度近似。
-	return len(docJSON) + len(d.idString()) + 24 + 2
+	// 动作行 ~80 字节（{"update":{"_id":"<id>","retry_on_conflict":3}}）+ script 常量
+	// + params.doc + upsert.doc + JSON 结构 overhead (~120) + 2 换行。
+	return 80 + len(preservePainless) + 2*len(docJSON) + 120 + 2
 }
 
 // bulkOnce 执行单次 _bulk（原 BulkDocs 主体），用于 BulkDocs 的按字节子批切分。
@@ -319,22 +398,33 @@ func encodeBulkBody(docs []Doc) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// writeBulkDoc 向 buf 写一条 doc 的 index 动作行 + 文档行。
+// writeBulkDoc 向 buf 写一条 doc 的 update+scripted_upsert 动作行 + body 行（v1.13）。
+// 动作行携带 retry_on_conflict=3 与 file-extractor oswriter 一致，缓解并发冲突。
 func writeBulkDoc(buf *bytes.Buffer, d Doc) error {
 	id := d.idString()
 	var action bulkActionLine
-	action.Index.ID = id
+	action.Update.ID = id
+	action.Update.RetryOnConflict = 3
 	actionJSON, err := json.Marshal(action)
 	if err != nil {
 		return fmt.Errorf("esindex: marshal bulk action for %s: %w", id, err)
 	}
-	docJSON, err := json.Marshal(d)
+	body := bulkUpdateBody{
+		Script: scriptBlock{
+			Lang:   "painless",
+			Source: preservePainless,
+			Params: map[string]any{"doc": d},
+		},
+		Upsert:         d,
+		ScriptedUpsert: true,
+	}
+	bodyJSON, err := json.Marshal(body)
 	if err != nil {
-		return fmt.Errorf("esindex: marshal doc for %s: %w", id, err)
+		return fmt.Errorf("esindex: marshal update body for %s: %w", id, err)
 	}
 	buf.Write(actionJSON)
 	buf.WriteByte('\n')
-	buf.Write(docJSON)
+	buf.Write(bodyJSON)
 	buf.WriteByte('\n')
 	return nil
 }
@@ -380,7 +470,8 @@ func mapBulkResults(docs []Doc, resp *opensearchapi.BulkResp) []BulkItemResult {
 }
 
 // bulkItemResult 解析 _bulk 响应第 idx 项，返回单条 BulkItemResult（MessageID=id）。
-// 响应缺项/无 index 动作 → transient(Status=0) 让整批重试，绝不静默当成功。
+// 响应缺项/无 update 动作 → transient(Status=0) 让整批重试，绝不静默当成功。
+// v1.13：action key 从 "index" 改成 "update"（对齐 scripted_upsert 请求动作）。
 func bulkItemResult(id string, resp *opensearchapi.BulkResp, idx int) BulkItemResult {
 	res := BulkItemResult{MessageID: id}
 	if idx >= len(resp.Items) {
@@ -388,10 +479,10 @@ func bulkItemResult(id string, resp *opensearchapi.BulkResp, idx int) BulkItemRe
 		res.Err = fmt.Errorf("esindex: missing bulk response item for %s", id)
 		return res
 	}
-	item, ok := resp.Items[idx]["index"]
+	item, ok := resp.Items[idx]["update"]
 	if !ok {
 		res.Status = 0
-		res.Err = fmt.Errorf("esindex: bulk response item for %s has no index action", id)
+		res.Err = fmt.Errorf("esindex: bulk response item for %s has no update action", id)
 		return res
 	}
 	res.Status = item.Status

--- a/internal/esindex/writer_test.go
+++ b/internal/esindex/writer_test.go
@@ -79,8 +79,8 @@ func TestBulk_AllSuccess(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		gotBody = readAll(r.Body)
 		return jsonResp(200, `{"took":1,"errors":false,"items":[
-			{"index":{"_id":"101","status":201}},
-			{"index":{"_id":"102","status":200}}
+			{"update":{"_id":"101","status":201}},
+			{"update":{"_id":"102","status":200}}
 		]}`), nil
 	})
 	w := newTestWriter(t, rt)
@@ -102,16 +102,26 @@ func TestBulk_AllSuccess(t *testing.T) {
 	if !strings.Contains(gotBody, `"messageId":101`) {
 		t.Fatalf("bulk body must carry numeric messageId (reader long): %s", gotBody)
 	}
+	// v1.13 Blocker #3 fix：动作行必须是 update，body 必须含 scripted_upsert=true + painless script。
+	if !strings.Contains(gotBody, `"update"`) {
+		t.Fatalf("bulk action must be 'update' (scripted_upsert), got: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"scripted_upsert":true`) {
+		t.Fatalf("bulk body must carry scripted_upsert=true: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"lang":"painless"`) {
+		t.Fatalf("bulk body must carry painless script: %s", gotBody)
+	}
 }
 
 // TestBulk_MixedStatuses 混合状态：成功/4xx(permanent)/429(transient)/5xx(transient)。
 func TestBulk_MixedStatuses(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return jsonResp(200, `{"took":1,"errors":true,"items":[
-			{"index":{"_id":"201","status":201}},
-			{"index":{"_id":"400","status":400,"error":{"type":"mapper_parsing_exception","reason":"bad field"}}},
-			{"index":{"_id":"429","status":429,"error":{"type":"es_rejected","reason":"queue full"}}},
-			{"index":{"_id":"503","status":503,"error":{"type":"unavailable","reason":"node down"}}}
+			{"update":{"_id":"201","status":201}},
+			{"update":{"_id":"400","status":400,"error":{"type":"mapper_parsing_exception","reason":"bad field"}}},
+			{"update":{"_id":"429","status":429,"error":{"type":"es_rejected","reason":"queue full"}}},
+			{"update":{"_id":"503","status":503,"error":{"type":"unavailable","reason":"node down"}}}
 		]}`), nil
 	})
 	w := newTestWriter(t, rt)
@@ -132,6 +142,56 @@ func TestBulk_MixedStatuses(t *testing.T) {
 	}
 	if res[3].OK || res[3].Permanent() {
 		t.Fatalf("item 3 (503) must be transient (not permanent), got %+v", res[3])
+	}
+}
+
+// TestBulk_409IsTransient 🔴 Round-3 Blocker A regression：scripted_upsert + retry_on_conflict=3
+// 在两写者并发（es-indexer + file-extractor 都 update 同 _id）时可能耗尽 3 次内部重试仍报 409。
+// 老 isPermanentStatus 把 409 视作 permanent → 主 doc 甩进 DLQ + 前进 offset → 主 doc silently
+// 缺 search index。fix 后 409 归 transient，caller 应重试，与 sibling fileextract/oswriter.go 对齐。
+func TestBulk_409IsTransient(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"took":1,"errors":true,"items":[
+			{"update":{"_id":"409","status":409,"error":{"type":"version_conflict_engine_exception","reason":"concurrent update after 3 retry_on_conflict"}}}
+		]}`), nil
+	})
+	w := newTestWriter(t, rt)
+	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("409", "concurrent-write")})
+	if err != nil {
+		t.Fatalf("Bulk: %v", err)
+	}
+	if res[0].OK {
+		t.Fatalf("409 must NOT be OK, got %+v", res[0])
+	}
+	if res[0].Permanent() {
+		t.Fatalf("409 must be TRANSIENT (concurrent-write retriable), not permanent — else main doc silent-drops on redeliver conflict; got %+v", res[0])
+	}
+	if res[0].Status != 409 {
+		t.Fatalf("Status should carry 409, got %d", res[0].Status)
+	}
+}
+
+// TestIsPermanentStatus_409IsTransient Round-3 Blocker A：直接单测 isPermanentStatus 分类。
+func TestIsPermanentStatus_409IsTransient(t *testing.T) {
+	// transient (must not permanent)
+	transient := []int{0, 429, 500, 502, 503, 504, 409}
+	for _, s := range transient {
+		if isPermanentStatus(s) {
+			t.Errorf("status %d must be TRANSIENT (permanent=false), got permanent=true", s)
+		}
+	}
+	// permanent (real 4xx)
+	permanent := []int{400, 401, 403, 404, 410, 422}
+	for _, s := range permanent {
+		if !isPermanentStatus(s) {
+			t.Errorf("status %d must be PERMANENT (permanent=true), got permanent=false", s)
+		}
+	}
+	// 2xx: not permanent
+	for _, s := range []int{200, 201, 204} {
+		if isPermanentStatus(s) {
+			t.Errorf("2xx status %d must not be permanent, got permanent=true", s)
+		}
 	}
 }
 
@@ -173,7 +233,7 @@ func TestBulk_Idempotent(t *testing.T) {
 	var bodies []string
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		bodies = append(bodies, readAll(r.Body))
-		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"555","status":201}}]}`), nil
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"update":{"_id":"555","status":201}}]}`), nil
 	})
 	w := newTestWriter(t, rt)
 	for i := 0; i < 2; i++ {
@@ -187,8 +247,11 @@ func TestBulk_Idempotent(t *testing.T) {
 		if err := json.Unmarshal([]byte(first), &action); err != nil {
 			t.Fatalf("parse action line: %v", err)
 		}
-		if action.Index.ID != "555" {
-			t.Fatalf("idempotent key must be normalized messageId '555', got %q", action.Index.ID)
+		if action.Update.ID != "555" {
+			t.Fatalf("idempotent key must be normalized messageId '555', got %q", action.Update.ID)
+		}
+		if action.Update.RetryOnConflict != 3 {
+			t.Fatalf("update action must carry retry_on_conflict=3, got %d", action.Update.RetryOnConflict)
 		}
 	}
 }
@@ -196,7 +259,7 @@ func TestBulk_Idempotent(t *testing.T) {
 // TestBulk_MissingResponseItem 响应条目数少于请求 → 缺失条标 transient，绝不静默当成功。
 func TestBulk_MissingResponseItem(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"701","status":201}}]}`), nil
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"update":{"_id":"701","status":201}}]}`), nil
 	})
 	w := newTestWriter(t, rt)
 	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("701", "a"), msg("702", "b")})
@@ -276,7 +339,7 @@ func TestBulk_NonNumericIDIsPermanentNoES(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		sentBody = readAll(r.Body)
 		// ES 只应收到 1 条（合法的 808）。
-		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"_id":"808","status":201}}]}`), nil
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"update":{"_id":"808","status":201}}]}`), nil
 	})
 	w := newTestWriter(t, rt)
 	res, err := w.Bulk(context.Background(), []searchmsg.Message{msg("oops", "x"), msg("808", "y")})
@@ -327,8 +390,8 @@ func TestBulkDocs_SplitsByByteSize(t *testing.T) {
 	bulkCalls := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		body := readAll(r.Body)
-		// 数请求里的动作行条数（每条一行 {"index":...}），按数生成等量成功 items。
-		n := strings.Count(body, `{"index":`)
+		// 数请求里的动作行条数（每条一行 {"update":...}），按数生成等量成功 items。
+		n := strings.Count(body, `{"update":`)
 		bulkCalls++
 		var sb strings.Builder
 		sb.WriteString(`{"took":1,"errors":false,"items":[`)
@@ -336,7 +399,7 @@ func TestBulkDocs_SplitsByByteSize(t *testing.T) {
 			if i > 0 {
 				sb.WriteByte(',')
 			}
-			sb.WriteString(`{"index":{"status":201}}`)
+			sb.WriteString(`{"update":{"status":201}}`)
 		}
 		sb.WriteString(`]}`)
 		return jsonResp(200, sb.String()), nil
@@ -381,7 +444,7 @@ func TestBulkDocs_SubBatchEncodeFailureKeepsAlignment(t *testing.T) {
 	bulkCalls := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		body := readAll(r.Body)
-		n := strings.Count(body, `{"index":`)
+		n := strings.Count(body, `{"update":`)
 		bulkCalls++
 		var sb strings.Builder
 		sb.WriteString(`{"took":1,"errors":false,"items":[`)
@@ -389,15 +452,17 @@ func TestBulkDocs_SubBatchEncodeFailureKeepsAlignment(t *testing.T) {
 			if i > 0 {
 				sb.WriteByte(',')
 			}
-			sb.WriteString(`{"index":{"status":201}}`)
+			sb.WriteString(`{"update":{"status":201}}`)
 		}
 		sb.WriteString(`]}`)
 		return jsonResp(200, sb.String()), nil
 	})
 	w := osWriterFor(t, rt)
 
-	// doc0/doc1 各 ~30MB 合法 → 二者相加 >50MB 阈值 → doc0 独占第一子批。
-	big := make([]byte, 30<<20)
+	// doc0/doc1 各 ~20MB payloadRaw；v1.13 scripted_upsert body 含 params.doc + upsert 双 doc
+	// → encodedSingleDocSize ≈ 2×20MB + script overhead ≈ 40MB。两条相加 >50MB 阈值 →
+	// doc0 独占第一子批（且 40MB < 50MB 不触发 single-doc-permanent 413 分支）。
+	big := make([]byte, 20<<20)
 	for i := range big {
 		big[i] = 'x'
 	}
@@ -459,7 +524,7 @@ func TestBulkDocs_SingleOversizedDocIsPermanent(t *testing.T) {
 	bulkCalls := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		bulkCalls++
-		return jsonResp(200, `{"took":1,"errors":false,"items":[{"index":{"status":201}}]}`), nil
+		return jsonResp(200, `{"took":1,"errors":false,"items":[{"update":{"status":201}}]}`), nil
 	})
 	w := osWriterFor(t, rt)
 	// 一条 doc 的 payloadRaw 超过 maxBulkBodyBytes 自身。

--- a/internal/filebackfill/config.go
+++ b/internal/filebackfill/config.go
@@ -1,0 +1,73 @@
+// Package filebackfill 是 cmd/file-content-backfill 一次性 Job 的核心包（v1.12）。
+//
+// 目的：把 IDX-4 file-extractor 上线**之前**已经存在的历史 type=8 文件消息回填 payload.file.content
+// （prod 实测约 123K 条，v2 §11）。file-extractor 只处理 IDX-4 上线之后的增量。
+//
+// 与 file-extractor 的关系：
+//   - 复用 fileextract.Extractor（download + tika + os partial update 三链条同套）
+//   - 独立入口 cmd/file-content-backfill，走 K8s Job 一次性跑（主人决策 backfill 走 K8s Job 一次性）
+//   - 源不同：file-extractor 从 Kafka 拉；本 Job 从 OS scroll 反查 `payload.type=8 AND must_not exists content`
+//     （Kafka 历史消息大多超保留期；OS scroll query 天然幂等，重跑跳过已抽取的 doc）
+//   - 限速 50 RPS 避免压垮 Tika 或 CDN（v2 §9 回灌耗时估算 40min）
+//   - 无 checkpoint（简化版：重跑靠 OS scroll query 幂等；123K × 200ms 一小时内跑完，中断重跑成本可接受）
+//
+// Runner 用法：runner.Run(ctx) 阻塞跑到 EOF / ctx 取消 / 达 timeout；返回汇总 stats
+// （processed / dlq / errors）供 K8s Job 退出码判 (stats.errs > 0 → exit 1 让 K8s 报错)。
+package filebackfill
+
+import (
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/fileextract"
+)
+
+// Config 是 backfill Runner 的运行配置。
+type Config struct {
+	ESAddresses []string
+	ESIndex     string // e.g. "octo-message" (alias 或 backing index)
+	ESUsername  string
+	ESPassword  string
+
+	// TikaURL / DownloadTimeout / ExtractTimeout / MaxFileSize / MaxContentBytes / HTTPRetries
+	// 转发给 fileextract.NewExtractor 复用同一套抽取核心。
+	TikaURL         string
+	DownloadTimeout time.Duration
+	ExtractTimeout  time.Duration
+	MaxFileSize     int64
+	MaxContentBytes int
+	HTTPRetries     int
+
+	// Rate 是限速（docs/s），默认 50。0/负数 = 不限速。
+	Rate float64
+	// ScrollSize 是每批 scroll 拉取的 doc 数（默认 500）。
+	ScrollSize int
+	// ScrollTTL 是 scroll 上下文的 keep-alive 时间（默认 5min，每次 continue 会重置）。
+	ScrollTTL time.Duration
+	// Timeout 是整个 Job 上限（默认 2h）。
+	Timeout time.Duration
+}
+
+// ToExtractorConfig 转换成 fileextract.ServiceConfig（extractor 只用其中一部分字段）。
+func (c Config) ToExtractorConfig() fileextract.ServiceConfig {
+	return fileextract.ServiceConfig{
+		ESAddresses:     c.ESAddresses,
+		ESIndex:         c.ESIndex,
+		ESUsername:      c.ESUsername,
+		ESPassword:      c.ESPassword,
+		TikaURL:         c.TikaURL,
+		DownloadTimeout: c.DownloadTimeout,
+		ExtractTimeout:  c.ExtractTimeout,
+		MaxFileSize:     c.MaxFileSize,
+		MaxContentBytes: c.MaxContentBytes,
+		HTTPRetries:     c.HTTPRetries,
+	}
+}
+
+// Stats 是 Runner.Run 的汇总统计。K8s Job 用于退出码判定。
+type Stats struct {
+	Scanned     int64 // OS scroll 拉出的总 doc 数
+	Extracted   int64 // 成功抽取 + OS update 的 doc 数
+	DLQ         int64 // 抽取失败进 DLQ 计数（backfill 只 log 不真写 kafka，spill 到日志）
+	Skipped     int64 // ctx 取消 / 其他原因跳过
+	OSTransient int64 // OS errDocNotYet / transient 触发次数（backfill 场景理论上不该出现 errDocNotYet）
+}

--- a/internal/filebackfill/ratelimit.go
+++ b/internal/filebackfill/ratelimit.go
@@ -1,0 +1,73 @@
+package filebackfill
+
+// ratelimit.go — 简化令牌桶限速（backfill 场景够用；复制 internal/backfill/ratelimit.go 思路，
+// 不 import 避免耦合到 message-shard 场景的 randInt63n 依赖）。
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// rateLimiter 令牌桶：按 docsPerSec 匀速补充，burst = 1 秒的量。
+// docsPerSec <= 0 表示不限速。
+//
+// 并发安全：Wait 用 sync.Mutex 保护内部 mutable 状态 (tokens / last)，
+// Runner 主循环当前是单 goroutine 调用，但未来若加 worker 池不会 silent 破坏限速。
+type rateLimiter struct {
+	docsPerSec float64
+	burst      float64
+	mu         sync.Mutex
+	tokens     float64
+	last       time.Time
+}
+
+func newRateLimiter(docsPerSec float64) *rateLimiter {
+	burst := docsPerSec
+	if burst <= 0 {
+		burst = 1
+	}
+	// 关键：burst 最少 1，否则令牌永远补不到 1，Wait 死循环（例如 docsPerSec=0.1
+	// 时 burst=0.1，tokens += elapsed*0.1 但上限 0.1 → 永远 < 1 → 死锁）。
+	if burst < 1 {
+		burst = 1
+	}
+	return &rateLimiter{
+		docsPerSec: docsPerSec,
+		burst:      burst,
+		tokens:     burst,
+		last:       time.Now(),
+	}
+}
+
+// Wait 消耗 1 个令牌；不足则等到有为止（可被 ctx 取消）。线程安全。
+func (r *rateLimiter) Wait(ctx context.Context) error {
+	if r.docsPerSec <= 0 {
+		return nil
+	}
+	for {
+		r.mu.Lock()
+		now := time.Now()
+		elapsed := now.Sub(r.last).Seconds()
+		r.tokens += elapsed * r.docsPerSec
+		if r.tokens > r.burst {
+			r.tokens = r.burst
+		}
+		r.last = now
+		if r.tokens >= 1 {
+			r.tokens -= 1
+			r.mu.Unlock()
+			return nil
+		}
+		wait := time.Duration((1-r.tokens)/r.docsPerSec*1000) * time.Millisecond
+		r.mu.Unlock()
+		if wait < time.Millisecond {
+			wait = time.Millisecond
+		}
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/internal/filebackfill/runner.go
+++ b/internal/filebackfill/runner.go
@@ -1,0 +1,193 @@
+package filebackfill
+
+// runner.go — 串起 scroll source → 限速 → 复用 fileextract.Extractor → OS partial update → 进度日志。
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/fileextract"
+)
+
+// ErrTimeoutIncomplete 是 Run 因 top-level context.DeadlineExceeded 提前退出的 sentinel
+// （v1.13 P2-3）。K8s Job 用它区分"正常 EOF"（return nil）与"timeout 剩余未跑"（return err，
+// exit non-zero → operator 得知需要重跑）。SIGTERM 触发的 context.Canceled 仍返 nil（优雅退出）。
+var ErrTimeoutIncomplete = errors.New("filebackfill: run timed out before scroll EOF (incomplete)")
+
+// scrollRetryConfig 是 P2-8：scroll source.Next 出 transient 错时的 in-place backoff retry 参数。
+const (
+	scrollMaxRetries = 3
+	scrollBackoffMin = 500 * time.Millisecond
+)
+
+// batchSource 是 Runner 依赖的 scroll source 抽象（便于测试注入 mock）。
+type batchSource interface {
+	Next(ctx context.Context) ([]sourceDoc, error)
+	Close(ctx context.Context) error
+}
+
+// docExtractor 抽象「抽一条 doc → OS partial update」的动作，便于 Runner.Run 单测注入 mock。
+// 生产实现是 realExtractor（包 *fileextract.Extractor），测试实现 mock 返回预置结果。
+//
+// 返回签名对齐 fileextract.ExtractAndWriteForBackfill：
+//   - (reason="",  cause=nil, err=nil)  → 成功
+//   - (reason!="", cause=err, err=nil)  → 抽取失败，DLQ
+//   - (reason="",  cause=nil, err!=nil) → OS transient（含 errDocNotYet）
+type docExtractor interface {
+	Extract(ctx context.Context, messageID, url, name, ext string, size int64) (reason string, cause error, err error)
+}
+
+// realExtractor 是 docExtractor 的生产实现，包 fileextract.Extractor。
+type realExtractor struct{ e *fileextract.Extractor }
+
+func (r *realExtractor) Extract(ctx context.Context, messageID, url, name, ext string, size int64) (string, error, error) {
+	return fileextract.ExtractAndWriteForBackfill(ctx, r.e, messageID, url, name, ext, size)
+}
+
+// Runner 是一次性 Job 的主控。
+type Runner struct {
+	source    batchSource
+	extractor docExtractor
+	limiter   *rateLimiter
+	progress  time.Duration // 每隔多久 log 一次进度（默认 30s）
+}
+
+// NewRunner 装配 Runner（生产用；测试走 NewRunnerWith 注入 mock）。
+func NewRunner(cfg Config) (*Runner, error) {
+	src, err := newOSScrollSource(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ext, err := fileextract.NewExtractor(cfg.ToExtractorConfig())
+	if err != nil {
+		return nil, err
+	}
+	rate := cfg.Rate
+	if rate == 0 {
+		rate = 50 // v2 §9 默认 50 RPS
+	}
+	return &Runner{
+		source:    src,
+		extractor: &realExtractor{e: ext},
+		limiter:   newRateLimiter(rate),
+		progress:  30 * time.Second,
+	}, nil
+}
+
+// NewRunnerWith 用注入的 source/extractor 建 Runner（测试用）。
+func NewRunnerWith(src batchSource, ext docExtractor, rate float64) *Runner {
+	return &Runner{
+		source:    src,
+		extractor: ext,
+		limiter:   newRateLimiter(rate),
+		progress:  10 * time.Millisecond,
+	}
+}
+
+// Run 主循环：拉一批 → 逐条限速抽取 → 累计 stats → 直到 EOF / ctx 取消 / timeout。
+// 返回汇总 stats（K8s Job 用 stats.OSTransient/DLQ 判退出码）。
+//
+// v1.13 P2-3：区分 ctx.Canceled（signal 优雅退出，nil）与 ctx.DeadlineExceeded（timeout
+// 提前退出，ErrTimeoutIncomplete）。老代码把两者都当 graceful → K8s Job exit 0 但实际未跑完，
+// 掩盖需要重跑的信号。
+// v1.13 P2-8：source.Next 出 transient 错时 bounded backoff retry，避免长跑 job 因单次 blip 中断。
+func (r *Runner) Run(ctx context.Context) (Stats, error) {
+	var stats Stats
+	lastLog := time.Now()
+	defer func() {
+		if err := r.source.Close(context.Background()); err != nil {
+			log.Printf("filebackfill: close source: %v", err)
+		}
+		log.Printf("filebackfill DONE: scanned=%d extracted=%d dlq=%d skipped=%d os_transient=%d",
+			stats.Scanned, stats.Extracted, stats.DLQ, stats.Skipped, stats.OSTransient)
+	}()
+	for {
+		// P2-3：判 ctx 类型，把 DeadlineExceeded 与 Canceled 分开返
+		if err := ctx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return stats, ErrTimeoutIncomplete
+			}
+			return stats, nil // Canceled = SIGTERM 优雅退出
+		}
+		batch, err := r.nextWithRetry(ctx)
+		if errors.Is(err, io.EOF) {
+			return stats, nil // 正常 EOF
+		}
+		if errors.Is(err, context.Canceled) {
+			return stats, nil
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return stats, ErrTimeoutIncomplete
+		}
+		if err != nil {
+			return stats, err
+		}
+		for _, doc := range batch {
+			stats.Scanned++
+			if err := r.limiter.Wait(ctx); err != nil {
+				stats.Skipped++
+				// P2-3 一致：limiter Wait 因 ctx 取消退出，判类型
+				if errors.Is(err, context.DeadlineExceeded) {
+					return stats, ErrTimeoutIncomplete
+				}
+				return stats, nil
+			}
+			r.processOne(ctx, doc, &stats)
+			if time.Since(lastLog) > r.progress {
+				log.Printf("filebackfill progress: scanned=%d extracted=%d dlq=%d os_transient=%d",
+					stats.Scanned, stats.Extracted, stats.DLQ, stats.OSTransient)
+				lastLog = time.Now()
+			}
+		}
+	}
+}
+
+// nextWithRetry 包装 source.Next 加 bounded backoff retry（P2-8）。
+//   - EOF / ctx err → 直接返（上层处理）
+//   - transient err（非 EOF / 非 ctx）→ retry with backoff，共 scrollMaxRetries 次
+//   - 重试耗尽 → 返最后一次 err（上层视为 fatal）
+//
+// scroll 查询本身是幂等的（same query 每次返 same page），故 retry 安全。
+func (r *Runner) nextWithRetry(ctx context.Context) ([]sourceDoc, error) {
+	var lastErr error
+	for attempt := 0; attempt <= scrollMaxRetries; attempt++ {
+		if attempt > 0 {
+			wait := scrollBackoffMin * time.Duration(1<<(attempt-1)) // 500ms/1s/2s/4s
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		batch, err := r.source.Next(ctx)
+		if err == nil {
+			return batch, nil
+		}
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		lastErr = err
+		log.Printf("filebackfill: source.Next transient err (attempt %d/%d): %v", attempt+1, scrollMaxRetries+1, err)
+	}
+	return nil, lastErr
+}
+
+// processOne 抽取一条 → 更新 stats（不 return err，让 Job 继续跑）。
+// 若 OS transient (errDocNotYet 极少见——backfill 场景主 doc 一定存在)，记 OSTransient 计数继续。
+func (r *Runner) processOne(ctx context.Context, doc sourceDoc, stats *Stats) {
+	reason, cause, err := r.extractor.Extract(ctx, doc.MessageID, doc.URL, doc.Name, doc.Extension, doc.Size)
+	if err != nil {
+		stats.OSTransient++
+		log.Printf("filebackfill: os transient for messageId=%s: %v", doc.MessageID, err)
+		return
+	}
+	if reason != "" {
+		stats.DLQ++
+		log.Printf("filebackfill: dlq messageId=%s reason=%s cause=%v url=%s", doc.MessageID, reason, cause, doc.URL)
+		return
+	}
+	stats.Extracted++
+}

--- a/internal/filebackfill/runner_test.go
+++ b/internal/filebackfill/runner_test.go
@@ -1,0 +1,393 @@
+package filebackfill
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// mockSource 是 batchSource 测试实现：预置 batches 队列，逐批返回，末尾返 io.EOF。
+// nextErr 非 nil 时，Next 优先返 nextErr（模拟 ctx 取消 / OS 5xx）。
+type mockSource struct {
+	mu       sync.Mutex
+	batches  [][]sourceDoc
+	closed   bool
+	nextErr  error
+	nextHook func() // 每次 Next 前触发（测 ctx cancel timing）
+}
+
+func (m *mockSource) Next(ctx context.Context) ([]sourceDoc, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.nextHook != nil {
+		m.nextHook()
+	}
+	if m.nextErr != nil {
+		return nil, m.nextErr
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(m.batches) == 0 {
+		return nil, io.EOF
+	}
+	b := m.batches[0]
+	m.batches = m.batches[1:]
+	return b, nil
+}
+
+func (m *mockSource) Close(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+// mockExtractor 按预置结果依次返回抽取结论。
+// results[i] 描述第 i 次调用返回的 (reason, cause, err)。
+type mockExtractor struct {
+	mu      sync.Mutex
+	results []extractorResult
+	calls   []string // 记录调用顺序（messageID）
+}
+
+type extractorResult struct {
+	reason string
+	cause  error
+	err    error
+}
+
+func (m *mockExtractor) Extract(ctx context.Context, messageID, url, name, ext string, size int64) (string, error, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, messageID)
+	if len(m.results) == 0 {
+		return "", nil, nil
+	}
+	r := m.results[0]
+	m.results = m.results[1:]
+	return r.reason, r.cause, r.err
+}
+
+// TestRateLimiter_Basic 消耗令牌 → 补充 → 消耗（默认 burst=rate，一秒内耗尽 rate 个token）。
+func TestRateLimiter_Basic(t *testing.T) {
+	rl := newRateLimiter(100)
+	// 首次调用应立即返（burst=100 有余额）
+	start := time.Now()
+	for i := 0; i < 50; i++ {
+		if err := rl.Wait(context.Background()); err != nil {
+			t.Fatalf("Wait: %v", err)
+		}
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("burst path should be fast, got %v", elapsed)
+	}
+}
+
+// TestRateLimiter_Unlimited docsPerSec<=0 不限速。
+func TestRateLimiter_Unlimited(t *testing.T) {
+	rl := newRateLimiter(0)
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		if err := rl.Wait(context.Background()); err != nil {
+			t.Fatalf("Wait: %v", err)
+		}
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Errorf("unlimited should be instant, got %v", elapsed)
+	}
+}
+
+// TestRateLimiter_CtxCancel ctx 取消 → Wait 立即返 err。
+func TestRateLimiter_CtxCancel(t *testing.T) {
+	rl := newRateLimiter(0.1) // 极慢，每 10s 一个令牌
+	// 先消耗初始 burst 让下次 wait 会阻塞
+	if err := rl.Wait(context.Background()); err != nil {
+		t.Fatalf("initial Wait unexpected err: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+	err := rl.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected error on ctx cancel")
+	}
+}
+
+// TestFormatDuration OS scroll TTL 参数格式化（"5m" / "30s"）。< 1s floor 到 "1s"（N4）。
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{5 * time.Minute, "5m"},
+		{30 * time.Second, "30s"},
+		{2 * time.Minute, "2m"},
+		{500 * time.Millisecond, "1s"}, // < 1s floor 到 "1s"（避免 OS scroll TTL 立即过期）
+		{0, "1s"},                      // 0 也 floor
+	}
+	for _, c := range cases {
+		if got := formatDuration(c.d); got != c.want {
+			t.Errorf("formatDuration(%v): got %q want %q", c.d, got, c.want)
+		}
+	}
+}
+
+// TestStats_TypeShape Stats 字段全 int64（K8s Job 退出码计算依赖），确保编译期锁死类型。
+func TestStats_TypeShape(t *testing.T) {
+	var s Stats
+	// 都必须支持 int64 递增
+	s.Scanned++
+	s.Extracted++
+	s.DLQ++
+	s.Skipped++
+	s.OSTransient++
+	if s.Scanned != 1 || s.Extracted != 1 || s.DLQ != 1 || s.Skipped != 1 || s.OSTransient != 1 {
+		t.Fatal("Stats fields did not increment as expected")
+	}
+}
+
+// TestConfig_ToExtractorConfig 字段转发正确。
+func TestConfig_ToExtractorConfig(t *testing.T) {
+	c := Config{
+		ESAddresses:     []string{"http://os:9200"},
+		ESIndex:         "octo-message",
+		ESUsername:      "u",
+		ESPassword:      "p",
+		TikaURL:         "http://tika:9998",
+		DownloadTimeout: 10 * time.Second,
+		ExtractTimeout:  20 * time.Second,
+		MaxFileSize:     1024,
+		MaxContentBytes: 2048,
+		HTTPRetries:     5,
+	}
+	ec := c.ToExtractorConfig()
+	if len(ec.ESAddresses) != 1 || ec.ESAddresses[0] != "http://os:9200" {
+		t.Errorf("ESAddresses: %v", ec.ESAddresses)
+	}
+	if ec.TikaURL != "http://tika:9998" || ec.MaxFileSize != 1024 || ec.HTTPRetries != 5 {
+		t.Errorf("mismatched fields: %+v", ec)
+	}
+}
+
+// TestSourceDoc_ParseFromHit sourceDoc 字段结构（防未来 refactor 破坏契约）。
+func TestSourceDoc_ParseFromHit(t *testing.T) {
+	d := sourceDoc{
+		MessageID: "42",
+		URL:       "https://cdn.deepminer.com.cn/x.pdf",
+		Name:      "x.pdf",
+		Extension: ".pdf",
+		Size:      1024,
+	}
+	if d.MessageID == "" || d.URL == "" {
+		t.Fatal("required fields empty")
+	}
+}
+
+// mkDoc 造一条 sourceDoc 用于 Runner.Run 测试。
+func mkDoc(id string) sourceDoc {
+	return sourceDoc{
+		MessageID: id,
+		URL:       "https://cdn.deepminer.com.cn/" + id + ".pdf",
+		Name:      id + ".pdf",
+		Extension: ".pdf",
+		Size:      1024,
+	}
+}
+
+// TestRun_HappyPath 5 条 doc 全 success → Extracted=5，DLQ=0，OSTransient=0。
+func TestRun_HappyPath(t *testing.T) {
+	src := &mockSource{batches: [][]sourceDoc{
+		{mkDoc("1"), mkDoc("2"), mkDoc("3")},
+		{mkDoc("4"), mkDoc("5")},
+	}}
+	ext := &mockExtractor{} // 空 results → 默认全 success
+	r := NewRunnerWith(src, ext, 0)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Scanned != 5 || stats.Extracted != 5 || stats.DLQ != 0 || stats.OSTransient != 0 {
+		t.Errorf("unexpected stats: %+v", stats)
+	}
+	if !src.closed {
+		t.Error("source should be closed after Run")
+	}
+	if len(ext.calls) != 5 {
+		t.Errorf("expected 5 extractor calls, got %d", len(ext.calls))
+	}
+}
+
+// TestRun_MixedOutcomes 5 条 doc 混合：3 success + 1 DLQ + 1 OSTransient → stats 全对。
+func TestRun_MixedOutcomes(t *testing.T) {
+	src := &mockSource{batches: [][]sourceDoc{{
+		mkDoc("1"), mkDoc("2"), mkDoc("3"), mkDoc("4"), mkDoc("5"),
+	}}}
+	ext := &mockExtractor{results: []extractorResult{
+		{}, // 1 → success
+		{reason: "oversize", cause: errors.New("too big")}, // 2 → DLQ
+		{},                               // 3 → success
+		{err: errors.New("os 500 boom")}, // 4 → OSTransient
+		{},                               // 5 → success
+	}}
+	r := NewRunnerWith(src, ext, 0)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Scanned != 5 {
+		t.Errorf("Scanned: got %d want 5", stats.Scanned)
+	}
+	if stats.Extracted != 3 {
+		t.Errorf("Extracted: got %d want 3", stats.Extracted)
+	}
+	if stats.DLQ != 1 {
+		t.Errorf("DLQ: got %d want 1", stats.DLQ)
+	}
+	if stats.OSTransient != 1 {
+		t.Errorf("OSTransient: got %d want 1", stats.OSTransient)
+	}
+}
+
+// TestRun_CtxCancelDuringLoop source.Next 返 context.Canceled → Run 优雅退出（err=nil）。
+// 覆盖 M4 修复：ctx.Canceled 不当作运行错误。
+func TestRun_CtxCancelDuringLoop(t *testing.T) {
+	src := &mockSource{
+		batches: [][]sourceDoc{{mkDoc("1"), mkDoc("2")}},
+		nextErr: context.Canceled, // 第一次 Next 就返 canceled
+	}
+	ext := &mockExtractor{}
+	r := NewRunnerWith(src, ext, 0)
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("ctx.Canceled from source should be graceful, got err=%v", err)
+	}
+	// canceled 场景 Scanned=0（一批都没拉出来）
+	if stats.Scanned != 0 || stats.Extracted != 0 {
+		t.Errorf("cancelled mid-fetch stats should be zero: %+v", stats)
+	}
+	if !src.closed {
+		t.Error("source should be closed even on cancel")
+	}
+}
+
+// TestRun_CtxDeadlineExceeded ctx timeout 期间 → 返 ErrTimeoutIncomplete（v1.13 P2-3）：
+// K8s Job 需要区分 timeout（提前退出，剩余未跑）vs signal-cancel（优雅退出），前者要 exit
+// non-zero 让 operator 知道重跑。
+func TestRun_CtxDeadlineExceeded(t *testing.T) {
+	src := &mockSource{
+		batches: [][]sourceDoc{{mkDoc("1")}},
+		nextErr: context.DeadlineExceeded,
+	}
+	ext := &mockExtractor{}
+	r := NewRunnerWith(src, ext, 0)
+	_, err := r.Run(context.Background())
+	if !errors.Is(err, ErrTimeoutIncomplete) {
+		t.Fatalf("ctx.DeadlineExceeded must return ErrTimeoutIncomplete (P2-3), got %v", err)
+	}
+}
+
+// TestRun_SourceRealError source 返非 ctx 类错 → Run 上抛（K8s Job 退 1）。
+func TestRun_SourceRealError(t *testing.T) {
+	realErr := errors.New("os 502 bad gateway")
+	src := &mockSource{nextErr: realErr}
+	ext := &mockExtractor{}
+	r := NewRunnerWith(src, ext, 0)
+	_, err := r.Run(context.Background())
+	if !errors.Is(err, realErr) {
+		t.Fatalf("expected real error propagate, got %v", err)
+	}
+}
+
+// TestParseHits_SnowflakePrecision 🔴 S1 回归测试：
+// 19 位 snowflake messageId 通过 json.Number + UseNumber() 保精度，不再变科学计数法。
+// 参考 internal/esindex/buildraw.go:22 精度铁律。
+func TestParseHits_SnowflakePrecision(t *testing.T) {
+	// 真实 snowflake id 长度 18-19 位，超 float64 精度上限 2^53 (~9e15)
+	realIDs := []string{
+		"1234567890123456789", // 19 位典型 snowflake
+		"9007199254740993",    // 2^53 + 1（float64 首次丢精度的边界）
+		"12345678901234567",   // 17 位（略超 2^53）
+	}
+	for _, id := range realIDs {
+		body := []byte(`{"messageId":` + id + `,"payload":{"file":{"url":"https://x/y.pdf","name":"y.pdf","extension":".pdf","size":1024}}}`)
+		hit := opensearchapi.SearchHit{Source: body}
+		docs := (&osScrollSource{}).parseHits([]opensearchapi.SearchHit{hit})
+		if len(docs) != 1 {
+			t.Fatalf("id=%s: expected 1 doc, got %d", id, len(docs))
+		}
+		if docs[0].MessageID != id {
+			t.Errorf("id=%s: precision loss — got %q want %q", id, docs[0].MessageID, id)
+		}
+		if docs[0].Size != 1024 {
+			t.Errorf("id=%s: size mismatch — got %d", id, docs[0].Size)
+		}
+	}
+}
+
+// TestParseHits_MissingMessageIDSkipped messageId 字段缺失 → 单条跳过，不 panic。
+func TestParseHits_MissingMessageIDSkipped(t *testing.T) {
+	body := []byte(`{"payload":{"file":{"url":"x"}}}`)
+	hit := opensearchapi.SearchHit{Source: body}
+	docs := (&osScrollSource{}).parseHits([]opensearchapi.SearchHit{hit})
+	if len(docs) != 0 {
+		t.Errorf("missing messageId should skip, got %d docs", len(docs))
+	}
+}
+
+// TestParseHits_MalformedJSONSkipped 损坏 JSON → 单条跳过，其他 hit 正常处理。
+func TestParseHits_MalformedJSONSkipped(t *testing.T) {
+	hits := []opensearchapi.SearchHit{
+		{Source: []byte(`{not json}`)},
+		{Source: []byte(`{"messageId":42,"payload":{"file":{"url":"x","size":8}}}`)},
+	}
+	docs := (&osScrollSource{}).parseHits(hits)
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 good doc, got %d", len(docs))
+	}
+	if docs[0].MessageID != "42" {
+		t.Errorf("MessageID: got %q", docs[0].MessageID)
+	}
+}
+
+// TestBuildFirstBatchQuery_ExcludesTombstone Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2)：
+// scroll 首批 query 必须同时用 must_not 过滤 (1) content 缺失 (2) contentMeta.status=unextractable，
+// 防 permanent-fail 文件每次 rerun 都被重新 DLQ。
+func TestBuildFirstBatchQuery_ExcludesTombstone(t *testing.T) {
+	q := buildFirstBatchQuery(500)
+	body, err := json.Marshal(q)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(body)
+	// filter: term payload.type=8
+	if !strings.Contains(s, `"payload.type":8`) {
+		t.Errorf("query must filter payload.type=8, got: %s", s)
+	}
+	// must_not: exists content
+	if !strings.Contains(s, `"exists":{"field":"payload.file.content"}`) {
+		t.Errorf("query must have must_not exists content, got: %s", s)
+	}
+	// Round-3 Blocker B: must_not term status=unextractable
+	if !strings.Contains(s, `"payload.file.contentMeta.status":"unextractable"`) {
+		t.Errorf("query must exclude tombstone via must_not term contentMeta.status=unextractable, got: %s", s)
+	}
+	if !strings.Contains(s, `"size":500`) {
+		t.Errorf("query must carry size=500, got: %s", s)
+	}
+}
+
+// TestTombstoneStatusValue_HardcodedContract 契约锁：filebackfill 侧 tombstoneStatusValue
+// 必须硬编码为 "unextractable"（与 fileextract/oswriter.go tombstoneStatus 同字符串）。
+// 两包独立断言同一字面值，改任一处不改另一处 → CI 挂。避免跨包 import 膨胀。
+func TestTombstoneStatusValue_HardcodedContract(t *testing.T) {
+	if tombstoneStatusValue != "unextractable" {
+		t.Fatalf("filebackfill.tombstoneStatusValue must == \"unextractable\" (fileextract-side tombstone status), got %q", tombstoneStatusValue)
+	}
+}

--- a/internal/filebackfill/source.go
+++ b/internal/filebackfill/source.go
@@ -1,0 +1,268 @@
+package filebackfill
+
+// source.go — OS scroll query 反查 type=8 且 payload.file.content 缺失的 doc（IDX-5 backfill 源）。
+//
+// 用 OS scroll API 而非 search_after + PIT：scroll 简单够用，一次性 Job 场景不追求实时性。
+// query DSL：
+//   {
+//     "size": <ScrollSize>,
+//     "query": {
+//       "bool": {
+//         "filter": [{"term":{"payload.type":8}}],
+//         "must_not": [{"exists":{"field":"payload.file.content"}}]
+//       }
+//     },
+//     "_source": ["messageId","payload.file"]
+//   }
+// 幂等：`must_not exists content` 自动跳过已抽取 doc，重跑无副作用。
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// sourceDoc 是 scroll 拉出的一条待回填 doc 摘要。
+type sourceDoc struct {
+	MessageID string
+	URL       string
+	Name      string
+	Extension string
+	Size      int64
+}
+
+// tombstoneStatusValue 是 backfill scroll query 用来排除 permanent-fail tombstone doc 的
+// contentMeta.status 值。**必须**与 internal/fileextract/oswriter.go tombstoneStatus 严格
+// 一致（Round-3 Blocker B fix）。跨包不 import 避免 filebackfill → fileextract 依赖膨胀，
+// 靠 TestTombstoneStatusValue_MatchesFileextract 契约 test 锁死同步。
+const tombstoneStatusValue = "unextractable"
+
+// osScrollSource 用 OS scroll API 遍历待回填 doc。
+type osScrollSource struct {
+	client    *opensearchapi.Client
+	index     string
+	size      int
+	scrollTTL time.Duration
+	scrollID  string // 首批后由 OS 返回
+	exhausted bool
+}
+
+func newOSScrollSource(cfg Config) (*osScrollSource, error) {
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: cfg.ESAddresses,
+			Username:  cfg.ESUsername,
+			Password:  cfg.ESPassword,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("filebackfill: new opensearch client: %w", err)
+	}
+	size := cfg.ScrollSize
+	if size <= 0 {
+		size = 500
+	}
+	ttl := cfg.ScrollTTL
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	if ttl < time.Second {
+		// OS scroll TTL 精度到秒；< 1s 会被 formatDuration floor 到 "1s"，
+		// 显式在构造期兜底避免运维改 config 后困惑「为啥我设 500ms 没生效」。
+		ttl = time.Second
+	}
+	return &osScrollSource{
+		client:    client,
+		index:     cfg.ESIndex,
+		size:      size,
+		scrollTTL: ttl,
+	}, nil
+}
+
+// Next 拉下一批。首批调 /_search + scroll=<TTL>；后续调 /_search/scroll 用 scroll_id。
+// 返回 (docs, io.EOF) 表示遍历完（docs 可能是空）。
+func (s *osScrollSource) Next(ctx context.Context) ([]sourceDoc, error) {
+	if s.exhausted {
+		return nil, io.EOF
+	}
+	if s.scrollID == "" {
+		return s.firstBatch(ctx)
+	}
+	return s.continueScroll(ctx)
+}
+
+func (s *osScrollSource) firstBatch(ctx context.Context) ([]sourceDoc, error) {
+	body, err := json.Marshal(buildFirstBatchQuery(s.size))
+	if err != nil {
+		return nil, fmt.Errorf("filebackfill: marshal scroll query: %w", err)
+	}
+	req := &opensearchapi.SearchReq{
+		Indices: []string{s.index},
+		Body:    bytes.NewReader(body),
+		Params:  opensearchapi.SearchParams{Scroll: s.scrollTTL},
+	}
+	resp, err := s.client.Search(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("filebackfill: first scroll search: %w", err)
+	}
+	if resp.ScrollID != nil {
+		s.scrollID = *resp.ScrollID
+	}
+	return s.parseHits(resp.Hits.Hits), nil
+}
+
+// buildFirstBatchQuery 构造 backfill scroll 首批查询 DSL（抽出便于单测）。
+//
+// Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2)：must_not 加 term 过滤
+// `payload.file.contentMeta.status = tombstoneStatusValue`，排除已被 file-extractor
+// 标记为 permanent-fail 的 tombstone doc。防 backfill Job rerun 无限重复 DLQ 已知永久
+// 失败文件（之前 must_not 只查 content 缺失，permanent-fail 文件永远匹配 → 每次 rerun
+// 都重复 DLQ → DLQ 无界增长）。tombstone 常量与 fileextract/oswriter.go tombstoneStatus
+// 严格对齐（有 test 契约锁）。用结构体 + json.Marshal 构造，避免字符串拼接。
+func buildFirstBatchQuery(size int) map[string]any {
+	return map[string]any{
+		"size": size,
+		"query": map[string]any{
+			"bool": map[string]any{
+				"filter": []map[string]any{{"term": map[string]any{"payload.type": 8}}},
+				"must_not": []map[string]any{
+					{"exists": map[string]any{"field": "payload.file.content"}},
+					{"term": map[string]any{"payload.file.contentMeta.status": tombstoneStatusValue}},
+				},
+			},
+		},
+		"_source": []string{"messageId", "payload.file"},
+	}
+}
+
+// continueScroll 用 scroll_id 请求下一批。走裸 HTTP：
+// opensearch-go v3.1.0 的 opensearchapi 未提供高层 ScrollReq，
+// 但 client.Client 是底层 opensearch.Client 可发裸请求。
+func (s *osScrollSource) continueScroll(ctx context.Context) ([]sourceDoc, error) {
+	body, err := json.Marshal(map[string]string{
+		"scroll":    formatDuration(s.scrollTTL),
+		"scroll_id": s.scrollID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("filebackfill: marshal continue scroll body: %w", err)
+	}
+	req, err := opensearch.BuildRequest("POST", "/_search/scroll", bytes.NewReader(body), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Client.Perform(req.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("filebackfill: continue scroll: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // close-on-read: nothing to do with close err
+	raw, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("filebackfill: continue scroll read body: %w", readErr)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("filebackfill: continue scroll status %d: %s", resp.StatusCode, string(raw))
+	}
+	var out struct {
+		ScrollID *string `json:"_scroll_id"`
+		Hits     struct {
+			Hits []opensearchapi.SearchHit `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("filebackfill: parse scroll response: %w", err)
+	}
+	if out.ScrollID != nil {
+		s.scrollID = *out.ScrollID
+	}
+	hits := s.parseHits(out.Hits.Hits)
+	if len(hits) == 0 {
+		s.exhausted = true
+		return nil, io.EOF
+	}
+	return hits, nil
+}
+
+// parseHits 从 SearchHit slice 里抽 messageId + payload.file 字段。
+//
+// 🔴 精度铁律：messageId 是 OS mapping 声明的 long（snowflake 19 位 > 2^53），MUST 走
+// json.Decoder + UseNumber() 保精度。默认 json.Unmarshal 遇到 interface{}/any 目标会把
+// JSON number 解成 float64，snowflake 会被截断成 "1.234e+18"，作为 OS `_id` 打不到 doc。
+// 参考 internal/esindex/buildraw.go:22 段落警告 + decodeObjectUseNumber helper。
+func (s *osScrollSource) parseHits(hits []opensearchapi.SearchHit) []sourceDoc {
+	docs := make([]sourceDoc, 0, len(hits))
+	for _, h := range hits {
+		var src struct {
+			MessageID json.Number `json:"messageId"`
+			Payload   struct {
+				File struct {
+					URL       string      `json:"url"`
+					Name      string      `json:"name"`
+					Extension string      `json:"extension"`
+					Size      json.Number `json:"size"`
+				} `json:"file"`
+			} `json:"payload"`
+		}
+		dec := json.NewDecoder(bytes.NewReader(h.Source))
+		dec.UseNumber()
+		if err := dec.Decode(&src); err != nil {
+			continue // 单条解析失败跳过
+		}
+		msgID := src.MessageID.String()
+		if msgID == "" {
+			continue
+		}
+		var size int64
+		if src.Payload.File.Size != "" {
+			if n, err := src.Payload.File.Size.Int64(); err == nil {
+				size = n
+			}
+		}
+		docs = append(docs, sourceDoc{
+			MessageID: msgID,
+			URL:       src.Payload.File.URL,
+			Name:      src.Payload.File.Name,
+			Extension: src.Payload.File.Extension,
+			Size:      size,
+		})
+	}
+	return docs
+}
+
+// Close 清理 scroll 上下文。best-effort，不 block Job 退出。
+func (s *osScrollSource) Close(ctx context.Context) error {
+	if s.scrollID == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string][]string{"scroll_id": {s.scrollID}})
+	if err != nil {
+		return err
+	}
+	req, err := opensearch.BuildRequest("DELETE", "/_search/scroll", bytes.NewReader(body), nil, nil)
+	if err != nil {
+		return err
+	}
+	// Close scroll 是尽力操作（scroll ctx 会自动过期），错误只 log 不阻断。
+	if _, perr := s.client.Client.Perform(req.WithContext(ctx)); perr != nil {
+		// intentional: 忽略 close 失败（scroll 后 5 min 自动 GC）；不返 err 以免 Runner defer 报误。
+		_ = perr
+	}
+	return nil
+}
+
+// formatDuration 把 Duration 转成 OS scroll 参数格式（"5m" / "30s" 而非 Go "5m0s"）。
+// < 1s 会被 floor 到 "1s"，避免误配置让 OS 视 scroll TTL 为 0 → scroll context 立即过期。
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return "1s"
+	}
+	if d >= time.Minute {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	return fmt.Sprintf("%ds", int(d/time.Second))
+}

--- a/internal/fileextract/backfill_bridge.go
+++ b/internal/fileextract/backfill_bridge.go
@@ -1,0 +1,24 @@
+package fileextract
+
+// backfill_bridge.go — 为 internal/filebackfill 提供一个跨包边界安全的 wrapper：
+// 因为 filePayload 是本包 unexported struct（保持解析细节内部封装），backfill 复用抽取核心
+// 时不能直接构造 *filePayload，故用这个纯值参数的桥梁函数代替。
+//
+// 语义与 Extractor.ExtractAndWrite 完全一致，只是把 *filePayload 拆成入参字段。
+
+import "context"
+
+// ExtractAndWriteForBackfill 为 backfill 场景包装 Extractor.ExtractAndWrite。
+// 返回签名同 Extractor.ExtractAndWrite：
+//   - (reason="", cause=nil, err=nil) → 成功
+//   - (reason=非空, cause=err, err=nil) → 应投 DLQ
+//   - (reason="", cause=nil, err=非空) → OS transient (含 errDocNotYet)，caller 决定重试策略
+func ExtractAndWriteForBackfill(ctx context.Context, e *Extractor, messageID, url, name, ext string, size int64) (string, error, error) {
+	fp := &filePayload{
+		URL:       url,
+		Name:      name,
+		Extension: ext,
+		Size:      size,
+	}
+	return e.ExtractAndWrite(ctx, messageID, fp)
+}

--- a/internal/fileextract/backoff.go
+++ b/internal/fileextract/backoff.go
@@ -1,0 +1,54 @@
+package fileextract
+
+// backoff.go — in-place bounded retry 用的退避与 sleep helper。
+// 复制自 internal/consumer/backoff.go 但参数化 Max（fileextract 允许 cfg 调整上限）。
+// 不 import consumer 包避免循环依赖 + 保持 fileextract 独立可测。
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// defaultBackoffMax 是 in-place retry 单次退避的默认上限（cfg 不设时用）。
+const defaultBackoffMax = 60 * time.Second
+
+// expJitterBackoff 计算第 attempt 次（1-based）的指数退避 + 满抖动（full jitter）时长：
+// base*2^(attempt-1) 截到 max，再在 [0, that] 区间随机取值打散并发副本的重试节拍
+// （缓解 thundering herd）。attempt<=0 视为 1；base<=0 返 0；max<=0 用 defaultBackoffMax。
+func expJitterBackoff(base, max time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	if max <= 0 {
+		max = defaultBackoffMax
+	}
+	d := base
+	for i := 1; i < attempt && d < max; i++ {
+		d *= 2
+	}
+	if d > max {
+		d = max
+	}
+	// full jitter：[0, d] 上均匀取样。
+	return time.Duration(rand.Int63n(int64(d) + 1)) //nolint:gosec // 抖动非安全用途
+}
+
+// sleepCtx 在 ctx 取消时尽早返回（SIGTERM/timeout 立即关停，不被 sleep 拖住）。
+// 返回 ctx.Err()（被取消则非 nil）。d<=0 时仅检查一次 ctx。
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/fileextract/config.go
+++ b/internal/fileextract/config.go
@@ -1,0 +1,80 @@
+// Package fileextract 是 cmd/file-extractor 独立服务的核心包（v1.12 file content indexing）。
+//
+// 定位：跟 es-indexer 同一个 Kafka topic `octo.message.v1{,.prod}`，独立 consumer group
+// `file-extractor`（不抢 es-indexer 位点）。命中 payload.type=8 (File) 的消息 → 下载 CDN 文件
+// → 调 Tika HTTP 抽取正文 → OS partial `_update` 只写 payload.file.content + contentMeta。
+// 命中非 file 类型 → commit 位点跳过。
+//
+// 与 internal/consumer 的关系：
+//   - 结构镜像 internal/consumer/{service.go, consumer.go, kafka.go, dlq.go}（消费组
+//     协调、CommitInterval=0 手动提交、DLQ Kafka producer、per-batch 处理循环），保持团队
+//     心智模型一致；不 import consumer 包避免循环依赖 + 保持本包独立可测。
+//   - 与 esindex.Writer 语义不同：Writer 走 _bulk index (upsert 主 doc)，fileextract.osWriter
+//     走 _update (partial merge，只覆盖 content/contentMeta，doc_as_upsert=false 避免造孤儿子文档）。
+//     故不复用 esindex.Writer，本包新增 osWriter。
+package fileextract
+
+import "time"
+
+// ServiceConfig 是 file-extractor 服务的运行配置（由 cmd 从环境装配）。
+//
+// Kafka + OS 部分复用 es-indexer 的配置形态（同 topic 不同 groupID + 同 alias 不同写入模式）。
+type ServiceConfig struct {
+	// Kafka
+	Brokers   []string
+	Topic     string
+	DLQTopic  string
+	GroupID   string
+	BatchSize int
+
+	// OpenSearch（partial _update 目标）
+	ESAddresses []string
+	ESIndex     string
+	ESUsername  string
+	ESPassword  string
+
+	// Tika / Download / Extract
+	TikaURL         string        // http://localhost:9998（sidecar 部署方案 α）
+	DownloadTimeout time.Duration // 单次 CDN GET 超时（默认 30s）
+	ExtractTimeout  time.Duration // Tika PUT /tika 超时（默认 30s）
+	MaxFileSize     int64         // 单文件抽取 size cutoff（默认 20MB）
+	MaxContentBytes int           // 抽出文本截断（默认 256KB）
+	HTTPRetries     int           // CDN GET 重试次数（默认 3，指数退避 1s/2s/4s/8s）
+
+	// 时序竞态防护（v2 §7 #1）：启动时 sleep 缓解首启动瞬间 file-extractor 比
+	// es-indexer 抢先跑到 OS _update 返 404 的窄窗口。稳态竞态由 errDocNotYet + in-place
+	// bounded retry 兜底（v1.13 Blocker #2 fix）。
+	ExtractStartupDelay time.Duration
+
+	// v1.13 Blocker #2 fix — in-place bounded retry 参数。
+	// 单条消息 in-place retry 最大次数（默认 10）。达上限 → 强制 DLQ ReasonRetryExhausted
+	// + commit offset，避免 partition 永久阻塞。生产按 OS SLA 与业务延迟容忍度调。
+	MaxRetriesPerMessage int
+	// TransientBackoffBase 是 in-place retry 指数退避基（默认 1s）。第 N 次重试 sleep =
+	// min(Base × 2^(N-1), Max) + 满抖动。SIGTERM 立即返（ctx 感知）。
+	TransientBackoffBase time.Duration
+	// TransientBackoffMax 是单次退避上限（默认 60s），避免指数增长到不可接受延迟。
+	TransientBackoffMax time.Duration
+
+	// v1.13 Blocker #1 fix — SSRF 防护参数。
+	// AllowedDownloadHosts 是 CDN 下载 URL 的 host 白名单（默认 ["cdn.deepminer.com.cn"]）。
+	// URL host 不在此列则 pre-check 拒绝（不下载）。future 切内网 COS 通过 env 扩展。
+	AllowedDownloadHosts []string
+	// AllowedDownloadSchemes 是 URL scheme 白名单（默认 ["https"]）。
+	AllowedDownloadSchemes []string
+	// SSRFAllowLoopback：**仅测试用**，允许 dial 解析到 127.0.0.1 / ::1 loopback IP。
+	// 生产**必须 false**（默认）：loopback 是 SSRF 目标之一（内网服务）。test 场景
+	// httptest.NewServer 走 127.0.0.1 才需打开。
+	SSRFAllowLoopback bool
+
+	// v1.13 P2-1 fix (yujiawei review) — DLQ 投递有界重试 + 本地 spill 逃逸。
+	// 老代码 writeDLQ 直接调 dlqSink.WriteDLQ 失败即 outcomeFatal 全 worker 停 —— 与 consumer
+	// 侧成熟的「有界重试 → spill 落盘 → 越过 offset」pattern 不对称。补齐同 pattern。
+	// DLQMaxRetries：DLQ 投递自身 transient 失败的有界重试次数（默认 5）。
+	DLQMaxRetries int
+	// DLQRetryBackoff：DLQ 重试退避基（指数 + 满抖动，默认 200ms）。
+	DLQRetryBackoff time.Duration
+	// DLQSpillDir：DLQ 写耗尽时本地落地目录。为空 → 硬停返 errDLQHardStop（K8s 重启保 offset）；
+	// 非空 → 落盘 + 告警 + 越过 offset（绝不永久卡 partition，回灌工具从此读文件重投）。
+	DLQSpillDir string
+}

--- a/internal/fileextract/consumer.go
+++ b/internal/fileextract/consumer.go
@@ -1,0 +1,349 @@
+// Package fileextract consumer 主循环：pull batch → filter type=8 → 抽取 → OS partial update
+// → DLQ 路由 → in-place bounded retry state machine → 按分区连续成功前缀 commit。
+//
+// v1.13 Blocker #2 fix：从"单条独立 commit + err 上抛"改为"batch 内 in-place bounded retry
+// state machine"（照抄 internal/consumer pattern）。老 pattern 触发 silent skip / data loss：
+// kafka-go FetchMessage 在 fetch 时执行 r.offset = m.message.Offset + 1，err 上抛不 commit
+// 后 reader 已经 advance，后续 message commit 越过前面 → 永久丢。
+//
+// 新语义（对齐 internal/consumer::processBatch）：
+//   - 一批消息进 processBatch → dispositions state machine（transient/ok/dlqResolved）
+//   - 每轮对仍 transient 条目跑 attemptOne → 更新 disposition
+//   - 达 MaxRetriesPerMessage 上限的 transient → 强制 DLQ ReasonRetryExhausted + 标 dlqResolved
+//     （避免 partition 永久阻塞）
+//   - 每轮结束按 partitionCommitPoints 推进 commit（每分区连续可越过前缀末）
+//   - 全部条目终态 → 本批完成，拉下一批
+package fileextract
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// Processor 串起一轮批处理。字段命名对齐 consumer/consumer.go Processor 便于阅读。
+type Processor struct {
+	source    messageSource
+	dlqSink   dlqSink
+	dlq       *dlqHandler // v1.13 P2-1：DLQ 投递有界重试 + spill 逃逸（yujiawei review fix）
+	metrics   *counters
+	extractor extractorService
+	cfg       ServiceConfig
+	// sleep 由 backoff.go 提供；抽成字段便于测试注入（跳过真实 sleep）。
+	sleep func(context.Context, time.Duration) error
+}
+
+// extractorService 抽象「抽取 + OS partial update」核心行为，供 Processor 测试注入 mock。
+// 生产实现是 *Extractor（extractor.go），本 interface 只暴露 processOne/attemptOne 需要的
+// 单个方法，便于最小化 test surface。
+type extractorService interface {
+	ExtractAndWrite(ctx context.Context, messageID string, fp *filePayload) (dlqReason string, cause error, err error)
+}
+
+// defaultMaxRetriesPerMessage 是单条消息 in-place retry 上限的兜底默认（cfg 未设时用）。
+// 10 次 + backoff 1s→60s → 单条最坏阻塞 ~10 min（业务 SLO 允许）。
+const defaultMaxRetriesPerMessage = 10
+
+// NewProcessor 组装 Processor（生产用；extractor 必须非 nil）。
+// ext 类型为 extractorService interface：生产传 *Extractor，测试注入 mock。
+func NewProcessor(src messageSource, dlq dlqSink, ext extractorService, cfg ServiceConfig) *Processor {
+	if cfg.MaxRetriesPerMessage <= 0 {
+		cfg.MaxRetriesPerMessage = defaultMaxRetriesPerMessage
+	}
+	if cfg.TransientBackoffBase <= 0 {
+		cfg.TransientBackoffBase = time.Second
+	}
+	if cfg.TransientBackoffMax <= 0 {
+		cfg.TransientBackoffMax = defaultBackoffMax
+	}
+	// v1.13 P2-1：dlqHandler 有界重试 + spill 逃逸（yujiawei review fix）。缺 SpillDir 时
+	// DLQ 写耗尽 → errDLQHardStop → outcomeFatal → Run 停 worker + K8s 重启（保 offset 不推进）。
+	// 配 SpillDir 后转成落盘 + 告警 + offset 越过（绝不永久卡 partition）。
+	handler := newDLQHandler(dlq, newLogAlerter(log.Printf), dlqHandlerConfig{
+		MaxRetries:   cfg.DLQMaxRetries,
+		RetryBackoff: cfg.DLQRetryBackoff,
+		SpillDir:     cfg.DLQSpillDir,
+	})
+	return &Processor{
+		source:    src,
+		dlqSink:   dlq,
+		dlq:       handler,
+		metrics:   &counters{},
+		extractor: ext,
+		cfg:       cfg,
+		sleep:     sleepCtx,
+	}
+}
+
+// Run 持续消费直到 ctx 取消。每轮拉一批 → processBatch → 短暂间隔（避免空转打满 CPU）。
+func (p *Processor) Run(ctx context.Context) error {
+	// v2 §7 #1 时序竞态缓解：启动时 sleep 5s（可配），给 es-indexer 先跑机会。
+	// 稳态竞态由 in-place bounded retry 兜底（v1.13 Blocker #2 fix）。
+	if p.cfg.ExtractStartupDelay > 0 {
+		log.Printf("file-extractor: startup delay %v (mitigate es-indexer race)", p.cfg.ExtractStartupDelay)
+		select {
+		case <-time.After(p.cfg.ExtractStartupDelay):
+		case <-ctx.Done():
+			return nil
+		}
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		batch, err := p.fetchBatch(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.Printf("file-extractor: fetch error: %v", err)
+			select {
+			case <-time.After(500 * time.Millisecond):
+			case <-ctx.Done():
+				return nil
+			}
+			continue
+		}
+		if len(batch) == 0 {
+			continue
+		}
+		if err := p.processBatch(ctx, batch); err != nil {
+			// DLQ 硬停 fatal 或 ctx 取消 → Run 退出（K8s 重启保 offset 未推进）
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.Printf("file-extractor: processBatch fatal, stopping Run: %v", err)
+			return err
+		}
+	}
+}
+
+// fetchBatch 拉一批消息（BatchSize 上限），拿到就返回；单条 fetch 失败上抛。
+// 首条阻塞等，后续 10ms 短超时凑批。
+func (p *Processor) fetchBatch(ctx context.Context) ([]fetchedMessage, error) {
+	size := p.cfg.BatchSize
+	if size <= 0 {
+		size = 50
+	}
+	batch := make([]fetchedMessage, 0, size)
+	for len(batch) < size {
+		fetchCtx := ctx
+		var cancel context.CancelFunc
+		if len(batch) > 0 {
+			fetchCtx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
+		}
+		m, err := p.source.Fetch(fetchCtx)
+		if cancel != nil {
+			cancel()
+		}
+		if err != nil {
+			if len(batch) > 0 && fetchCtx.Err() != nil {
+				return batch, nil // 超时凑批就走
+			}
+			return batch, err
+		}
+		batch = append(batch, m)
+	}
+	return batch, nil
+}
+
+// attemptOutcome 是 attemptOne 单次尝试的结果（v1.13 Blocker #2）。
+type attemptOutcome int
+
+const (
+	// outcomeOK 抽取 + OS 写入成功。
+	outcomeOK attemptOutcome = iota
+	// outcomeDLQ 已投 DLQ（永久失败：parse_error / oversize / blacklist_ext /
+	// download_failed / extract_* / os_permanent）。offset 可越过。
+	outcomeDLQ
+	// outcomeTransient 需重试（errDocNotYet / errOSTransient / 429/5xx）。
+	// caller 应下轮再调 attemptOne（或达上限强制 DLQ）。
+	outcomeTransient
+	// outcomeFatal 硬停（DLQ 写失败）；上抛让 Run 停 worker，保 offset 未推进。
+	outcomeFatal
+)
+
+// processBatch 批内 in-place bounded retry state machine（v1.13 Blocker #2 fix 核心）。
+//
+// 语义（对齐 internal/consumer::processBatch）：
+//  1. dispositions 初始全 transient；attempts 每条独立计数
+//  2. 每轮对仍 transient 条目跑 attemptOne：
+//     - attempts[i] > 0 时先退避（指数 + jitter，ctx 感知）
+//     - attempts[i] >= MaxRetriesPerMessage → 强制 DLQ ReasonRetryExhausted，标 dlqResolved
+//     - 否则调 attemptOne，按 outcome 更新 disposition + attempts[i]++
+//  3. 有条目终态变更 → 按 partitionCommitPoints 推进 commit（多分区各自前缀末）
+//  4. 全部终态 → return nil
+//  5. attemptOne 返 outcomeFatal → 立即 return err（Run 停 worker）
+func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) error {
+	n := len(batch)
+	dispositions := make([]itemDisposition, n)
+	attempts := make([]int, n)
+	// 初始全部 transient（下面 attemptOne 后按 outcome 收敛）
+	for i := range dispositions {
+		dispositions[i] = dispTransient
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		changed := false
+		for i, m := range batch {
+			if dispositions[i] != dispTransient {
+				continue
+			}
+
+			// 达重试上限 → 强制 DLQ ReasonRetryExhausted（避免 partition 永久阻塞）
+			if attempts[i] >= p.cfg.MaxRetriesPerMessage {
+				if werr := p.writeDLQ(ctx, m, ReasonRetryExhausted, "", nil,
+					fmt.Errorf("in-place retry exhausted after %d attempts", attempts[i])); werr != nil {
+					return werr // DLQ 硬停 fatal
+				}
+				p.metrics.IncRetryExhausted()
+				p.metrics.IncDLQ()
+				dispositions[i] = dispDLQResolved
+				changed = true
+				continue
+			}
+
+			// 退避（attempts[i]>0 才 sleep；1-based attempt = attempts[i]+1）
+			if attempts[i] > 0 {
+				if serr := p.sleep(ctx, expJitterBackoff(p.cfg.TransientBackoffBase, p.cfg.TransientBackoffMax, attempts[i])); serr != nil {
+					return serr
+				}
+			}
+
+			outcome, err := p.attemptOne(ctx, m)
+			attempts[i]++
+			switch outcome {
+			case outcomeOK:
+				dispositions[i] = dispOK
+				changed = true
+			case outcomeDLQ:
+				dispositions[i] = dispDLQResolved
+				changed = true
+			case outcomeTransient:
+				// 保持 transient，下轮继续（或触发上限）
+			case outcomeFatal:
+				return err
+			}
+		}
+
+		// 有条目终态 → 按分区推进连续前缀 commit
+		if changed {
+			for _, point := range partitionCommitPoints(batch, dispositions) {
+				if err := p.source.Commit(ctx, point); err != nil {
+					return fmt.Errorf("commit offset (partition=%d offset=%d): %w",
+						point.Partition, point.Offset, err)
+				}
+			}
+		}
+
+		// 全终态 → 本批完成
+		if !hasTransient(dispositions) {
+			return nil
+		}
+	}
+}
+
+// attemptOne 单次抽取尝试（v1.13 Blocker #2 fix）。
+// 返回 (outcome, err)。outcome 见 attemptOutcome 常量；err 仅在 outcomeFatal 时非 nil。
+//
+// P2-2：errOSPermanent 走 DLQ ReasonOSPermanent（老代码只上抛 err → 无 DLQ 路径 →
+// 与 Blocker #2 老 skip 语义叠加 → 4xx 永久错误也被 silent skip）。
+func (p *Processor) attemptOne(ctx context.Context, m fetchedMessage) (attemptOutcome, error) {
+	var msg searchmsg.Message
+	if err := json.Unmarshal(m.Value, &msg); err != nil {
+		p.metrics.IncDLQ()
+		if werr := p.writeDLQ(ctx, m, ReasonParseError, "", nil, err); werr != nil {
+			return outcomeFatal, werr
+		}
+		return outcomeDLQ, nil
+	}
+	fp, isFile := extractContentTypeFile(msg.RawPayload)
+	if !isFile {
+		p.metrics.IncSkippedNonFile()
+		return outcomeOK, nil
+	}
+	p.metrics.IncProcessed()
+	dlqReason, cause, err := p.extractor.ExtractAndWrite(ctx, msg.MessageID, fp)
+	if err != nil {
+		// P2-2：OS permanent 4xx → 走 DLQ ReasonOSPermanent（不走 transient retry）
+		if errors.Is(err, errOSPermanent) {
+			p.metrics.IncDLQ()
+			p.metrics.IncOSPermanent()
+			if werr := p.writeDLQ(ctx, m, ReasonOSPermanent, msg.MessageID, fp, err); werr != nil {
+				return outcomeFatal, werr
+			}
+			return outcomeDLQ, nil
+		}
+		if errors.Is(err, errDocNotYet) {
+			p.metrics.IncDocNotYet()
+		}
+		// 其他 OS transient / errDocNotYet → 交给 processBatch 状态机重试
+		return outcomeTransient, nil
+	}
+	if dlqReason != "" {
+		p.metrics.IncDLQ()
+		if werr := p.writeDLQ(ctx, m, dlqReason, msg.MessageID, fp, cause); werr != nil {
+			return outcomeFatal, werr
+		}
+		return outcomeDLQ, nil
+	}
+	return outcomeOK, nil
+}
+
+// processOne 单次尝试的兼容 wrapper（供老 test 直接调用）。
+//   - outcomeOK / outcomeDLQ → nil
+//   - outcomeTransient → 上抛 errTransientNeedsRetry（暴露"需要 caller 重试"语义）
+//   - outcomeFatal → 上抛具体 err（DLQ 写失败等）
+//
+// 生产路径不用 processOne；processBatch 走 attemptOne + state machine。
+func (p *Processor) processOne(ctx context.Context, m fetchedMessage) error {
+	outcome, err := p.attemptOne(ctx, m)
+	switch outcome {
+	case outcomeOK, outcomeDLQ:
+		return nil
+	case outcomeTransient:
+		return errTransientNeedsRetry
+	default: // outcomeFatal
+		return err
+	}
+}
+
+// errTransientNeedsRetry 是 processOne 老签名（单次尝试）向 caller 表达"需要 in-place retry"
+// 的 sentinel。生产路径不会返 —— processBatch 状态机内部消化 transient 语义。仅供 test 断言。
+var errTransientNeedsRetry = errors.New("fileextract: transient error needs in-place retry")
+
+// writeDLQ 构造 dlqRecord → 通过 dlqHandler 有界重试 + spill 逃逸投递到 DLQ topic。
+// 返回 nil 表示已终态处理（投递成功 or spill 落盘）—— caller 可放心越过 offset；返回 error 表示
+// 硬停（errDLQHardStop：未配 SpillDir 且 DLQ 写耗尽）—— caller 应走 outcomeFatal 让 Run 停 worker。
+// key 用原消息 key（=messageId）保证分区一致性 + spill 文件命名有意义。
+func (p *Processor) writeDLQ(ctx context.Context, m fetchedMessage, reason, messageID string, fp *filePayload, cause error) error {
+	value, truncated := truncateValueIfNeeded(m.Value)
+	rec := dlqRecord{
+		Reason:           reason,
+		Topic:            m.Topic,
+		Partition:        m.Partition,
+		Offset:           m.Offset,
+		Key:              m.Key,
+		Value:            value,
+		MessageID:        messageID,
+		PayloadTruncated: truncated,
+	}
+	if fp != nil {
+		rec.FileURL = fp.URL
+		rec.FileExt = fp.Extension
+		rec.FileSize = fp.Size
+	}
+	if cause != nil {
+		rec.Detail = cause.Error()
+	}
+	return p.dlq.Send(ctx, rec)
+}

--- a/internal/fileextract/consumer_test.go
+++ b/internal/fileextract/consumer_test.go
@@ -1,0 +1,187 @@
+package fileextract
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// mockSource 是 messageSource 的测试假实现：预置 messages 队列，Fetch 逐个返回，
+// 走到末尾返 context.DeadlineExceeded 触发 processBatch 收批（模拟 kafka 无新消息）。
+type mockSource struct {
+	mu       sync.Mutex
+	messages []fetchedMessage
+	commits  []fetchedMessage
+	closed   bool
+}
+
+func (m *mockSource) Fetch(ctx context.Context) (fetchedMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.messages) == 0 {
+		// 模拟无新消息（阻塞到 ctx 超时或取消）
+		<-ctx.Done()
+		return fetchedMessage{}, ctx.Err()
+	}
+	msg := m.messages[0]
+	m.messages = m.messages[1:]
+	return msg, nil
+}
+
+func (m *mockSource) Commit(ctx context.Context, msg fetchedMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.commits = append(m.commits, msg)
+	return nil
+}
+
+func (m *mockSource) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+// mockDLQSink 抓 DLQ 写入。
+type mockDLQSink struct {
+	mu       sync.Mutex
+	records  []dlqRecord
+	writeErr error // 注入写失败
+}
+
+func (m *mockDLQSink) WriteDLQ(ctx context.Context, key []byte, value []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	var rec dlqRecord
+	if err := json.Unmarshal(value, &rec); err != nil {
+		return err
+	}
+	m.records = append(m.records, rec)
+	return nil
+}
+
+func (m *mockDLQSink) Close() error { return nil }
+
+// mkNonFileMessage 造一条非 file 消息（type=1 text）。
+func mkNonFileMessage(t *testing.T, msgID string, contentType int) fetchedMessage {
+	t.Helper()
+	rawPayload := map[string]any{
+		"type":    contentType,
+		"content": "hello",
+	}
+	rawBytes, err := json.Marshal(rawPayload)
+	if err != nil {
+		t.Fatalf("marshal rawPayload: %v", err)
+	}
+	msg := searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     msgID,
+		RawPayload:    rawBytes,
+	}
+	value, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal msg: %v", err)
+	}
+	return fetchedMessage{Topic: "test-topic", Partition: 0, Offset: 100, Key: []byte(msgID), Value: value}
+}
+
+// TestProcessOne_SkipNonFileMessages 非 file 类型（text/image/video）应跳过 + 不投 DLQ + skippedNonFile 计数 +1。
+func TestProcessOne_SkipNonFileMessages(t *testing.T) {
+	for _, ct := range []int{1, 2, 5, 11, 14} { // text/image/video/mergeForward/richText
+		src := &mockSource{}
+		dlq := &mockDLQSink{}
+		p := NewProcessor(src, dlq, nil, ServiceConfig{}) // extractor 不会被走到（非 file 走 skip 分支）
+		msg := mkNonFileMessage(t, "42", ct)
+		if err := p.processOne(context.Background(), msg); err != nil {
+			t.Fatalf("processOne ct=%d: %v", ct, err)
+		}
+		if len(dlq.records) != 0 {
+			t.Errorf("ct=%d: expected 0 DLQ records, got %d: %+v", ct, len(dlq.records), dlq.records)
+		}
+		if p.metrics.skippedNonFile.Load() != 1 {
+			t.Errorf("ct=%d: skippedNonFile expected 1, got %d", ct, p.metrics.skippedNonFile.Load())
+		}
+	}
+}
+
+// TestProcessOne_ParseErrorToDLQ 塞坏 JSON → parse_error DLQ 触发。
+func TestProcessOne_ParseErrorToDLQ(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	p := NewProcessor(src, dlq, nil, ServiceConfig{}) // parse_error 分支不走到 extractor
+	msg := fetchedMessage{
+		Topic:     "test-topic",
+		Partition: 0,
+		Offset:    100,
+		Key:       []byte("bad-msg"),
+		Value:     []byte("this is not json"),
+	}
+	if err := p.processOne(context.Background(), msg); err != nil {
+		t.Fatalf("processOne: %v", err)
+	}
+	if len(dlq.records) != 1 {
+		t.Fatalf("expected 1 DLQ record, got %d", len(dlq.records))
+	}
+	if dlq.records[0].Reason != ReasonParseError {
+		t.Errorf("reason: got %q want %q", dlq.records[0].Reason, ReasonParseError)
+	}
+	if p.metrics.dlqTotal.Load() != 1 {
+		t.Errorf("dlqTotal expected 1, got %d", p.metrics.dlqTotal.Load())
+	}
+}
+
+// TestProcessOne_DLQWriteFailure_ReturnsError DLQ 自身写失败时上抛，暂停批推进（避免静默丢毒丸）。
+func TestProcessOne_DLQWriteFailure_ReturnsError(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{writeErr: errors.New("kafka down")}
+	p := NewProcessor(src, dlq, nil, ServiceConfig{}) // parse_error 分支不走到 extractor
+	msg := fetchedMessage{Key: []byte("k"), Value: []byte("bad json")}
+	err := p.processOne(context.Background(), msg)
+	if err == nil {
+		t.Fatal("expected error when DLQ write fails")
+	}
+}
+
+// TestExtractContentTypeFile_HappyPath 覆盖 payload.go 核心解析路径。
+func TestExtractContentTypeFile_HappyPath(t *testing.T) {
+	raw := []byte(`{"type":8,"url":"https://cdn.deepminer.com.cn/y.pdf","name":"y.pdf","extension":".pdf","size":2048}`)
+	fp, ok := extractContentTypeFile(raw)
+	if !ok {
+		t.Fatal("expected true for type=8")
+	}
+	if fp.URL != "https://cdn.deepminer.com.cn/y.pdf" || fp.Extension != ".pdf" || fp.Size != 2048 {
+		t.Errorf("unexpected payload: %+v", fp)
+	}
+}
+
+// TestExtractContentTypeFile_NonFileType 各种非 8 type 应返 (nil, false)。
+func TestExtractContentTypeFile_NonFileType(t *testing.T) {
+	cases := []string{
+		`{"type":1,"content":"hello"}`,
+		`{"type":2,"url":"x"}`,
+		`{"type":5,"url":"y"}`,
+		`{"type":11}`,
+		`{"type":14}`,
+	}
+	for _, raw := range cases {
+		if _, ok := extractContentTypeFile([]byte(raw)); ok {
+			t.Errorf("expected false for %s", raw)
+		}
+	}
+}
+
+// TestExtractContentTypeFile_MalformedPayload 空/损坏 payload 应返 (nil, false) 不 panic。
+func TestExtractContentTypeFile_MalformedPayload(t *testing.T) {
+	for _, raw := range [][]byte{nil, {}, []byte(`not json`), []byte(`[]`), []byte(`123`)} {
+		if _, ok := extractContentTypeFile(raw); ok {
+			t.Errorf("expected false for %q", raw)
+		}
+	}
+}

--- a/internal/fileextract/decision.go
+++ b/internal/fileextract/decision.go
@@ -1,0 +1,72 @@
+package fileextract
+
+// decision.go — 处置状态机与「每分区连续可越过前缀」提交点计算。
+// 复制自 internal/consumer/decision.go（不 import consumer 避免循环依赖 + 保持独立可测）。
+// v1.13 Blocker #2 fix：Blocker #2 §8 已识别问题 #1（多分区 commit prefix 未按 partition
+// group 聚合）在此一步到位——不引入单分区简化版，直接照抄成熟 pattern。
+
+import "sort"
+
+// itemDisposition 是单条消息经处理（含 in-place retry）后的最终处置类别。
+type itemDisposition int
+
+const (
+	// dispOK 抽取成功 + OS partial update 成功。
+	dispOK itemDisposition = iota
+	// dispDLQResolved 永久失败（parse_error / oversize / blacklist_ext / download_failed /
+	// extract_* / os_permanent / retry_exhausted）且已成功落 DLQ → offset 可越过。
+	dispDLQResolved
+	// dispTransient 暂时失败（errDocNotYet / errOSTransient / 429/5xx）→ 原地退避重试；
+	// offset 不越过此条，直到达 MaxRetriesPerMessage 上限被强制归入 dispDLQResolved。
+	dispTransient
+)
+
+// hasTransient 报告 dispositions 中是否含 transient（需继续原地重试）。
+func hasTransient(dispositions []itemDisposition) bool {
+	for _, disp := range dispositions {
+		if disp == dispTransient {
+			return true
+		}
+	}
+	return false
+}
+
+// partitionCommitPoints 计算**每分区**「连续可越过前缀」的提交点。
+//
+// kafka offset 是 per-partition 的；本 processor 单 Reader 可同时被分配多个分区，
+// FetchMessage 在不同分区间交错返回。因此连续前缀必须**按分区**算：每个分区内按 offset
+// 升序，从最低 offset 起，dispOK/dispDLQResolved 计入前缀，遇到第一个 dispTransient 立即停。
+// 返回每个分区前缀末的那条消息（供 CommitMessages 提交，kafka 单调高水位语义）。
+//
+// 这杜绝「A 分区某 offset transient 未确认，却因 B 分区更高 offset 成功 commit 把它隐式越过」
+// 造成的丢消息（Blocker #2 fix + fix-plan §8 #1）。
+func partitionCommitPoints(batch []fetchedMessage, dispositions []itemDisposition) []fetchedMessage {
+	type pkey struct {
+		topic     string
+		partition int
+	}
+	idxByPart := make(map[pkey][]int)
+	for i := range batch {
+		k := pkey{batch[i].Topic, batch[i].Partition}
+		idxByPart[k] = append(idxByPart[k], i)
+	}
+
+	var points []fetchedMessage
+	for _, idxs := range idxByPart {
+		// 按 offset 升序（FetchMessage 单分区本就有序，排序以防御乱序入参）。
+		sort.Slice(idxs, func(a, b int) bool {
+			return batch[idxs[a]].Offset < batch[idxs[b]].Offset
+		})
+		lastPrefix := -1
+		for _, i := range idxs {
+			if dispositions[i] == dispTransient {
+				break // 该分区前缀在首个 transient 处截断
+			}
+			lastPrefix = i
+		}
+		if lastPrefix >= 0 {
+			points = append(points, batch[lastPrefix])
+		}
+	}
+	return points
+}

--- a/internal/fileextract/dlq.go
+++ b/internal/fileextract/dlq.go
@@ -1,0 +1,73 @@
+package fileextract
+
+// DLQReason 是 file-extractor DLQ 投递原因枚举（v1.13）。全部触发点在 IDX-4 接上；
+// IDX-3 骨架期只定义常量 + ReasonParseError（Kafka 反序列化失败）触发。
+//
+// v1.13 Blocker #2 fix 新增 2 项 (retry_exhausted / os_permanent)：
+//
+//	| reason              | 触发条件                                      | 是否重试 |
+//	|---------------------|---------------------------------------------|----------|
+//	| parse_error         | Kafka 消息反序列化 searchmsg 失败              | ❌      |
+//	| oversize            | 文件 > MaxFileSize                            | ❌      |
+//	| blacklist_ext       | 扩展名在黑名单（不该走这里，是设计正常跳过） | ❌      |
+//	| download_failed     | HTTP GET CDN 5xx 或连接超时（重试耗尽）        | ✅ 3 次 |
+//	| extract_timeout     | Tika 抽取 > ExtractTimeout                    | ❌      |
+//	| encrypted           | Tika 抛 EncryptedDocumentException             | ❌      |
+//	| empty_extract       | Tika 返回空串或空白                           | ❌      |
+//	| extract_error       | 其他 Tika parse 异常                          | ✅ 1 次 |
+//	| retry_exhausted     | in-place bounded retry N 次未成功（Blocker #2） | ✅ N 次 |
+//	| os_permanent        | OS 返 4xx (非 404/409/429) permanent (P2-2)   | ❌      |
+const (
+	ReasonParseError     = "parse_error"
+	ReasonOversize       = "oversize"
+	ReasonBlacklistExt   = "blacklist_ext"
+	ReasonDownloadFailed = "download_failed"
+	ReasonExtractTimeout = "extract_timeout"
+	ReasonEncrypted      = "encrypted"
+	ReasonEmptyExtract   = "empty_extract"
+	ReasonExtractError   = "extract_error"
+
+	// ReasonRetryExhausted：单条消息 in-place bounded retry N 次仍未成功
+	// (errDocNotYet / errOSTransient 长期未收敛) → 强制 DLQ 并 commit offset，避免
+	// partition 无限阻塞。回灌工具按 messageId 从源 MySQL 重取重试。
+	ReasonRetryExhausted = "retry_exhausted"
+
+	// ReasonOSPermanent：OS 写返 4xx (非 404/409/429) permanent error，通常是请求
+	// body 编程 bug 或 mapping 冲突。立即 DLQ 不重试（重试无意义 + 会阻塞 partition）。
+	ReasonOSPermanent = "os_permanent"
+)
+
+// dlqRecord 是 file-extractor 落 DLQ topic 的记录载荷。
+// 与 consumer/dlq.go dlqRecord 语义相同但字段更聚焦：只带 file-extractor 排障关心的信息
+// （消息元数据 + 抽取上下文），不带 bulk per-item status。回灌工具按 Reason + MessageID 反查。
+type dlqRecord struct {
+	Reason    string `json:"reason"`    // 8 种枚举之一
+	Topic     string `json:"topic"`     // 源 topic
+	Partition int    `json:"partition"` // 源分区
+	Offset    int64  `json:"offset"`    // 源 offset
+	Key       []byte `json:"key"`       // 原始 Kafka key（= message_id）
+	Value     []byte `json:"value"`     // 原始 Kafka 消息 bytes（截断规则见 maxDLQRawValueBytes）
+	// 抽取上下文（IDX-4 触发点填入；IDX-3 骨架期只有 parse_error 填 Detail）
+	MessageID string `json:"messageId,omitempty"` // 契约 message_id 字符串
+	FileURL   string `json:"fileURL,omitempty"`   // 文件 CDN URL（download_failed / extract_* 时填）
+	FileExt   string `json:"fileExt,omitempty"`   // 扩展名（oversize / blacklist_ext 时填）
+	FileSize  int64  `json:"fileSize,omitempty"`  // 文件字节数（oversize 时填）
+	Detail    string `json:"detail,omitempty"`    // 错误详情字符串
+	SpilledAt int64  `json:"spilledAt,omitempty"` // 本地 spill 文件写入时刻（epoch second）
+	// PayloadTruncated 标记 Value 因超限被截断（同 consumer/dlq.go 语义），回灌工具
+	// 读到 true 时须按 MessageID 从源 MySQL 重取，不依赖 DLQ 内字节。
+	PayloadTruncated bool `json:"payloadTruncated,omitempty"`
+}
+
+// maxDLQRawValueBytes 是 DLQ 信封里原始 Value 字节的截断阈值（与 consumer/dlq.go 700_000 同口径）。
+// 按 base64 膨胀 (~1.33x) + 信封字段开销预留：700KB × 1.33 ≈ 931KB + 信封 < 1MiB broker 硬限。
+const maxDLQRawValueBytes = 700_000
+
+// truncateValueIfNeeded 按 maxDLQRawValueBytes 决定是否截断 Value + 标记 PayloadTruncated。
+// 返回 (可能被截断的 Value, 是否被截断)。
+func truncateValueIfNeeded(v []byte) ([]byte, bool) {
+	if len(v) <= maxDLQRawValueBytes {
+		return v, false
+	}
+	return v[:maxDLQRawValueBytes], true
+}

--- a/internal/fileextract/dlq_handler.go
+++ b/internal/fileextract/dlq_handler.go
@@ -1,0 +1,151 @@
+package fileextract
+
+// dlq_handler.go — DLQ 投递有界重试 + 本地 spill 逃逸（v1.13 P2-1 yujiawei review fix）。
+//
+// 端口自 internal/consumer/dlq.go 的 dlqHandler pattern。老 fileextract.Processor 直接调
+// p.dlqSink.WriteDLQ，DLQ topic 挂即 outcomeFatal 全 worker 停 —— 与 consumer 侧成熟的
+// 「有界重试 → spill 落盘 → 告警 → 越过 offset（绝不永久卡 partition）」pattern 不对称。
+// 本 handler 补齐同 pattern；不 import consumer 包避免循环依赖 + 保持独立可测。
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// alerter 抽象「响铃告警」。生产接 Prometheus counter + 告警规则；这里默认走 log。
+// 测试注入假实现记录 event 序列做断言。
+type alerter interface {
+	Alert(event string, detail string)
+}
+
+// dlqHandlerConfig 配 DLQ 投递有界重试 + 逃逸策略（与 consumer/dlq.go dlqConfig 语义一致）。
+type dlqHandlerConfig struct {
+	// MaxRetries：DLQ 投递自身 transient 失败的有界重试次数。默认 5。
+	MaxRetries int
+	// RetryBackoff：重试退避基（指数 + 满抖动，与 backoff.go expJitterBackoff 一致）。默认 200ms。
+	RetryBackoff time.Duration
+	// SpillDir：逃逸时本地落地目录；为空 → 逃逸=硬停返 errDLQHardStop（分区不推进，人工介入）。
+	// 生产建议挂一个 emptyDir 或 PVC 目录（K8s pod），运维回灌工具从此读文件重投 DLQ。
+	SpillDir string
+}
+
+// defaultDLQHandlerConfig 生产默认（对齐 consumer/dlq.go defaultDLQConfig）。
+func defaultDLQHandlerConfig() dlqHandlerConfig {
+	return dlqHandlerConfig{MaxRetries: 5, RetryBackoff: 200 * time.Millisecond, SpillDir: ""}
+}
+
+// errDLQHardStop 表示 DLQ 写持续失败且未配置 spill → 调用方硬停分区（不前进 offset）。
+// 与 consumer/dlq.go errDLQHardStop 语义一致；processBatch 收到此错走 outcomeFatal 停 worker，
+// K8s 会重启保 offset 未推进；同时 alerter 已 page 告警提示运维手工介入。
+var errDLQHardStop = errors.New("fileextract: DLQ write exhausted retries and no spill configured (hard stop)")
+
+// dlqHandler 负责把 fileextract 的毒丸消息可靠送进 DLQ topic；DLQ 写自身 transient 失败时
+// 执行终态逃逸：
+//   - 有界重试（指数退避 + 满抖动 + ctx 感知，SIGTERM 即停）
+//   - 全部失败 → 若配置 SpillDir，落盘 + 告警 + 返回 nil（允许 offset 越过，绝不卡分区）
+//   - 未配 SpillDir → 返 errDLQHardStop 硬停分区 + page 告警（人工介入）
+type dlqHandler struct {
+	sink    dlqSink
+	alert   alerter
+	cfg     dlqHandlerConfig
+	sleep   func(context.Context, time.Duration) error // ctx-aware，测试注入即时返
+	nowUnix func() int64
+}
+
+// newDLQHandler 组装 handler。sleep 走本包 backoff.go 的 sleepCtx，nowUnix 走 time.Now。
+func newDLQHandler(sink dlqSink, alert alerter, cfg dlqHandlerConfig) *dlqHandler {
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = defaultDLQHandlerConfig().MaxRetries
+	}
+	if cfg.RetryBackoff <= 0 {
+		cfg.RetryBackoff = defaultDLQHandlerConfig().RetryBackoff
+	}
+	return &dlqHandler{
+		sink:    sink,
+		alert:   alert,
+		cfg:     cfg,
+		sleep:   sleepCtx,
+		nowUnix: func() int64 { return time.Now().Unix() },
+	}
+}
+
+// Send 把一条 DLQ record 送进 DLQ topic。返回 nil = 已终态处理（投递成功 or 已 spill 落地），
+// 调用方可放心越过 offset；返回 error = 硬停逃逸（offset 不推进，需人工介入）。
+// ctx 取消（SIGTERM）时立刻返 ctx.Err()。
+func (h *dlqHandler) Send(ctx context.Context, rec dlqRecord) error {
+	value, err := json.Marshal(rec)
+	if err != nil {
+		h.alert.Alert("dlq_marshal_failed", fmt.Sprintf("offset=%d: %v", rec.Offset, err))
+		return h.escape(rec, fmt.Sprintf("marshal failed: %v", err))
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= h.cfg.MaxRetries; attempt++ {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if attempt > 0 {
+			// 指数退避 + 满抖动 + ctx 感知（复用本包 backoff.go）。
+			if serr := h.sleep(ctx, expJitterBackoff(h.cfg.RetryBackoff, 0, attempt)); serr != nil {
+				return serr
+			}
+		}
+		if werr := h.sink.WriteDLQ(ctx, rec.Key, value); werr == nil {
+			return nil // DLQ 投递成功
+		} else {
+			lastErr = werr
+		}
+	}
+
+	h.alert.Alert("dlq_write_exhausted",
+		fmt.Sprintf("offset=%d retries=%d lastErr=%v", rec.Offset, h.cfg.MaxRetries, lastErr))
+	return h.escape(rec, fmt.Sprintf("dlq write exhausted: %v", lastErr))
+}
+
+// escape 执行终态逃逸：SpillDir 非空 → 落盘 + 告警 + 返 nil 允许越过；否则返 errDLQHardStop。
+// 落盘文件名 `dlq-spill-<partition>-<offset>-<epoch>.json`（partition+offset 保证唯一，epoch 便于排序）。
+func (h *dlqHandler) escape(rec dlqRecord, detail string) error {
+	if h.cfg.SpillDir == "" {
+		return errDLQHardStop
+	}
+	rec.SpilledAt = h.nowUnix()
+	if rec.Detail == "" {
+		rec.Detail = detail
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("%w: spill marshal failed: %v", errDLQHardStop, err)
+	}
+	if err := os.MkdirAll(h.cfg.SpillDir, 0o750); err != nil {
+		return fmt.Errorf("%w: spill mkdir failed: %v", errDLQHardStop, err)
+	}
+	name := fmt.Sprintf("dlq-spill-%d-%d-%d.json", rec.Partition, rec.Offset, rec.SpilledAt)
+	path := filepath.Join(h.cfg.SpillDir, name)
+	if err := os.WriteFile(path, append(data, '\n'), 0o640); err != nil {
+		return fmt.Errorf("%w: spill write failed: %v", errDLQHardStop, err)
+	}
+	h.alert.Alert("dlq_spilled_to_disk", fmt.Sprintf("path=%s offset=%d", path, rec.Offset))
+	return nil
+}
+
+// logAlerter 是默认 alerter 实现，走 log.Printf。生产可以在 cmd 里注入 Prometheus counter 版。
+type logAlerter struct {
+	logf func(format string, args ...any)
+}
+
+// newLogAlerter 组装 log-based alerter（logf 通常传 log.Printf；测试可注入自己的记录函数）。
+func newLogAlerter(logf func(string, ...any)) *logAlerter {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &logAlerter{logf: logf}
+}
+
+func (l *logAlerter) Alert(event string, detail string) {
+	l.logf("file-extractor ALERT [%s]: %s", event, detail)
+}

--- a/internal/fileextract/dlq_handler_test.go
+++ b/internal/fileextract/dlq_handler_test.go
@@ -1,0 +1,242 @@
+package fileextract
+
+// dlq_handler_test.go — DLQ handler 有界重试 + spill 逃逸回归 test（v1.13 P2-1，
+// yujiawei review 发现的 sibling consumer/dlq.go pattern 未 port 问题）。
+//
+// 覆盖场景（对齐 consumer/dlq_test.go）：
+//   1. 首次成功
+//   2. 前 N 次失败第 N+1 次成功（有界重试）
+//   3. 全部失败 + 配 SpillDir → 落盘 + 告警 + 返回 nil（越过 offset）
+//   4. 全部失败 + 未配 SpillDir → errDLQHardStop（硬停）
+//   5. ctx 取消（SIGTERM）立即返 ctx.Err，不再重试
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeDLQSink 是 dlqSink 的 test 假实现。可配「首 N 次失败」/「一直失败」。
+type fakeDLQSink struct {
+	writes    int
+	failFor   int  // 前 failFor 次返错，之后成功
+	alwaysErr bool // true → 每次都返错
+	err       error
+}
+
+func (f *fakeDLQSink) WriteDLQ(_ context.Context, _ []byte, _ []byte) error {
+	f.writes++
+	if f.alwaysErr {
+		if f.err == nil {
+			return errors.New("fake dlq sink always fail")
+		}
+		return f.err
+	}
+	if f.writes <= f.failFor {
+		return errors.New("fake dlq sink transient fail")
+	}
+	return nil
+}
+
+func (f *fakeDLQSink) Close() error { return nil }
+
+// recordAlerter 记录 Alert 事件序列供断言。
+type recordAlerter struct {
+	events []string // 每个元素形如 "event|detail"
+}
+
+func (r *recordAlerter) Alert(event, detail string) {
+	r.events = append(r.events, event+"|"+detail)
+}
+
+// has 返回 event 是否在事件序列里出现过（前缀匹配 event 名）。
+func (r *recordAlerter) has(event string) bool {
+	for _, e := range r.events {
+		if len(e) >= len(event) && e[:len(event)] == event {
+			return true
+		}
+	}
+	return false
+}
+
+// newTestDLQHandler 组装一个 test-only handler（sleep no-op，nowUnix 固定）。
+func newTestDLQHandler(sink dlqSink, alert alerter, spillDir string) *dlqHandler {
+	h := newDLQHandler(sink, alert, dlqHandlerConfig{
+		MaxRetries:   2,
+		RetryBackoff: time.Millisecond,
+		SpillDir:     spillDir,
+	})
+	h.sleep = func(context.Context, time.Duration) error { return nil }
+	h.nowUnix = func() int64 { return 1_700_000_000 }
+	return h
+}
+
+func sampleDLQRec() dlqRecord {
+	return dlqRecord{
+		Reason:    ReasonOSPermanent,
+		Topic:     "octo.message.v1.file-extract.dlq",
+		Partition: 0,
+		Offset:    42,
+		Key:       []byte("msg-42"),
+		Value:     []byte(`{"messageId":"42"}`),
+		MessageID: "42",
+	}
+}
+
+// TestDLQHandler_SuccessFirstTry 首次投递成功 → writes=1，无 alerts。
+func TestDLQHandler_SuccessFirstTry(t *testing.T) {
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	h := newTestDLQHandler(sink, alert, "")
+	if err := h.Send(context.Background(), sampleDLQRec()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sink.writes != 1 {
+		t.Errorf("expected 1 write, got %d", sink.writes)
+	}
+	if len(alert.events) != 0 {
+		t.Errorf("no alerts expected on happy path, got %v", alert.events)
+	}
+}
+
+// TestDLQHandler_RetryThenSucceed 前 2 次失败第 3 次成功 → writes=3。
+func TestDLQHandler_RetryThenSucceed(t *testing.T) {
+	sink := &fakeDLQSink{failFor: 2}
+	alert := &recordAlerter{}
+	h := newTestDLQHandler(sink, alert, "")
+	if err := h.Send(context.Background(), sampleDLQRec()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sink.writes != 3 {
+		t.Errorf("expected 3 attempts (2 fail + 1 succeed), got %d", sink.writes)
+	}
+}
+
+// TestDLQHandler_EscapeToSpill 全部失败 + 配 SpillDir → 落盘 + 告警 + 返回 nil。
+// v1.13 P2-1 核心 pattern：DLQ topic 挂时保 partition 不永久卡死。
+func TestDLQHandler_EscapeToSpill(t *testing.T) {
+	sink := &fakeDLQSink{alwaysErr: true}
+	alert := &recordAlerter{}
+	dir := t.TempDir()
+	h := newTestDLQHandler(sink, alert, dir)
+
+	err := h.Send(context.Background(), sampleDLQRec())
+	if err != nil {
+		t.Fatalf("escape to spill must return nil (allow offset cross), got %v", err)
+	}
+	if !alert.has("dlq_write_exhausted") {
+		t.Errorf("expected dlq_write_exhausted alert, got %v", alert.events)
+	}
+	if !alert.has("dlq_spilled_to_disk") {
+		t.Errorf("expected dlq_spilled_to_disk alert, got %v", alert.events)
+	}
+	// spill dir 里应有一个文件 dlq-spill-<partition>-<offset>-<epoch>.json
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		t.Fatalf("read spill dir: %v", rerr)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 spill file, got %d", len(entries))
+	}
+	wantName := "dlq-spill-0-42-1700000000.json"
+	if entries[0].Name() != wantName {
+		t.Errorf("spill file name: got %q want %q", entries[0].Name(), wantName)
+	}
+	// 文件内容应含 SpilledAt 字段
+	data, rerr := os.ReadFile(filepath.Join(dir, wantName))
+	if rerr != nil {
+		t.Fatalf("read spill file: %v", rerr)
+	}
+	if !contains(data, `"spilledAt":1700000000`) {
+		t.Errorf("spill file must carry SpilledAt=1700000000, got %s", data)
+	}
+}
+
+// TestDLQHandler_HardStopNoSpill 全部失败 + 未配 SpillDir → errDLQHardStop（硬停分区）。
+func TestDLQHandler_HardStopNoSpill(t *testing.T) {
+	sink := &fakeDLQSink{alwaysErr: true}
+	alert := &recordAlerter{}
+	h := newTestDLQHandler(sink, alert, "")
+
+	err := h.Send(context.Background(), sampleDLQRec())
+	if !errors.Is(err, errDLQHardStop) {
+		t.Fatalf("no SpillDir + exhausted must return errDLQHardStop, got %v", err)
+	}
+	if !alert.has("dlq_write_exhausted") {
+		t.Errorf("expected dlq_write_exhausted alert even on hard stop, got %v", alert.events)
+	}
+	// 未配 SpillDir 时不应有 spilled_to_disk 事件
+	if alert.has("dlq_spilled_to_disk") {
+		t.Errorf("must NOT spill when SpillDir unset, got %v", alert.events)
+	}
+}
+
+// TestDLQHandler_CtxCancelDuringRetry ctx 取消（SIGTERM）→ 立即返 ctx.Err，不再重试。
+func TestDLQHandler_CtxCancelDuringRetry(t *testing.T) {
+	sink := &fakeDLQSink{alwaysErr: true}
+	alert := &recordAlerter{}
+	h := newDLQHandler(sink, alert, dlqHandlerConfig{
+		MaxRetries:   10,
+		RetryBackoff: time.Hour, // 大 backoff 保证 sleep 里被 ctx cancel 中断
+		SpillDir:     "",
+	})
+	// 用 real sleepCtx 而非 no-op，才能被 ctx cancel 打断
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消
+
+	err := h.Send(ctx, sampleDLQRec())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ctx cancel must surface as context.Canceled, got %v", err)
+	}
+	// 第一次 write 会尝试（ctx.Err() 在 loop 首 check 时可能 nil；实际 sink 调用后 attempt++）
+	// 关键断言：不会一直重试到耗尽
+	if sink.writes > 3 {
+		t.Errorf("cancelled ctx should stop early, got %d writes", sink.writes)
+	}
+}
+
+// TestDLQHandler_DefaultsFilledFromZero MaxRetries=0 / RetryBackoff=0 → 走 default（防 divide-by-zero / 立即耗尽）。
+func TestDLQHandler_DefaultsFilledFromZero(t *testing.T) {
+	sink := &fakeDLQSink{}
+	alert := &recordAlerter{}
+	h := newDLQHandler(sink, alert, dlqHandlerConfig{})
+	if h.cfg.MaxRetries != defaultDLQHandlerConfig().MaxRetries {
+		t.Errorf("MaxRetries=0 must fill default 5, got %d", h.cfg.MaxRetries)
+	}
+	if h.cfg.RetryBackoff != defaultDLQHandlerConfig().RetryBackoff {
+		t.Errorf("RetryBackoff=0 must fill default 200ms, got %v", h.cfg.RetryBackoff)
+	}
+	// 空 SpillDir 保持空（生产默认，配了才启用）
+	if h.cfg.SpillDir != "" {
+		t.Errorf("SpillDir default must be empty, got %q", h.cfg.SpillDir)
+	}
+}
+
+// contains 是最小 substring check（避免 import strings 只为一处）。
+func contains(haystack []byte, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	if len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if string(haystack[i:i+len(needle)]) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestTombstoneStatus_HardcodedContract 契约锁：fileextract 侧 tombstoneStatus 必须硬编码
+// 为 "unextractable"（与 filebackfill/source.go tombstoneStatusValue 同字面值）。两包独立
+// 断言同一字符串，改任一处不改另一处 → CI 挂。避免跨包 import 膨胀（filebackfill 不 import
+// fileextract 是有意为之，见 filebackfill/source.go tombstoneStatusValue 注释）。
+func TestTombstoneStatus_HardcodedContract(t *testing.T) {
+	if tombstoneStatus != "unextractable" {
+		t.Fatalf("fileextract.tombstoneStatus must == \"unextractable\" (filebackfill-side scroll query value), got %q", tombstoneStatus)
+	}
+}

--- a/internal/fileextract/dlq_test.go
+++ b/internal/fileextract/dlq_test.go
@@ -1,0 +1,72 @@
+package fileextract
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDLQReason_ConstantsExist v1.12 §6.1 表格里的 8 种 reason 常量必须存在（避免误删/改名）。
+func TestDLQReason_ConstantsExist(t *testing.T) {
+	want := []string{
+		"parse_error", "oversize", "blacklist_ext",
+		"download_failed", "extract_timeout", "encrypted",
+		"empty_extract", "extract_error",
+	}
+	got := []string{
+		ReasonParseError, ReasonOversize, ReasonBlacklistExt,
+		ReasonDownloadFailed, ReasonExtractTimeout, ReasonEncrypted,
+		ReasonEmptyExtract, ReasonExtractError,
+	}
+	if len(want) != len(got) {
+		t.Fatalf("count mismatch: want %d reasons, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("reason[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestDLQRecord_SerializationRoundtrip dlqRecord 序列化/反序列化字段完整对齐。
+func TestDLQRecord_SerializationRoundtrip(t *testing.T) {
+	orig := dlqRecord{
+		Reason:           ReasonEncrypted,
+		Topic:            "octo.message.v1",
+		Partition:        3,
+		Offset:           12345,
+		Key:              []byte("42"),
+		Value:            []byte("original message bytes"),
+		MessageID:        "42",
+		FileURL:          "https://cdn.deepminer.com.cn/x.pdf",
+		FileExt:          ".pdf",
+		FileSize:         1024,
+		Detail:           "org.apache.tika.exception.EncryptedDocumentException",
+		SpilledAt:        1727712345,
+		PayloadTruncated: false,
+	}
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back dlqRecord
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Reason != orig.Reason || back.MessageID != orig.MessageID || back.FileURL != orig.FileURL {
+		t.Errorf("round-trip mismatch: got %+v", back)
+	}
+}
+
+// TestTruncateValueIfNeeded 小 value 不截断；超阈值截断 + 标记 true。
+func TestTruncateValueIfNeeded(t *testing.T) {
+	small := make([]byte, 1024)
+	out, trunc := truncateValueIfNeeded(small)
+	if trunc || len(out) != len(small) {
+		t.Errorf("small value should not truncate: trunc=%v len=%d", trunc, len(out))
+	}
+	big := make([]byte, maxDLQRawValueBytes+1)
+	out, trunc = truncateValueIfNeeded(big)
+	if !trunc || len(out) != maxDLQRawValueBytes {
+		t.Errorf("big value should truncate to %d: trunc=%v len=%d", maxDLQRawValueBytes, trunc, len(out))
+	}
+}

--- a/internal/fileextract/download.go
+++ b/internal/fileextract/download.go
@@ -1,0 +1,180 @@
+package fileextract
+
+// download.go — 从 CDN URL 拉文件 bytes，带超时 + 指数退避重试 + size cutoff。
+// 走公网 CDN (cdn.deepminer.com.cn) 直连（v2 §16.2 决策 (d)，Max prod 实测通过）。
+//
+// 错误分类：
+//   - HTTP 200 → (bytes, contentType, nil)
+//   - HTTP 200 但 Content-Length > MaxFileSize → errOversize（permanent, DLQ reason=oversize）
+//   - HTTP 5xx / net 超时 / DNS 失败 → transient，触发指数退避重试
+//   - HTTP 4xx (非 429) / 3 次重试耗尽 → errDownloadFailed（permanent, DLQ reason=download_failed）
+//   - ctx 取消 → ctx.Err() 立即返
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// errCDNPermanent 是 tryFetch 遇到 CDN 4xx (非 429) 返回的 sentinel（v1.13 P2-6）。
+// 老代码用字符串 "cdn permanent status" 分类，重构 err.Error() 格式即静默把 4xx 归成 transient
+// 丢消息。改成 sentinel + errors.Is，无字符串耦合。
+var errCDNPermanent = errors.New("fileextract: cdn permanent status")
+
+// errOversize 是文件超过 MaxFileSize 阈值（不下载 body 直接返，节省带宽）。
+var errOversize = errors.New("fileextract: file size exceeds MaxFileSize cutoff")
+
+// errDownloadFailed 是重试耗尽或 4xx 非 429 permanent 失败（触发 DLQ reason=download_failed）。
+var errDownloadFailed = errors.New("fileextract: download exhausted retries or 4xx permanent")
+
+// downloadClient 从 URL 拉文件 bytes。
+type downloadClient struct {
+	hc             *http.Client
+	maxSize        int64
+	retries        int
+	retryBackoff   time.Duration
+	allowedHosts   []string // v1.13 Blocker #1：SSRF host allowlist（pre-check）
+	allowedSchemes []string
+}
+
+// newDownloadClient 用 stdlib http.Client（Timeout 已含拨号+读体总耗时）。
+// v1.13 Blocker #1：Transport 挂 SSRF-restricted dialer + CheckRedirect 校验，防
+// (1) 消息 payload.file.url 指向 metadata IP (169.254.169.254) 或内网服务
+// (2) DNS rebinding 绕过 host allowlist
+// (3) redirect 到 blocked host / IP
+func newDownloadClient(cfg ServiceConfig) *downloadClient {
+	maxSize := cfg.MaxFileSize
+	if maxSize <= 0 {
+		maxSize = 20 * 1024 * 1024
+	}
+	retries := cfg.HTTPRetries
+	if retries <= 0 {
+		retries = 3
+	}
+	backoff := cfg.RetryBackoffBase()
+	allowedHosts := cfg.AllowedDownloadHosts
+	allowedSchemes := cfg.AllowedDownloadSchemes
+	baseDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport := &http.Transport{
+		DialContext:         ssrfRestrictedDialer(baseDialer, cfg.SSRFAllowLoopback),
+		MaxIdleConns:        100,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return &downloadClient{
+		hc: &http.Client{
+			Timeout:       cfg.DownloadTimeout,
+			Transport:     transport,
+			CheckRedirect: ssrfCheckRedirect(allowedHosts, allowedSchemes),
+		},
+		maxSize:        maxSize,
+		retries:        retries,
+		retryBackoff:   backoff,
+		allowedHosts:   allowedHosts,
+		allowedSchemes: allowedSchemes,
+	}
+}
+
+// RetryBackoffBase 是 IDX-4 复用型 backoff base（1s），指数退避 1s / 4s / 16s。
+// 挂 ServiceConfig 上便于测试注入更短值加速 test。
+func (c ServiceConfig) RetryBackoffBase() time.Duration {
+	// 未来加 config field 时改这里；目前固定 1s。
+	return time.Second
+}
+
+// Fetch 拉 URL 到 bytes 数组。重试策略：transient 错误按 base * 2^attempt 退避，共 retries+1 次尝试。
+// v1.13 Blocker #1：入口前置 SSRF 校验，scheme/host 不合法直接返 errDownloadFailed（不重试，
+// URL 不变重试无意义）。
+func (d *downloadClient) Fetch(ctx context.Context, url string) ([]byte, string, error) {
+	if err := validateURL(url, d.allowedHosts, d.allowedSchemes); err != nil {
+		// SSRF pre-check 拒绝 → download_failed（不重试；host/scheme 不变重试无意义）
+		return nil, "", fmt.Errorf("%w: %v", errDownloadFailed, err)
+	}
+	var lastErr error
+	for attempt := 0; attempt <= d.retries; attempt++ {
+		body, ct, err := d.tryFetch(ctx, url)
+		if err == nil {
+			return body, ct, nil
+		}
+		// ctx 取消快速返，caller 走优雅退出（不消耗 backoff 预算）
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, "", err
+		}
+		// permanent 错误立即返，不重试
+		if errors.Is(err, errOversize) {
+			return nil, "", err
+		}
+		if isPermanentDownloadErr(err) {
+			return nil, "", errDownloadFailed
+		}
+		lastErr = err
+		if attempt == d.retries {
+			break
+		}
+		wait := d.retryBackoff * time.Duration(1<<attempt) // 1s / 2s / 4s / 8s (base=1s, retries=3 → 1s/2s/4s)
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+	}
+	return nil, "", fmt.Errorf("%w: %v", errDownloadFailed, lastErr)
+}
+
+// tryFetch 单次 GET 尝试。返回：
+//   - 成功：(body, contentType, nil)
+//   - 文件超大：(nil, "", errOversize)（permanent）
+//   - transient (5xx/net 错)：(nil, "", 具体 err)
+//   - permanent (4xx 非 429)：(nil, "", 具体 err)
+func (d *downloadClient) tryFetch(ctx context.Context, url string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := d.hc.Do(req)
+	if err != nil {
+		// ctx 取消/超时快速返，caller 不必再走 backoff
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, "", ctxErr
+		}
+		return nil, "", err // 网络/超时都进 transient 分支
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // close-on-read: nothing to do with close err
+
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+		return nil, "", fmt.Errorf("cdn transient status %d", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 {
+		// v1.13 P2-6：用 sentinel errCDNPermanent（下方 isPermanentDownloadErr 走 errors.Is）
+		return nil, "", fmt.Errorf("%w: status %d", errCDNPermanent, resp.StatusCode)
+	}
+	if resp.ContentLength > d.maxSize {
+		return nil, "", errOversize
+	}
+	// 限流 body 读取避免读到 > maxSize+1 字节浪费内存（服务端谎报 Content-Length 的兜底）
+	lr := io.LimitReader(resp.Body, d.maxSize+1)
+	body, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(len(body)) > d.maxSize {
+		return nil, "", errOversize
+	}
+	return body, resp.Header.Get("Content-Type"), nil
+}
+
+// isPermanentDownloadErr 判 err 是否 permanent（4xx 非 429，不重试）。
+// v1.13 P2-6：改 sentinel + errors.Is，不依赖 err.Error() 字符串（重构风险）。
+func isPermanentDownloadErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, errCDNPermanent)
+}

--- a/internal/fileextract/extractor.go
+++ b/internal/fileextract/extractor.go
@@ -1,0 +1,205 @@
+package fileextract
+
+// extractor.go — 抽取核心可复用 struct（IDX-4 从 consumer.processOne 抽出，IDX-5 backfill Job 复用）。
+//
+// 一个 Extractor 组合 downloadClient + tikaClient + osWriter + 扩展名白名单，暴露一个方法：
+// ExtractAndWrite(ctx, messageID, filePayload) → (dlqReason, cause, err)
+//   - dlqReason 非空 → 抽取失败，caller 应投 DLQ（consumer 走 kafka DLQ；backfill 走 spill 或 log）
+//   - err 非 nil → OS 写失败（含 errDocNotYet），caller 应重试整批（consumer）或跳过该 doc（backfill）
+
+import (
+	"context"
+	"errors"
+	"log"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+// Extractor 抽取核心。跨 consumer + backfill 复用。
+type Extractor struct {
+	download       *downloadClient
+	tika           *tikaClient
+	os             *osWriter
+	maxFileSize    int64
+	extractorLabel string // 写进 contentMeta.extractor (e.g. "tika/3.3.0")
+}
+
+// NewExtractor 构造。所有下游 client 均在这里装配，consumer.Service / backfill Runner 各自 New 一份。
+func NewExtractor(cfg ServiceConfig) (*Extractor, error) {
+	os, err := newOSWriter(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Extractor{
+		download:       newDownloadClient(cfg),
+		tika:           newTikaClient(cfg),
+		os:             os,
+		maxFileSize:    firstNonZero(cfg.MaxFileSize, 20*1024*1024),
+		extractorLabel: "tika/3.3.0",
+	}, nil
+}
+
+func firstNonZero(a, b int64) int64 {
+	if a > 0 {
+		return a
+	}
+	return b
+}
+
+// tombstoneReasons 是"文件本身永久不可抽取"类 DLQ 原因集合；只有这些 reason 会写 tombstone
+// (contentMeta.status="unextractable")。
+//
+// Round-4 Should-Fix (lml2468 review)：老实现对**所有** dlqReason 都写 tombstone (包括
+// download_failed / extract_timeout 等 transient 类)，永久移除 backfill recovery safety net —
+// download_failed 是 CDN 5xx / 网络抖动，extract_timeout 是 Tika 临时资源紧张，下次 rerun 可能
+// 成功。写 tombstone 后 backfill scroll `must_not term contentMeta.status=unextractable` 直接
+// 跳过 → **永远不再重试**。commit message 声称的"permanent DLQ"列表也漏了 extract_timeout →
+// intent vs impl 不一致，本轮修 impl 匹配 intent（不改 intent）。
+//
+// 白名单只覆盖 extractor.ExtractAndWrite 内部返回的 permanent 类（不含 ParseError /
+// RetryExhausted / OSPermanent — 这些 reason 由 consumer.processBatch 直接 writeDLQ，不经
+// extractor.defer；ParseError 场景 doc 不存在于 OS 也不需要 tombstone）。
+var tombstoneReasons = map[string]bool{
+	ReasonBlacklistExt: true, // 扩展名黑名单：永远不该抽
+	ReasonOversize:     true, // 文件超大：不会自己变小
+	ReasonEncrypted:    true, // 加密 PDF：无密码无解
+	ReasonEmptyExtract: true, // Tika 抽出空/纯空白：文件真无文本
+	ReasonExtractError: true, // Tika 报 exception：内容/格式问题，重试无益
+	// 明确排除：ReasonDownloadFailed（CDN 5xx / 网络抖动，rerun 可能成功）
+	// 明确排除：ReasonExtractTimeout（Tika 临时资源紧张 / 大文件超时，rerun 可能成功）
+}
+
+// isTombstoneReason 报告某 DLQ reason 是否属于"文件永久不可抽取"类，值得写 tombstone。
+// 供 extractor.defer 过滤 transient 类不写 tombstone（保留 backfill recovery safety net）。
+func isTombstoneReason(reason string) bool {
+	return tombstoneReasons[reason]
+}
+
+// ExtractAndWrite 拉文件 → Tika 抽取 → OS partial update。
+// 返回：
+//   - (dlqReason="", cause=nil, err=nil) → 成功
+//   - (dlqReason="oversize"/"blacklist_ext"/... , cause=err, err=nil) → 抽取 permanent 失败，caller 投 DLQ
+//   - (dlqReason="", cause=nil, err=errDocNotYet) → OS 主 doc 未落，caller 应触发本批重试
+//   - (dlqReason="", cause=nil, err=其他) → OS 或网络 transient 错，caller 决定重试策略
+//
+// Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2)：permanent DLQ 返回前 defer 写 tombstone
+// (contentMeta.status="unextractable" + reason=<dlqReason>)，让 backfill scroll query 通过
+// `must_not term contentMeta.status=unextractable` 过滤，避免 rerun 无限重复 DLQ 同一文件。
+// tombstone 写失败不阻塞主 DLQ 路径（下次 backfill/consumer 兜底）。
+//
+// Round-4 Should-Fix (lml2468)：defer 加 isTombstoneReason 白名单过滤，只对**文件本身永久
+// 不可抽取**类 reason 写 tombstone；transient 类 (download_failed / extract_timeout) 不写，
+// 保留 backfill recovery safety net。
+func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *filePayload) (dlqReason string, cause error, err error) {
+	// Round-3 Blocker B: 命名返回值 + defer 统一处理 tombstone 写入，避免每个 return 点重复代码。
+	// Round-4 Should-Fix: 加白名单过滤，只对 permanent 类写 tombstone；transient 类
+	// (download_failed / extract_timeout) 保留 backfill recovery 语义。
+	// err != nil 分支 (errDocNotYet / OS transient / ctx 取消) 依然不写（caller 会重试整批）。
+	defer func() {
+		if dlqReason == "" || err != nil {
+			return
+		}
+		if !isTombstoneReason(dlqReason) {
+			// transient 类 DLQ reason (download_failed / extract_timeout) 不写 tombstone，
+			// 保留 backfill 下次 rerun 兜底重试的能力。
+			return
+		}
+		if terr := e.os.WriteTombstone(ctx, messageID, dlqReason); terr != nil {
+			// tombstone 写失败不阻塞：主 DLQ 路径依然让 caller 投 DLQ，下次 backfill 兜底重跑
+			// （若主 doc 未落 → 404 = errDocNotYet 也算 tombstone 无法写；等 es-indexer 落主 doc 后
+			//  backfill 再次拉到同 doc 时会重新触发 tombstone 写入）。
+			log.Printf("file-extractor: WriteTombstone messageID=%s reason=%s failed (backfill will retry): %v",
+				messageID, dlqReason, terr)
+		}
+	}()
+
+	// 1. 扩展名白名单前置校验（黑名单 → skip 不 DLQ，白名单外 → DLQ blacklist_ext）
+	ext := normalizeExt(fp.Extension, fp.Name)
+	if isBlacklistedExt(ext) {
+		return ReasonBlacklistExt, errors.New("blacklisted extension " + ext), nil
+	}
+	// 2. size cutoff（>MaxFileSize 直接 DLQ 不下载）
+	if fp.Size > 0 && fp.Size > e.maxFileSize {
+		return ReasonOversize, errors.New("file size exceeds cutoff"), nil
+	}
+	// 3. 下载
+	body, _, derr := e.download.Fetch(ctx, fp.URL)
+	if derr != nil {
+		if errors.Is(derr, errOversize) {
+			return ReasonOversize, derr, nil
+		}
+		if errors.Is(derr, errDownloadFailed) {
+			return ReasonDownloadFailed, derr, nil
+		}
+		// context 取消/网络重试耗尽后仍然算 download_failed
+		if ctx.Err() != nil {
+			return "", nil, ctx.Err()
+		}
+		return ReasonDownloadFailed, derr, nil
+	}
+	// 4. Tika 抽取（ext 已 normalize 好，传给 tika 用于设 Content-Type）
+	start := time.Now()
+	content, truncated, terr := e.tika.Extract(ctx, body, fp.Name, ext)
+	extractMs := time.Since(start).Milliseconds()
+	if terr != nil {
+		switch {
+		case errors.Is(terr, errEncrypted):
+			return ReasonEncrypted, terr, nil
+		case errors.Is(terr, errExtractTimeout):
+			return ReasonExtractTimeout, terr, nil
+		default:
+			return ReasonExtractError, terr, nil
+		}
+	}
+	if content == "" || strings.TrimSpace(content) == "" {
+		// v1.13 P2-7：whitespace-only 也视为 empty_extract（老代码只判 == ""，
+		// scanned/empty PDF 常返 "\n\n" / 空格串，会漏过 → 无意义 doc 被误 commit）
+		return ReasonEmptyExtract, errors.New("tika returned empty or whitespace-only content"), nil
+	}
+	// 5. OS partial update
+	meta := esindex.FileContentMeta{
+		ExtractedAt: time.Now().Unix(),
+		Extractor:   e.extractorLabel,
+		Truncated:   &truncated, // v1.13 P2-5：指针便于清除 stale true
+		ExtractMs:   &extractMs, // Round-4 TKT-5：同 P2-5 pattern，显式落盘允许 0ms 覆盖 stale
+	}
+	if uerr := e.os.UpdateContent(ctx, messageID, content, meta); uerr != nil {
+		// 主 doc 未落 → 上抛让 caller 重试整批（consumer 走 kafka rebalance 重取）
+		return "", nil, uerr
+	}
+	return "", nil, nil
+}
+
+// normalizeExt 归一化扩展名：优先信 payload.file.extension 字段（octo-server 上传时磁数存的），
+// fallback filename 后缀。全部小写 + 保证前导 '.'。
+func normalizeExt(ext, name string) string {
+	e := strings.ToLower(strings.TrimSpace(ext))
+	if e == "" {
+		e = strings.ToLower(filepath.Ext(name))
+	}
+	if e == "" {
+		return ""
+	}
+	if !strings.HasPrefix(e, ".") {
+		e = "." + e
+	}
+	return e
+}
+
+// blacklistedExtensions v2 §6 表格的抽取黑名单（二进制媒体/压缩/图片，抽取无意义）。
+var blacklistedExtensions = map[string]bool{
+	".mp4": true, ".mov": true, ".avi": true, ".mkv": true, ".webm": true, ".flv": true, ".wmv": true, ".m4v": true,
+	".mp3": true, ".wav": true, ".aac": true, ".flac": true, ".ogg": true, ".wma": true, ".m4a": true, ".amr": true,
+	".zip": true, ".rar": true, ".7z": true, ".tar": true, ".gz": true, ".bz2": true, ".xz": true,
+	".dmg": true, ".pkg": true, ".deb": true, ".rpm": true, ".appimage": true,
+	".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".bmp": true, ".webp": true, ".ico": true,
+}
+
+// isBlacklistedExt 判扩展名是否在黑名单。
+// **注**：扩展名为空也返 false（v2 §7 #4 "宁抽多不漏"策略，让 Tika 兜底判是否可抽）。
+func isBlacklistedExt(ext string) bool {
+	return blacklistedExtensions[ext]
+}

--- a/internal/fileextract/idx4_test.go
+++ b/internal/fileextract/idx4_test.go
@@ -1,0 +1,699 @@
+package fileextract
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mkCfgForTest 造小超时的测试 config，避免测试跑太久。
+// v1.13 Blocker #1：test 用 httptest server 走 http://127.0.0.1:PORT，需要绕过 SSRF
+// scheme/host 白名单——加 http scheme + 127.0.0.1 host + SSRFAllowLoopback=true。
+// SSRF 的正式 test 覆盖在 ssrf_test.go（用默认 cfg 校验白名单拒绝逻辑）。
+func mkCfgForTest(maxSize int64) ServiceConfig {
+	return ServiceConfig{
+		DownloadTimeout:        500 * time.Millisecond,
+		ExtractTimeout:         500 * time.Millisecond,
+		MaxFileSize:            maxSize,
+		MaxContentBytes:        128, // 短便于测截断
+		HTTPRetries:            2,   // 3 次尝试
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true, // httptest server 走 loopback，生产必须 false
+	}
+}
+
+// TestDownload_HappyPath GET 200 返 bytes + Content-Type。
+func TestDownload_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		if _, werr := w.Write([]byte("%PDF-1.7 hello")); werr != nil {
+			t.Errorf("test server write: %v", werr)
+		}
+	}))
+	defer srv.Close()
+	dc := newDownloadClient(mkCfgForTest(1024))
+	body, ct, err := dc.Fetch(context.Background(), srv.URL+"/x.pdf")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(body) != "%PDF-1.7 hello" || ct != "application/pdf" {
+		t.Errorf("unexpected: body=%q ct=%q", string(body), ct)
+	}
+}
+
+// TestDownload_5xxTransientThenSuccess 前两次 500，第三次 200 → 抽取成功（覆盖重试策略）。
+func TestDownload_5xxTransientThenSuccess(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(500)
+			return
+		}
+		if _, werr := w.Write([]byte("ok")); werr != nil {
+			t.Errorf("test server write: %v", werr)
+		}
+	}))
+	defer srv.Close()
+	cfg := mkCfgForTest(1024)
+	// 缩短 backoff 使测试更快
+	dc := &downloadClient{
+		hc:             &http.Client{Timeout: 500 * time.Millisecond},
+		maxSize:        1024,
+		retries:        3,
+		retryBackoff:   10 * time.Millisecond,
+		allowedHosts:   []string{"127.0.0.1"},
+		allowedSchemes: []string{"http", "https"},
+	}
+	_ = cfg
+	body, _, err := dc.Fetch(context.Background(), srv.URL+"/x")
+	if err != nil {
+		t.Fatalf("Fetch: %v (calls=%d)", err, calls.Load())
+	}
+	if string(body) != "ok" {
+		t.Errorf("body: %q", string(body))
+	}
+	if calls.Load() != 3 {
+		t.Errorf("expected 3 calls (2 fail + 1 succeed), got %d", calls.Load())
+	}
+}
+
+// TestDownload_5xxRetryExhausted 三次都 500 → errDownloadFailed。
+func TestDownload_5xxRetryExhausted(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+	dc := &downloadClient{
+		hc:             &http.Client{Timeout: 500 * time.Millisecond},
+		maxSize:        1024,
+		retries:        2, // 共 3 次尝试
+		retryBackoff:   5 * time.Millisecond,
+		allowedHosts:   []string{"127.0.0.1"},
+		allowedSchemes: []string{"http", "https"},
+	}
+	_, _, err := dc.Fetch(context.Background(), srv.URL+"/x")
+	if !errors.Is(err, errDownloadFailed) {
+		t.Fatalf("expected errDownloadFailed, got %v", err)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls.Load())
+	}
+}
+
+// TestDownload_4xxPermanent 404 直接 errDownloadFailed，不重试。
+func TestDownload_4xxPermanent(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+	dc := &downloadClient{
+		hc:             &http.Client{Timeout: 500 * time.Millisecond},
+		maxSize:        1024,
+		retries:        3,
+		retryBackoff:   5 * time.Millisecond,
+		allowedHosts:   []string{"127.0.0.1"},
+		allowedSchemes: []string{"http", "https"},
+	}
+	_, _, err := dc.Fetch(context.Background(), srv.URL+"/x")
+	if !errors.Is(err, errDownloadFailed) {
+		t.Fatalf("expected errDownloadFailed, got %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("4xx should not retry, got %d attempts", calls.Load())
+	}
+}
+
+// TestDownload_ContentLengthOversize Content-Length > MaxFileSize → 立即 errOversize，不读 body。
+func TestDownload_ContentLengthOversize(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "999999")
+		w.WriteHeader(200)
+		if _, werr := w.Write(make([]byte, 999999)); werr != nil {
+			// Content-Length 触发 client 早退不读 body 是预期，Broken pipe 可忽略
+			_ = werr
+		}
+	}))
+	defer srv.Close()
+	dc := newDownloadClient(mkCfgForTest(1024))
+	_, _, err := dc.Fetch(context.Background(), srv.URL+"/big")
+	if !errors.Is(err, errOversize) {
+		t.Fatalf("expected errOversize, got %v", err)
+	}
+}
+
+// TestDownload_LiedContentLength 服务端谎报 Content-Length（无 header 但 body 超大）→ 兜底截断 + errOversize。
+func TestDownload_LiedContentLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		if _, werr := w.Write(make([]byte, 2048)); werr != nil {
+			// Broken pipe when client cuts off at LimitReader boundary is expected
+			_ = werr //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+	dc := newDownloadClient(mkCfgForTest(1024))
+	_, _, err := dc.Fetch(context.Background(), srv.URL+"/x")
+	if !errors.Is(err, errOversize) {
+		t.Fatalf("expected errOversize, got %v", err)
+	}
+}
+
+// TestDownload_ContextCancelled ctx 取消 → 立即返 ctx.Err。
+func TestDownload_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer srv.Close()
+	dc := &downloadClient{
+		hc:             &http.Client{Timeout: time.Second},
+		maxSize:        1024,
+		retries:        3,
+		retryBackoff:   time.Second,
+		allowedHosts:   []string{"127.0.0.1"},
+		allowedSchemes: []string{"http", "https"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+	_, _, err := dc.Fetch(ctx, srv.URL+"/x")
+	if err == nil {
+		t.Fatal("expected error on ctx cancel")
+	}
+}
+
+// ---- tika client tests ----
+
+// TestTika_Success 200 + body → 内容返回，truncated=false。
+func TestTika_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/tika" {
+			t.Errorf("unexpected req: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "text/plain" {
+			t.Errorf("Accept header: got %q", got)
+		}
+		if _, werr := w.Write([]byte("extracted text 抽出内容")); werr != nil {
+			t.Errorf("test server write: %v", werr)
+		}
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+	content, trunc, err := tc.Extract(context.Background(), []byte("pdf bytes"), "x.pdf", "")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if content != "extracted text 抽出内容" || trunc {
+		t.Errorf("got content=%q trunc=%v", content, trunc)
+	}
+}
+
+// TestTika_ContentTruncated 抽出内容超过 MaxContentBytes → 截断 + truncated=true。
+func TestTika_ContentTruncated(t *testing.T) {
+	longText := strings.Repeat("abc", 200) // 600 bytes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, werr := w.Write([]byte(longText)); werr != nil {
+			t.Errorf("test server write: %v", werr)
+		}
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+	content, trunc, err := tc.Extract(context.Background(), []byte("data"), "x.pdf", "")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !trunc {
+		t.Error("expected truncated=true")
+	}
+	if len(content) > 128 {
+		t.Errorf("content len %d > 128", len(content))
+	}
+}
+
+// TestTika_Utf8SafeTruncate 中文内容超长截断不产生半字符（unicode/utf8.RuneStart 边界）。
+func TestTika_Utf8SafeTruncate(t *testing.T) {
+	longChinese := strings.Repeat("中文字符", 100) // 每个 "中" = 3 bytes UTF-8
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(longChinese)) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 50})
+	content, trunc, err := tc.Extract(context.Background(), []byte("data"), "x.pdf", "")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !trunc {
+		t.Error("expected truncated=true")
+	}
+	// 关键：截断后的字符串必须是合法 UTF-8（不含半字符）
+	for i, r := range content {
+		if r == 0xFFFD {
+			t.Errorf("truncated content has invalid UTF-8 rune at index %d", i)
+			break
+		}
+	}
+}
+
+// TestTika_EncryptedDocument500Body 500 body 含 EncryptedDocumentException → errEncrypted。
+// v2 §7 #2 关键契约锁：Tika 版本升级 body 格式若变化，本 test 需同步 review。
+func TestTika_EncryptedDocument500Body(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		// 真实 Tika 3.3.0 加密 PDF 抛的 Java stack trace 采样：
+		_, _ = w.Write([]byte("org.apache.tika.exception.EncryptedDocumentException: encrypted PDF")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+	_, _, err := tc.Extract(context.Background(), []byte("pdf"), "x.pdf", "")
+	if !errors.Is(err, errEncrypted) {
+		t.Fatalf("expected errEncrypted, got %v", err)
+	}
+}
+
+// TestTika_500Generic 500 但非 encrypted → errExtractGeneric。
+func TestTika_500Generic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("org.apache.tika.exception.TikaException: some other error")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+	_, _, err := tc.Extract(context.Background(), []byte("data"), "x.pdf", "")
+	if !errors.Is(err, errExtractGeneric) {
+		t.Fatalf("expected errExtractGeneric, got %v", err)
+	}
+}
+
+// TestTika_422Unsupported Tika 明确不支持某格式返 422 → errExtractGeneric。
+func TestTika_422Unsupported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+	_, _, err := tc.Extract(context.Background(), []byte("data"), "x.xyz", "")
+	if !errors.Is(err, errExtractGeneric) {
+		t.Fatalf("expected errExtractGeneric on 422, got %v", err)
+	}
+}
+
+// TestTika_Timeout 服务端 sleep > timeout → errExtractTimeout。
+func TestTika_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		_, _ = w.Write([]byte("ok")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: 100 * time.Millisecond, MaxContentBytes: 128})
+	_, _, err := tc.Extract(context.Background(), []byte("data"), "x.pdf", "")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	// http.Client Timeout 超时的 err 可能不是 context.DeadlineExceeded 但会被包装成 errExtractGeneric；
+	// 若单元 test 里通过 ctx.WithTimeout 走则是 errExtractTimeout。这里两种都接受。
+	if !errors.Is(err, errExtractGeneric) && !errors.Is(err, errExtractTimeout) {
+		t.Fatalf("expected errExtractTimeout or errExtractGeneric, got %v", err)
+	}
+}
+
+// TestTika_EmptyBody 200 空 body → content="" err=nil（让上层判 empty_extract）。
+func TestTika_EmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+	content, trunc, err := tc.Extract(context.Background(), []byte("data"), "x.pdf", "")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if content != "" || trunc {
+		t.Errorf("empty body: got content=%q trunc=%v", content, trunc)
+	}
+}
+
+// ---- extractor tests (end-to-end w/ mock CDN + Tika + OS) ----
+
+// TestExtractor_BlacklistExtDLQ .mp4 扩展名 → DLQ blacklist_ext，不下载。
+// Round-3 Blocker B: 断言 permanent-fail 路径同步写 tombstone (contentMeta.status=unextractable)。
+func TestExtractor_BlacklistExtDLQ(t *testing.T) {
+	var tombstoneBody string
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Errorf("read body: %v", rerr)
+		}
+		tombstoneBody = string(b)
+		_, _ = w.Write([]byte(`{"_id":"42","result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses: []string{osSrv.URL},
+		ESIndex:     "octo-message",
+		MaxFileSize: 1024,
+	}
+	os, err := newOSWriter(cfg)
+	if err != nil {
+		t.Fatalf("newOSWriter: %v", err)
+	}
+	e := &Extractor{
+		download:       &downloadClient{}, // 不会被调
+		tika:           &tikaClient{},
+		os:             os,
+		maxFileSize:    1024,
+		extractorLabel: "tika/test",
+	}
+	fp := &filePayload{URL: "http://x/y.mp4", Name: "y.mp4", Extension: ".mp4", Size: 100}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if reason != ReasonBlacklistExt {
+		t.Errorf("reason: got %q want blacklist_ext", reason)
+	}
+	if cause == nil || err != nil {
+		t.Errorf("cause=%v err=%v", cause, err)
+	}
+	// Round-3 Blocker B: tombstone must be written on permanent-fail
+	if !strings.Contains(tombstoneBody, `"status":"unextractable"`) {
+		t.Errorf("tombstone must contain status=unextractable, got: %s", tombstoneBody)
+	}
+	if !strings.Contains(tombstoneBody, `"reason":"blacklist_ext"`) {
+		t.Errorf("tombstone must carry dlqReason=blacklist_ext, got: %s", tombstoneBody)
+	}
+	// tombstone 只写 contentMeta，不写 content 字段（保留真无 content 语义）
+	if strings.Contains(tombstoneBody, `"content":`) {
+		t.Errorf("tombstone must NOT write content field, got: %s", tombstoneBody)
+	}
+}
+
+// TestExtractor_OversizeDLQ size > cutoff → DLQ oversize，不下载。
+// Round-3 Blocker B: 断言 tombstone 同步写入。
+func TestExtractor_OversizeDLQ(t *testing.T) {
+	var tombstoneBody string
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Errorf("read body: %v", rerr)
+		}
+		tombstoneBody = string(b)
+		_, _ = w.Write([]byte(`{"_id":"42","result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses: []string{osSrv.URL},
+		ESIndex:     "octo-message",
+		MaxFileSize: 1024,
+	}
+	os, err := newOSWriter(cfg)
+	if err != nil {
+		t.Fatalf("newOSWriter: %v", err)
+	}
+	e := &Extractor{os: os, maxFileSize: 1024, extractorLabel: "tika/test"}
+	fp := &filePayload{URL: "http://x/y.pdf", Name: "y.pdf", Extension: ".pdf", Size: 2048}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if reason != ReasonOversize {
+		t.Errorf("reason: got %q want oversize (cause=%v)", reason, cause)
+	}
+	if err != nil {
+		t.Errorf("err: %v (cause=%v)", err, cause)
+	}
+	if !strings.Contains(tombstoneBody, `"status":"unextractable"`) {
+		t.Errorf("tombstone must contain status=unextractable, got: %s", tombstoneBody)
+	}
+	if !strings.Contains(tombstoneBody, `"reason":"oversize"`) {
+		t.Errorf("tombstone must carry dlqReason=oversize, got: %s", tombstoneBody)
+	}
+}
+
+// TestExtractor_HappyPath 下载 + Tika + OS 全流程走通（mock CDN + Tika + OS）。
+func TestExtractor_HappyPath(t *testing.T) {
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("pdf bytes")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer cdn.Close()
+	tika := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("extracted content 抽出内容")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer tika.Close()
+
+	var osCalls atomic.Int32
+	os := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		osCalls.Add(1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
+		if !strings.Contains(string(body), `"content":"extracted content 抽出内容"`) {
+			t.Errorf("update body missing content: %s", string(body))
+		}
+		if !strings.Contains(string(body), `"doc_as_upsert":false`) {
+			t.Errorf("update body must have doc_as_upsert=false: %s", string(body))
+		}
+		_, _ = w.Write([]byte(`{"_id":"42","_version":2,"result":"updated","_shards":{"total":2,"successful":2,"failed":0}}`)) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer os.Close()
+
+	// 手工装配 Extractor 避开 newOSWriter（真实构造函数会因 http:// 前缀警告但可用）
+	cfg := ServiceConfig{
+		ESAddresses:            []string{os.URL},
+		ESIndex:                "octo-message",
+		TikaURL:                tika.URL,
+		DownloadTimeout:        time.Second,
+		ExtractTimeout:         time.Second,
+		MaxFileSize:            1024 * 1024,
+		MaxContentBytes:        1024 * 1024,
+		HTTPRetries:            2,
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	fp := &filePayload{URL: cdn.URL + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if err != nil {
+		t.Fatalf("ExtractAndWrite: err=%v cause=%v", err, cause)
+	}
+	if reason != "" {
+		t.Errorf("expected success, got reason=%q cause=%v", reason, cause)
+	}
+	if osCalls.Load() != 1 {
+		t.Errorf("expected 1 OS call, got %d", osCalls.Load())
+	}
+}
+
+// TestNormalizeExt 覆盖归一化各种输入形态。
+func TestNormalizeExt(t *testing.T) {
+	cases := []struct {
+		ext, name, want string
+	}{
+		{".pdf", "x.pdf", ".pdf"},     // 传入的 ext 优先
+		{"pdf", "x.pdf", ".pdf"},      // 无前导 dot 加上
+		{"PDF", "x.pdf", ".pdf"},      // 大写归一化
+		{"", "x.docx", ".docx"},       // fallback filename
+		{"", "no_extension_file", ""}, // 均无
+		{"  .txt  ", "x.txt", ".txt"}, // trim
+	}
+	for _, c := range cases {
+		if got := normalizeExt(c.ext, c.name); got != c.want {
+			t.Errorf("normalizeExt(%q,%q): got %q want %q", c.ext, c.name, got, c.want)
+		}
+	}
+}
+
+// TestIsBlacklistedExt 采样几个扩展名判断黑名单。
+func TestIsBlacklistedExt(t *testing.T) {
+	cases := []struct {
+		ext  string
+		want bool
+	}{
+		{".mp4", true}, {".zip", true}, {".png", true}, {".dmg", true},
+		{".pdf", false}, {".docx", false}, {".txt", false}, {".unknown", false}, {"", false},
+	}
+	for _, c := range cases {
+		if got := isBlacklistedExt(c.ext); got != c.want {
+			t.Errorf("isBlacklistedExt(%q): got %v want %v", c.ext, got, c.want)
+		}
+	}
+}
+
+// TestTika_FilenameCRLFInjection 🔴 M2 回归：filename 含 CR/LF/双引号/控制字符时
+// 必须被 sanitize，Tika HTTP 请求实际收到的 Content-Disposition 不含这些字符。
+// filename 源头是 octo-server 上传用户名，未 sanitize 会造 CRLF header smuggling。
+func TestTika_FilenameCRLFInjection(t *testing.T) {
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Content-Disposition")
+		_, _ = w.Write([]byte("ok")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+
+	dangerous := []struct {
+		in       string
+		mustHave string // 期望 sanitize 后 header 里包含的干净部分
+		mustNot  []string
+	}{
+		{
+			in:       "attack.pdf\r\nX-Injected: yes",
+			mustHave: "attack.pdf",
+			// 关键：CRLF 必须被剔除，否则 HTTP header smuggling；X-Injected 关键字本身是合法字符
+			// （sanitize 只剔除结构性危险字符，不做关键字黑名单），CRLF 剔除即防住注入。
+			mustNot: []string{"\r", "\n"},
+		},
+		{
+			in:       `bad"name.pdf`,
+			mustHave: "badname.pdf",
+			mustNot:  []string{`"bad"`, `"name`}, // 双引号被剔除
+		},
+		{
+			in:       "\x00\x01evil.pdf",
+			mustHave: "evil.pdf",
+			mustNot:  []string{"\x00", "\x01"},
+		},
+		{
+			in:       "中文名.pdf", // 合法中文名保留
+			mustHave: "中文名.pdf",
+			mustNot:  nil,
+		},
+	}
+	for _, c := range dangerous {
+		gotHeader = ""
+		tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+		_, _, err := tc.Extract(context.Background(), []byte("data"), c.in, "")
+		if err != nil {
+			t.Errorf("filename=%q: unexpected err: %v", c.in, err)
+			continue
+		}
+		if !strings.Contains(gotHeader, c.mustHave) {
+			t.Errorf("filename=%q: header %q missing expected substring %q", c.in, gotHeader, c.mustHave)
+		}
+		for _, forbidden := range c.mustNot {
+			if strings.Contains(gotHeader, forbidden) {
+				t.Errorf("filename=%q: header %q must not contain %q", c.in, gotHeader, forbidden)
+			}
+		}
+	}
+}
+
+// TestSanitizeFilename 单元覆盖：控制字符/双引号/反斜杠剔除，合法字符保留。
+func TestSanitizeFilename(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"foo.pdf", "foo.pdf"},
+		{"a\rb\nc", "abc"},
+		{`a"b`, "ab"},
+		{"a\\b", "ab"},
+		{"a\x00b\x1fc\x7fd", "abcd"},
+		{"中文 文件.pdf", "中文 文件.pdf"},
+	}
+	for _, c := range cases {
+		if got := sanitizeFilename(c.in); got != c.want {
+			t.Errorf("sanitizeFilename(%q): got %q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestMimeTypeForExtension 🔴 生产 blocker 修复配套：19 种 v2 §6 白名单扩展名映射到 Tika 认识的 MIME。
+// 未知扩展 / 空 ext → application/octet-stream（Tika 走 magic-number auto-detect）。
+// 大小写不敏感，带/不带 '.' 前缀都能识别。
+func TestMimeTypeForExtension(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// Office 全家
+		{".pdf", "application/pdf"},
+		{".doc", "application/msword"},
+		{".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+		{".xls", "application/vnd.ms-excel"},
+		{".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+		{".ppt", "application/vnd.ms-powerpoint"},
+		{".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+		// 文本 / 富文本
+		{".txt", "text/plain"},
+		{".csv", "text/csv"},
+		{".rtf", "application/rtf"},
+		{".md", "text/markdown"},
+		// OpenDocument
+		{".odt", "application/vnd.oasis.opendocument.text"},
+		{".ods", "application/vnd.oasis.opendocument.spreadsheet"},
+		// Web / 结构化
+		{".html", "text/html"},
+		{".htm", "text/html"},
+		{".json", "application/json"},
+		{".xml", "application/xml"},
+		{".yaml", "application/x-yaml"},
+		{".yml", "application/x-yaml"},
+		// 大小写 + 无点前缀 normalize
+		{".PDF", "application/pdf"},
+		{"pdf", "application/pdf"},
+		{"DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+		{"  .xlsx  ", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+		// fallback
+		{"", "application/octet-stream"},
+		{".unknown", "application/octet-stream"},
+		{".exe", "application/octet-stream"},
+	}
+	for _, c := range cases {
+		if got := mimeTypeForExtension(c.in); got != c.want {
+			t.Errorf("mimeTypeForExtension(%q): got %q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTika_ContentTypeHeaderSet 🔴 生产 blocker 回归：Tika PUT 请求必须显式送 Content-Type，
+// 否则 Tika fallback 到 EmptyParser 返 0 字节。断言不同 filename/extension 组合下 header 值正确。
+// Max 2026-07-02 部 Tika 到 dmwork-test 实测复现（送 Content-Disposition filename="x.pdf" 但不送
+// Content-Type → Tika 返 200 但 body 为空）。
+func TestTika_ContentTypeHeaderSet(t *testing.T) {
+	var gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		_, _ = w.Write([]byte("ok")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+
+	cases := []struct {
+		name      string
+		filename  string
+		extension string
+		want      string
+	}{
+		// extension 参数优先
+		{"extension_wins_over_filename", "anything", ".pdf", "application/pdf"},
+		{"extension_without_dot", "anything", "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+		// extension 空 → 从 filename 后缀 fallback
+		{"filename_fallback_pdf", "report.PDF", "", "application/pdf"},
+		{"filename_fallback_xlsx", "budget.xlsx", "", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+		{"filename_fallback_pptx", "deck.pptx", "", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+		// 生产真实场景：URL 里没扩展名，靠 extension 字段兜底
+		{"no_ext_in_filename_use_extension", "24DC4FDFD6E7680E18E66359A29F34FDpptx", ".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+		// 未知扩展 → octet-stream（Tika auto-detect）
+		{"unknown_ext_fallback", "mystery.xyz", "", "application/octet-stream"},
+		// 都为空 → octet-stream
+		{"all_empty", "", "", "application/octet-stream"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotCT = ""
+			tc := newTikaClient(ServiceConfig{TikaURL: srv.URL, ExtractTimeout: time.Second, MaxContentBytes: 128})
+			_, _, err := tc.Extract(context.Background(), []byte("data"), c.filename, c.extension)
+			if err != nil {
+				t.Fatalf("Extract: %v", err)
+			}
+			if gotCT != c.want {
+				t.Errorf("Content-Type: got %q want %q", gotCT, c.want)
+			}
+		})
+	}
+}

--- a/internal/fileextract/kafka.go
+++ b/internal/fileextract/kafka.go
@@ -1,0 +1,130 @@
+package fileextract
+
+// kafka.go — file-extractor 的 Kafka 消费侧封装。
+// 与 internal/consumer/kafka.go 结构一致（CommitInterval=0 手动提交 + 只用 FetchMessage），
+// 不 import consumer 包避免循环依赖 + 保持本包独立可测。DLQ producer 同理。
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/segmentio/kafka-go"
+)
+
+// fetchedMessage 是从 Kafka 拉到的原始消息（含 topic/partition/offset，供 CommitBatch 用）。
+type fetchedMessage struct {
+	Topic     string
+	Partition int
+	Offset    int64
+	Key       []byte
+	Value     []byte
+}
+
+// messageSource 抽象「从 Kafka 拉一条消息 + 提交位点」。测试注入 mock。
+type messageSource interface {
+	Fetch(ctx context.Context) (fetchedMessage, error)
+	Commit(ctx context.Context, msg fetchedMessage) error
+	Close() error
+}
+
+// kafkaSource 用 kafka-go Reader 实现 messageSource（同 consumer/kafka.go C4 语义：
+// CommitInterval=0 同步手动提交 + 只用 FetchMessage，禁自动提交）。
+type kafkaSource struct {
+	reader *kafka.Reader
+}
+
+// KafkaSourceConfig 配置消费侧 Kafka Reader。
+type KafkaSourceConfig struct {
+	Brokers  []string
+	Topic    string
+	GroupID  string
+	MinBytes int
+	MaxBytes int
+}
+
+func newKafkaSource(cfg KafkaSourceConfig) (*kafkaSource, error) {
+	if len(cfg.Brokers) == 0 {
+		return nil, fmt.Errorf("fileextract: kafka brokers required")
+	}
+	if cfg.Topic == "" || cfg.GroupID == "" {
+		return nil, fmt.Errorf("fileextract: kafka topic and groupID required")
+	}
+	minBytes := cfg.MinBytes
+	if minBytes <= 0 {
+		minBytes = 1
+	}
+	maxBytes := cfg.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = 10 << 20 // 10MB
+	}
+	r := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:        cfg.Brokers,
+		Topic:          cfg.Topic,
+		GroupID:        cfg.GroupID,
+		CommitInterval: 0,
+		MinBytes:       minBytes,
+		MaxBytes:       maxBytes,
+	})
+	return &kafkaSource{reader: r}, nil
+}
+
+func (k *kafkaSource) Fetch(ctx context.Context) (fetchedMessage, error) {
+	m, err := k.reader.FetchMessage(ctx)
+	if err != nil {
+		return fetchedMessage{}, err
+	}
+	return fetchedMessage{
+		Topic:     m.Topic,
+		Partition: m.Partition,
+		Offset:    m.Offset,
+		Key:       m.Key,
+		Value:     m.Value,
+	}, nil
+}
+
+func (k *kafkaSource) Commit(ctx context.Context, msg fetchedMessage) error {
+	return k.reader.CommitMessages(ctx, kafka.Message{
+		Topic:     msg.Topic,
+		Partition: msg.Partition,
+		Offset:    msg.Offset,
+	})
+}
+
+func (k *kafkaSource) Close() error {
+	return k.reader.Close()
+}
+
+// dlqSink 抽象「把一条 DLQ 记录投到 DLQ topic」。测试注入 mock。
+type dlqSink interface {
+	WriteDLQ(ctx context.Context, key []byte, value []byte) error
+	Close() error
+}
+
+// kafkaDLQSink 用 kafka-go Writer 把 DLQ 记录写入 DLQ topic。
+// AllowAutoTopicCreation=false：DLQ topic 须部署侧预建，避免 topic 名拼错静默建错。
+type kafkaDLQSink struct {
+	writer *kafka.Writer
+}
+
+func newKafkaDLQSink(brokers []string, dlqTopic string) (*kafkaDLQSink, error) {
+	if len(brokers) == 0 || dlqTopic == "" {
+		return nil, fmt.Errorf("fileextract: DLQ brokers and topic required")
+	}
+	w := &kafka.Writer{
+		Addr:                   kafka.TCP(brokers...),
+		Topic:                  dlqTopic,
+		Balancer:               &kafka.Hash{},
+		RequiredAcks:           kafka.RequireAll,
+		Async:                  false,
+		AllowAutoTopicCreation: false,
+	}
+	return &kafkaDLQSink{writer: w}, nil
+}
+
+func (s *kafkaDLQSink) WriteDLQ(ctx context.Context, key []byte, value []byte) error {
+	return s.writer.WriteMessages(ctx, kafka.Message{Key: key, Value: value})
+}
+
+func (s *kafkaDLQSink) Close() error {
+	return s.writer.Close()
+}

--- a/internal/fileextract/metrics.go
+++ b/internal/fileextract/metrics.go
@@ -1,0 +1,35 @@
+package fileextract
+
+// metrics.go — file-extractor 计数器骨架（IDX-3 只做 log 打印，IDX-4+ 接 Prometheus 阶段 7 独立任务）。
+// 名字对齐 feasibility.md v2 §11 里提到的观察指标：processed / skipped_non_file / dlq_total[reason] /
+// extract_duration_ms / doc_not_yet（时序竞态触发次数）。
+
+import (
+	"log"
+	"sync/atomic"
+)
+
+// counters 是一组进程内简单计数（uint64 atomic），无并发风险且零依赖。
+type counters struct {
+	processed      atomic.Uint64
+	skippedNonFile atomic.Uint64
+	dlqTotal       atomic.Uint64
+	docNotYet      atomic.Uint64 // v2 §7 #1 时序竞态触发计数，观察 Phase 2 独立 retry topic 是否要上
+	retryExhausted atomic.Uint64 // v1.13 Blocker #2：in-place retry N 次未成功 → DLQ 触发计数
+	osPermanent    atomic.Uint64 // v1.13 P2-2：OS 4xx permanent → DLQ 触发计数
+}
+
+func (c *counters) IncProcessed()      { c.processed.Add(1) }
+func (c *counters) IncSkippedNonFile() { c.skippedNonFile.Add(1) }
+func (c *counters) IncDLQ()            { c.dlqTotal.Add(1) }
+func (c *counters) IncDocNotYet()      { c.docNotYet.Add(1) }
+func (c *counters) IncRetryExhausted() { c.retryExhausted.Add(1) }
+func (c *counters) IncOSPermanent()    { c.osPermanent.Add(1) }
+
+// LogSnapshot 打印当前累计计数（周期性调用，比如每 N 秒或 debug 时）。
+// IDX-3 stub 版：只 log；阶段 7 接 Prometheus counter 替换。
+func (c *counters) LogSnapshot() {
+	log.Printf("file-extractor metrics: processed=%d skipped_non_file=%d dlq_total=%d doc_not_yet=%d retry_exhausted=%d os_permanent=%d",
+		c.processed.Load(), c.skippedNonFile.Load(), c.dlqTotal.Load(), c.docNotYet.Load(),
+		c.retryExhausted.Load(), c.osPermanent.Load())
+}

--- a/internal/fileextract/oswriter.go
+++ b/internal/fileextract/oswriter.go
@@ -1,0 +1,178 @@
+package fileextract
+
+// oswriter.go — OS partial `_update` client。只写 payload.file.content + payload.file.contentMeta，
+// 不动主 doc 其他字段。doc_as_upsert=false 避免主 doc 未落时造孤儿子文档（reader 会崩）。
+//
+// 错误分类：
+//   - HTTP 200/201 → nil
+//   - HTTP 404 → errDocNotYet（v2 §7 #1 时序竞态：es-indexer 还没消费到，本批重试）
+//   - HTTP 409 → nil（OS 内部 retry_on_conflict=3 已处理，超过依然报 409 时视为 caller 该重试）
+//   - HTTP 5xx → errOSTransient（transient，触发重试或吐 error 让 kafka 重放）
+//   - HTTP 4xx (非 404/409) → errOSPermanent（应罕见；写请求 body 4xx 是编程 bug 需修）
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+	"github.com/opensearch-project/opensearch-go/v3"
+	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
+)
+
+// OS 写入错误哨兵，上层用 errors.Is 分类。
+var (
+	// errDocNotYet 主 doc 还没落到 OS（es-indexer 慢一步），触发本批 Kafka 重试。
+	errDocNotYet = errors.New("fileextract: doc not yet indexed by es-indexer (404)")
+	// errOSTransient 5xx / 网络错，可重试。
+	errOSTransient = errors.New("fileextract: opensearch transient error")
+	// errOSPermanent 4xx (非 404/409) permanent，通常是请求 body 编程 bug。
+	errOSPermanent = errors.New("fileextract: opensearch permanent error")
+)
+
+// osWriter 只做一件事：给指定 messageId 的 doc 做 partial update payload.file.content + contentMeta。
+type osWriter struct {
+	client *opensearchapi.Client
+	index  string
+}
+
+// newOSWriter 构造 OpenSearch 客户端（复用 esindex.NewWriter 相同 dial 参数形态便于运维一致）。
+func newOSWriter(cfg ServiceConfig) (*osWriter, error) {
+	if len(cfg.ESAddresses) == 0 {
+		return nil, errors.New("fileextract: at least one OS address required")
+	}
+	if cfg.ESIndex == "" {
+		return nil, errors.New("fileextract: OS index required")
+	}
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: cfg.ESAddresses,
+			Username:  cfg.ESUsername,
+			Password:  cfg.ESPassword,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fileextract: new opensearch client: %w", err)
+	}
+	return &osWriter{client: client, index: cfg.ESIndex}, nil
+}
+
+// UpdateContent partial update 只写 payload.file.content + payload.file.contentMeta。
+// doc_as_upsert=false → 主 doc 未落时返 errDocNotYet（不 upsert 造孤儿）。
+// retry_on_conflict=3 → OS 内部处理 optimistic-lock 冲突（file-extractor 与 backfill Job
+// 同时写同一 doc 时缓解）。
+func (w *osWriter) UpdateContent(ctx context.Context, messageID string, content string, meta esindex.FileContentMeta) error {
+	body := map[string]any{
+		"doc": map[string]any{
+			"payload": map[string]any{
+				"file": map[string]any{
+					"content":     content,
+					"contentMeta": meta,
+				},
+			},
+		},
+		"doc_as_upsert": false,
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal update body: %w", err)
+	}
+	retry := 3
+	req := opensearchapi.UpdateReq{
+		Index:      w.index,
+		DocumentID: messageID,
+		Body:       bytes.NewReader(buf),
+		Params:     opensearchapi.UpdateParams{RetryOnConflict: &retry},
+	}
+	resp, err := w.client.Update(ctx, req)
+	if err != nil {
+		return classifyOSErr(resp, err)
+	}
+	if resp == nil {
+		return errors.New("fileextract: nil update response")
+	}
+	return nil
+}
+
+// tombstoneStatus 是 permanent-fail 文件在 contentMeta.status 里写入的常量，与 backfill
+// source.go scroll query `must_not term contentMeta.status=<value>` 严格对齐。改此值必须
+// 同步改 source.go（有 test 契约锁）。
+const tombstoneStatus = "unextractable"
+
+// WriteTombstone 是 Round-3 Blocker B (yujiawei P1 / Jerry-Xin #2) fix：对 permanent-fail 文件
+// 写 tombstone marker 到 contentMeta，让 backfill scroll query 通过 must_not term 过滤，避免
+// rerun 无限重复 DLQ 已知永久失败文件。
+//
+// 语义：partial _update 只写 contentMeta.{status,reason,extractedAt}，**不写 content 字段**
+// —— 保留 "真无 content" 语义（reader 搜索时不会命中，与不写 tombstone 时的行为一致）。
+// doc_as_upsert=false → 主 doc 未落时返 errDocNotYet（不 upsert 造孤儿）；上层收到 errDocNotYet
+// 视为可容忍（tombstone 只是补丁不阻塞主 DLQ 路径，backfill 兜底重跑时若主 doc 已落再补写）。
+//
+// 错误分类同 UpdateContent（复用 classifyOSErr）。retry_on_conflict=3 缓解与 es-indexer 并发。
+func (w *osWriter) WriteTombstone(ctx context.Context, messageID string, reason string) error {
+	status := tombstoneStatus
+	body := map[string]any{
+		"doc": map[string]any{
+			"payload": map[string]any{
+				"file": map[string]any{
+					"contentMeta": esindex.FileContentMeta{
+						ExtractedAt: time.Now().Unix(),
+						Status:      &status,
+						Reason:      &reason,
+					},
+				},
+			},
+		},
+		"doc_as_upsert": false,
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal tombstone body: %w", err)
+	}
+	retry := 3
+	req := opensearchapi.UpdateReq{
+		Index:      w.index,
+		DocumentID: messageID,
+		Body:       bytes.NewReader(buf),
+		Params:     opensearchapi.UpdateParams{RetryOnConflict: &retry},
+	}
+	resp, err := w.client.Update(ctx, req)
+	if err != nil {
+		return classifyOSErr(resp, err)
+	}
+	if resp == nil {
+		return errors.New("fileextract: nil tombstone response")
+	}
+	return nil
+}
+
+// classifyOSErr 把 opensearch-go 的通用 error 转成本包 sentinel（errors.Is 可读）。
+// opensearch-go v3 的 Update 在 HTTP 非 2xx 时会返回带 status code 的 err（含 response body）。
+//
+// v1.13 P2-1 fix：新增 429 (Too Many Requests) → errOSTransient 分类
+// （老代码走 status >= 400 catch-all 误归 errOSPermanent，429 是 OS 限流是 transient 语义，
+// 与 download.go:117 的 CDN 429 处理一致）。
+func classifyOSErr(resp *opensearchapi.UpdateResp, err error) error {
+	if resp != nil && resp.Inspect().Response != nil {
+		status := resp.Inspect().Response.StatusCode
+		switch {
+		case status == http.StatusNotFound:
+			return errDocNotYet
+		case status == http.StatusConflict:
+			// retry_on_conflict=3 已经尝试过，仍报 409 视为 transient（下轮重试）
+			return errOSTransient
+		case status == http.StatusTooManyRequests:
+			// v1.13 P2-1：OS 限流是 transient 语义，需在 400 catch-all 之前拦下
+			return errOSTransient
+		case status >= 500:
+			return errOSTransient
+		case status >= 400:
+			return fmt.Errorf("%w: status %d: %v", errOSPermanent, status, err)
+		}
+	}
+	return fmt.Errorf("%w: %v", errOSTransient, err)
+}

--- a/internal/fileextract/p2_test.go
+++ b/internal/fileextract/p2_test.go
@@ -1,0 +1,206 @@
+package fileextract
+
+// p2_test.go — v1.13 P2 修复的定向回归 test（补充 idx4_test.go / retry_test.go / ssrf_test.go
+// 未覆盖的 P2 项）：
+//   P2-6 isPermanentDownloadErr 使用 errCDNPermanent sentinel（errors.Is 而非字符串匹配）
+//   P2-7 empty_extract 覆盖 whitespace-only content
+//   P2-9 Tika timeout ctx-driven（parent cancel vs per-request timeout 区分）
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIsPermanentDownloadErr_UsesSentinel v1.13 P2-6：sentinel-based error 分类
+// （老代码用 strings.Contains "cdn permanent status"，重构 err 格式即静默把 4xx 归成 transient）。
+// v1.13 §2.3 rereview：删除对 legacy string-form 的兜底断言（生产已无外部构造该字符串路径）。
+func TestIsPermanentDownloadErr_UsesSentinel(t *testing.T) {
+	// wrap sentinel → 应识别为 permanent
+	err := fmt.Errorf("%w: status 404", errCDNPermanent)
+	if !isPermanentDownloadErr(err) {
+		t.Errorf("wrapped errCDNPermanent must be permanent (via errors.Is): %v", err)
+	}
+	// nested wrap 也识别
+	err2 := fmt.Errorf("outer: %w", err)
+	if !isPermanentDownloadErr(err2) {
+		t.Errorf("nested wrap must be permanent: %v", err2)
+	}
+	// 老字符串格式**不再**识别（sentinel-only）：确保未来重构 err 格式不会静默变行为
+	err3 := errors.New("cdn permanent status 403")
+	if isPermanentDownloadErr(err3) {
+		t.Errorf("legacy string-form err must NOT be recognized (sentinel-only, §2.3 rereview): %v", err3)
+	}
+	// nil / 其他 err 不应识别
+	if isPermanentDownloadErr(nil) {
+		t.Errorf("nil must not be permanent")
+	}
+	if isPermanentDownloadErr(errors.New("some transient network err")) {
+		t.Errorf("unrelated err must not be permanent")
+	}
+}
+
+// TestExtractor_WhitespaceOnlyIsEmptyExtract v1.13 P2-7：whitespace-only Tika 输出 → DLQ
+// empty_extract（老代码只判 == ""，"\n\n" 或空格串会漏过 → 无意义 content 被误 commit）。
+func TestExtractor_WhitespaceOnlyIsEmptyExtract(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+	}{
+		{"empty string", ""},
+		{"newlines only", "\n\n"},
+		{"spaces only", "   "},
+		{"mixed whitespace", " \t\n\r "},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// mock Tika 返 c.out；mock CDN 返 pdf bytes；mock OS 记录写入
+			cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("pdf bytes")) //nolint:errcheck // test handler write; not the SUT
+			}))
+			defer cdn.Close()
+			tika := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(c.out)) //nolint:errcheck // test handler write; not the SUT
+			}))
+			defer tika.Close()
+			// Round-3 Blocker B: empty_extract 现在会写 tombstone (contentMeta.status=unextractable)。
+			// 断言收到的 OS 写入是 tombstone 而**非** content（真无 content 语义保持）。
+			var osBody string
+			os := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, rerr := io.ReadAll(r.Body)
+				if rerr != nil {
+					t.Errorf("read os body: %v", rerr)
+				}
+				osBody = string(b)
+				_, _ = w.Write([]byte(`{"result":"updated"}`)) //nolint:errcheck // test handler write; not the SUT
+			}))
+			defer os.Close()
+
+			cfg := ServiceConfig{
+				ESAddresses:            []string{os.URL},
+				ESIndex:                "octo-message",
+				TikaURL:                tika.URL,
+				DownloadTimeout:        time.Second,
+				ExtractTimeout:         time.Second,
+				MaxFileSize:            1024,
+				MaxContentBytes:        1024,
+				HTTPRetries:            2,
+				AllowedDownloadHosts:   []string{"127.0.0.1"},
+				AllowedDownloadSchemes: []string{"http", "https"},
+				SSRFAllowLoopback:      true,
+			}
+			e, err := NewExtractor(cfg)
+			if err != nil {
+				t.Fatalf("NewExtractor: %v", err)
+			}
+			fp := &filePayload{URL: cdn.URL + "/x.pdf", Name: "x.pdf", Extension: ".pdf"}
+			reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+			if err != nil {
+				t.Fatalf("ExtractAndWrite: err=%v cause=%v", err, cause)
+			}
+			if reason != ReasonEmptyExtract {
+				t.Errorf("reason=%q want empty_extract (whitespace should DLQ, cause=%v)", reason, cause)
+			}
+			// Round-3 Blocker B: OS 现在会被写 tombstone (contentMeta.status=unextractable) 而**非** content。
+			// 断言 (1) OS 确实收到了写请求 (2) 请求 body 不含 content 字段 (3) 含 empty_extract tombstone。
+			if osBody == "" {
+				t.Error("OS must receive tombstone write for empty_extract (Blocker B)")
+			}
+			if strings.Contains(osBody, `"content":`) {
+				t.Errorf("tombstone must NOT write content field (preserve true no-content semantics), got: %s", osBody)
+			}
+			if !strings.Contains(osBody, `"status":"unextractable"`) {
+				t.Errorf("empty_extract tombstone must carry status=unextractable, got: %s", osBody)
+			}
+			if !strings.Contains(osBody, `"reason":"empty_extract"`) {
+				t.Errorf("tombstone must carry dlqReason=empty_extract, got: %s", osBody)
+			}
+		})
+	}
+}
+
+// TestTika_TimeoutFiresDeadlineExceeded v1.13 P2-9：per-request context.WithTimeout 触发时，
+// err 正确分类为 errExtractTimeout（老代码用 http.Client.Timeout 时 ctx.Err()=nil，分类为
+// errExtractGeneric → DLQ extract_error，扰乱 timeout 统计与 retry 语义）。
+func TestTika_TimeoutFiresDeadlineExceeded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 服务端故意慢，让 Tika client per-request timeout 触发
+		time.Sleep(300 * time.Millisecond)
+		_, _ = w.Write([]byte("late")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{
+		TikaURL:         srv.URL,
+		ExtractTimeout:  50 * time.Millisecond, // 短到必超
+		MaxContentBytes: 128,
+	})
+	_, _, err := tc.Extract(context.Background(), []byte("x"), "x.pdf", ".pdf")
+	if !errors.Is(err, errExtractTimeout) {
+		t.Fatalf("per-request timeout must map to errExtractTimeout, got %v", err)
+	}
+}
+
+// TestTika_ParentCancelDistinctFromTimeout v1.13 P2-9：parent ctx 取消（SIGTERM 场景）→
+// 上抛 ctx.Err()（context.Canceled），**不** map 成 errExtractTimeout。
+// 保证 caller 能区分"外部关停"与"本次 Tika 慢"。
+func TestTika_ParentCancelDistinctFromTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		_, _ = w.Write([]byte("late")) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{
+		TikaURL:         srv.URL,
+		ExtractTimeout:  time.Second, // 够长，不因 timeout 触发
+		MaxContentBytes: 128,
+	})
+	parentCtx, cancel := context.WithCancel(context.Background())
+	// 让 parent 在 50ms 后取消 → 应比 per-request timeout（1s）先触发
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	_, _, err := tc.Extract(parentCtx, []byte("x"), "x.pdf", ".pdf")
+	// 应返 ctx.Canceled 而非 errExtractTimeout
+	if errors.Is(err, errExtractTimeout) {
+		t.Errorf("parent cancel must NOT map to errExtractTimeout, got %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("parent cancel must surface as context.Canceled, got %v", err)
+	}
+}
+
+// TestTika_LimitReadResponse v1.13 P2-4：Tika 谎报大 body → io.LimitReader 兜住不 OOM。
+// 服务端返 100KB body，client MaxContentBytes=1KB → 只应读 1KB+4 字节（LimitReader 上限）。
+func TestTika_LimitReadResponse(t *testing.T) {
+	huge := make([]byte, 100*1024)
+	for i := range huge {
+		huge[i] = 'a'
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(huge) //nolint:errcheck // test handler write; not the SUT
+	}))
+	defer srv.Close()
+	tc := newTikaClient(ServiceConfig{
+		TikaURL:         srv.URL,
+		ExtractTimeout:  time.Second,
+		MaxContentBytes: 1024, // 1KB
+	})
+	content, truncated, err := tc.Extract(context.Background(), []byte("x"), "x.pdf", ".pdf")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !truncated {
+		t.Errorf("truncated flag should be true (LimitReader wraps read past cap)")
+	}
+	// 抽出 content 应 <= MaxContentBytes（LimitReader 严格截 + truncateContent 处理 utf8 边界）
+	if len(content) > 1024 {
+		t.Errorf("content len=%d exceeds MaxContentBytes=1024 (LimitReader failed)", len(content))
+	}
+}

--- a/internal/fileextract/payload.go
+++ b/internal/fileextract/payload.go
@@ -1,0 +1,95 @@
+package fileextract
+
+// payload.go 提供 file-extractor 内的轻量 payload 解析（只解 type + payload.file 子对象）。
+// 不 import internal/esindex（避免循环依赖 + fileextract 保持独立可测）；实现比 esindex/buildraw.go
+// 精简得多，只覆盖本服务需要的两件事：
+//   1. 判 payload.type 是否 = 8 (File)，非 8 直接跳过
+//   2. type=8 时从 raw payload 抽 url/name/extension/size 供下载 + DLQ 记录使用
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// PayloadTypeFile 对应 octo-lib common.File 常量值 8（与 esindex/buildraw.go payloadTypeFile 一致）。
+// 不 import octo-lib common 避免拖 zap/redis/grpc 200+ 依赖（同 producer/extract.go 复制常量策略）。
+const PayloadTypeFile = 8
+
+// filePayload 是本服务用到的 payload.file 子对象字段（对齐 octo-server FilePayload 上传契约）。
+type filePayload struct {
+	URL       string
+	Name      string
+	Extension string
+	Size      int64
+}
+
+// extractContentTypeFile 从 Kafka 消息 RawPayload 里判 type 是否 = 8。
+// 返回：
+//   - (payload, true)  — 是 type=8 file 消息，payload 已抽字段
+//   - (nil,     false) — 不是 file 消息（或 RawPayload 空/损坏，视为非 file 跳过）
+//
+// 只解顶层对象 + type/url/name/extension/size 5 个字段；不做完整 payload 校验（那是 es-indexer
+// 的活）。这样吞吐≈Kafka 消费速度，非 file 消息（占 99.3%）零解析开销。
+func extractContentTypeFile(rawPayload []byte) (*filePayload, bool) {
+	if len(rawPayload) == 0 {
+		return nil, false
+	}
+	dec := json.NewDecoder(bytes.NewReader(rawPayload))
+	dec.UseNumber()
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		return nil, false
+	}
+	t, ok := readType(m["type"])
+	if !ok || t != PayloadTypeFile {
+		return nil, false
+	}
+	p := &filePayload{}
+	if u, ok := m["url"].(string); ok {
+		p.URL = u
+	}
+	if n, ok := m["name"].(string); ok {
+		p.Name = n
+	}
+	if e, ok := m["extension"].(string); ok {
+		p.Extension = e
+	}
+	if sz, ok := readInt64(m["size"]); ok {
+		p.Size = sz
+	}
+	return p, true
+}
+
+// readType 兼容 float64 / int / json.Number 三种 JSON 数字解出形态（同 esindex/buildraw.go extractType）。
+func readType(v any) (int, bool) {
+	switch x := v.(type) {
+	case json.Number:
+		if n, err := x.Int64(); err == nil {
+			return int(n), true
+		}
+	case float64:
+		return int(x), true
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	}
+	return 0, false
+}
+
+// readInt64 兼容 float64 / int / int64 / json.Number 抽 int64 值。
+func readInt64(v any) (int64, bool) {
+	switch x := v.(type) {
+	case json.Number:
+		if n, err := x.Int64(); err == nil {
+			return n, true
+		}
+	case float64:
+		return int64(x), true
+	case int:
+		return int64(x), true
+	case int64:
+		return x, true
+	}
+	return 0, false
+}

--- a/internal/fileextract/retry_test.go
+++ b/internal/fileextract/retry_test.go
@@ -1,0 +1,410 @@
+package fileextract
+
+// retry_test.go — Blocker #2 修复回归 test（v1.13）。
+// 目标：验证 in-place bounded retry state machine 正确性：
+//   1. transient (errDocNotYet / errOSTransient) 触发重试直到 OK 或达上限 DLQ
+//   2. offset 只在"该消息达终态"后按连续前缀 commit（不跨越 transient）
+//   3. 429 (P2-1) 归 transient，不误判 permanent
+//   4. errOSPermanent (P2-2) 立即 DLQ ReasonOSPermanent，不重试
+//   5. 多分区 offset prefix 按分区独立推进（fix-plan §8 #1）
+//   6. 退避可 ctx-cancel（SIGTERM 立即返）
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/contract/searchmsg"
+)
+
+// mockExtractor 是 extractorService 的测试假实现。
+// 按 messageID 匹配预置的 outcomes 序列，逐次消费；用尽则返回默认。
+type mockExtractor struct {
+	mu sync.Mutex
+	// outcomes[msgID] = 一序列每次返回值（(reason, cause, err)）
+	outcomes   map[string][]extractResult
+	calls      map[string]int // 每 msgID 被调多少次
+	defaultRes extractResult
+}
+
+type extractResult struct {
+	reason string
+	cause  error
+	err    error
+}
+
+func newMockExtractor() *mockExtractor {
+	return &mockExtractor{
+		outcomes:   make(map[string][]extractResult),
+		calls:      make(map[string]int),
+		defaultRes: extractResult{}, // 默认 OK
+	}
+}
+
+func (m *mockExtractor) queue(msgID string, results ...extractResult) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.outcomes[msgID] = append(m.outcomes[msgID], results...)
+}
+
+func (m *mockExtractor) ExtractAndWrite(ctx context.Context, messageID string, fp *filePayload) (string, error, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls[messageID]++
+	seq := m.outcomes[messageID]
+	if len(seq) == 0 {
+		return m.defaultRes.reason, m.defaultRes.cause, m.defaultRes.err
+	}
+	r := seq[0]
+	m.outcomes[messageID] = seq[1:]
+	return r.reason, r.cause, r.err
+}
+
+// mkFileMessage 造一条 file 消息（type=8），用给定 msgID + partition + offset。
+func mkFileMessage(t *testing.T, msgID string, partition int, offset int64) fetchedMessage {
+	t.Helper()
+	rawPayload := map[string]any{
+		"type":      8,
+		"url":       "https://cdn.deepminer.com.cn/test.pdf",
+		"name":      "test.pdf",
+		"extension": ".pdf",
+		"size":      2048,
+	}
+	rawBytes, err := json.Marshal(rawPayload)
+	if err != nil {
+		t.Fatalf("marshal rawPayload: %v", err)
+	}
+	msg := searchmsg.Message{
+		SchemaVersion: searchmsg.SchemaVersion,
+		MessageID:     msgID,
+		RawPayload:    rawBytes,
+	}
+	value, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal msg: %v", err)
+	}
+	return fetchedMessage{
+		Topic:     "test-topic",
+		Partition: partition,
+		Offset:    offset,
+		Key:       []byte(msgID),
+		Value:     value,
+	}
+}
+
+// newRetryTestProcessor 构造 test-only Processor（sleep 换成 no-op 加速）。
+func newRetryTestProcessor(t *testing.T, src messageSource, dlq dlqSink, ext extractorService, maxRetries int) *Processor {
+	t.Helper()
+	cfg := ServiceConfig{
+		MaxRetriesPerMessage: maxRetries,
+		TransientBackoffBase: time.Nanosecond, // 让退避几乎 0，加速 test
+		TransientBackoffMax:  time.Microsecond,
+	}
+	p := NewProcessor(src, dlq, ext, cfg)
+	// 覆盖 sleep 为 no-op（避免真实 sleep 拖慢 test）
+	p.sleep = func(ctx context.Context, d time.Duration) error {
+		return ctx.Err()
+	}
+	return p
+}
+
+// TestProcessBatch_TransientRetryThenSuccess 前 2 次 attemptOne 返 transient，第 3 次 OK →
+// commit 1 次（成功那次的 offset），attempts=3。
+func TestProcessBatch_TransientRetryThenSuccess(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	ext.queue("42",
+		extractResult{err: errDocNotYet},   // attempt 1
+		extractResult{err: errOSTransient}, // attempt 2
+		extractResult{},                    // attempt 3 → OK
+	)
+	p := newRetryTestProcessor(t, src, dlq, ext, 10)
+
+	batch := []fetchedMessage{mkFileMessage(t, "42", 0, 100)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if ext.calls["42"] != 3 {
+		t.Fatalf("expected 3 extractor calls, got %d", ext.calls["42"])
+	}
+	if len(dlq.records) != 0 {
+		t.Fatalf("expected 0 DLQ records, got %d: %+v", len(dlq.records), dlq.records)
+	}
+	if len(src.commits) != 1 || src.commits[0].Offset != 100 {
+		t.Fatalf("expected exactly 1 commit at offset 100, got %+v", src.commits)
+	}
+}
+
+// TestProcessBatch_RetryExhaustedToDLQ 10 次全 errDocNotYet → 第 11 次不再调 extractor，
+// 强制 DLQ ReasonRetryExhausted，然后 commit offset。
+func TestProcessBatch_RetryExhaustedToDLQ(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	// 每次都返 errDocNotYet
+	ext.defaultRes = extractResult{err: errDocNotYet}
+	p := newRetryTestProcessor(t, src, dlq, ext, 5) // 限 5 次加速
+
+	batch := []fetchedMessage{mkFileMessage(t, "99", 0, 200)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if ext.calls["99"] != 5 {
+		t.Fatalf("expected 5 extractor calls (bounded), got %d", ext.calls["99"])
+	}
+	if len(dlq.records) != 1 || dlq.records[0].Reason != ReasonRetryExhausted {
+		t.Fatalf("expected 1 DLQ retry_exhausted, got %+v", dlq.records)
+	}
+	if p.metrics.retryExhausted.Load() != 1 {
+		t.Fatalf("retryExhausted counter should be 1, got %d", p.metrics.retryExhausted.Load())
+	}
+	if len(src.commits) != 1 || src.commits[0].Offset != 200 {
+		t.Fatalf("offset must be committed after DLQ retry_exhausted, got %+v", src.commits)
+	}
+}
+
+// TestProcessBatch_429IsTransient P2-1：OS 返 429 → errOSTransient → 走 retry 不是 DLQ。
+// 用 wrap 一个 429-status err（模拟 classifyOSErr 输出）。
+func TestProcessBatch_429IsTransient(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	// 前 1 次 wrap errOSTransient（模拟 classifyOSErr 判 429 后的错），第 2 次 OK
+	err429 := fmt.Errorf("%w: status 429: too many requests", errOSTransient)
+	ext.queue("t429",
+		extractResult{err: err429},
+		extractResult{},
+	)
+	p := newRetryTestProcessor(t, src, dlq, ext, 10)
+
+	batch := []fetchedMessage{mkFileMessage(t, "t429", 0, 300)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if ext.calls["t429"] != 2 {
+		t.Fatalf("429 must retry once then OK; got %d calls", ext.calls["t429"])
+	}
+	if len(dlq.records) != 0 {
+		t.Fatalf("429 must NOT DLQ (transient), got %+v", dlq.records)
+	}
+	if len(src.commits) != 1 || src.commits[0].Offset != 300 {
+		t.Fatalf("expected commit at 300 after transient resolves, got %+v", src.commits)
+	}
+}
+
+// TestProcessBatch_OSPermanentToDLQ P2-2：OS 返 400（非 404/409/429）→ errOSPermanent →
+// 立即 DLQ ReasonOSPermanent，不 retry。
+func TestProcessBatch_OSPermanentToDLQ(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	err400 := fmt.Errorf("%w: status 400: bad request", errOSPermanent)
+	ext.queue("t400", extractResult{err: err400})
+	p := newRetryTestProcessor(t, src, dlq, ext, 10)
+
+	batch := []fetchedMessage{mkFileMessage(t, "t400", 0, 400)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if ext.calls["t400"] != 1 {
+		t.Fatalf("os_permanent must NOT retry; got %d calls (want 1)", ext.calls["t400"])
+	}
+	if len(dlq.records) != 1 || dlq.records[0].Reason != ReasonOSPermanent {
+		t.Fatalf("expected 1 DLQ os_permanent, got %+v", dlq.records)
+	}
+	if p.metrics.osPermanent.Load() != 1 {
+		t.Fatalf("osPermanent counter should be 1, got %d", p.metrics.osPermanent.Load())
+	}
+}
+
+// TestProcessBatch_OffsetPrefixCommit_101FailsFirstAttempt 关键 Jerry-Xin scenario：
+// offset 100/101/102，101 first attempt fails；102 must NOT be committed until 101 reaches terminal.
+// 用只有 3 条一起的 batch 复现。
+func TestProcessBatch_OffsetPrefixCommit_101FailsFirstAttempt(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	// 100 立即 OK
+	ext.queue("100", extractResult{})
+	// 101 前 2 次 transient，第 3 次 OK
+	ext.queue("101",
+		extractResult{err: errDocNotYet},
+		extractResult{err: errDocNotYet},
+		extractResult{},
+	)
+	// 102 立即 OK
+	ext.queue("102", extractResult{})
+	p := newRetryTestProcessor(t, src, dlq, ext, 10)
+
+	batch := []fetchedMessage{
+		mkFileMessage(t, "100", 0, 100),
+		mkFileMessage(t, "101", 0, 101),
+		mkFileMessage(t, "102", 0, 102),
+	}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	// 验证最终 commit：应达到 offset 102（全部终态后按前缀推进）
+	if len(src.commits) == 0 {
+		t.Fatalf("expected at least 1 commit")
+	}
+	// 关键：**最后一次** commit 应到 102；且过程中不应出现"越过 101 直接提交 102"
+	for i, c := range src.commits {
+		// 每个提交点都必须 <= 该 partition 当前已到达 terminal 的最高连续 offset
+		if c.Offset > 102 {
+			t.Fatalf("commit[%d] offset=%d exceeds max input 102", i, c.Offset)
+		}
+	}
+	// 找中间过程 commit：第一轮 100 OK + 102 OK，101 transient → 前缀应只到 100
+	// 最终轮 101 OK → 前缀到 102
+	finalCommit := src.commits[len(src.commits)-1]
+	if finalCommit.Offset != 102 {
+		t.Fatalf("final commit must be 102 (full prefix), got %d", finalCommit.Offset)
+	}
+	// 中间不应有 "> 100 但 < 102" 的 commit（101 未达终态时不能越过）
+	for i, c := range src.commits[:len(src.commits)-1] {
+		if c.Offset >= 101 && c.Offset < 102 {
+			t.Fatalf("commit[%d]=%d must not jump past pending 101 (was: %+v)", i, c.Offset, src.commits)
+		}
+	}
+}
+
+// TestProcessBatch_MultiPartitionPrefixIndependent 多分区 offset 应独立推进（fix-plan §8 #1）。
+// 分区 0：offset 100 (transient forever)、101 (OK)；
+// 分区 1：offset 200 (OK)、201 (OK)。
+// 期望：分区 1 前缀推进到 201；分区 0 停在无提交（100 未终态直到达 retry 上限）。
+func TestProcessBatch_MultiPartitionPrefixIndependent(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	// p0/100 一直 transient（模拟 doc-not-yet 永久缺）；上限触发 DLQ
+	ext.defaultRes = extractResult{err: errDocNotYet}
+	// 但为 p0/101, p1/200, p1/201 预置 OK 覆盖 default
+	ext.queue("m101", extractResult{})
+	ext.queue("m200", extractResult{})
+	ext.queue("m201", extractResult{})
+	p := newRetryTestProcessor(t, src, dlq, ext, 3) // p0/m100 只 retry 3 次触发 DLQ
+
+	batch := []fetchedMessage{
+		mkFileMessage(t, "m100", 0, 100),
+		mkFileMessage(t, "m101", 0, 101),
+		mkFileMessage(t, "m200", 1, 200),
+		mkFileMessage(t, "m201", 1, 201),
+	}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	// 分区 1 应推进到 201（两条都 OK）
+	// 分区 0 触发 retry_exhausted DLQ 后 100 也标 dispDLQResolved，然后前缀推进到 101
+	// 最终两个分区都完全推进
+	if len(dlq.records) != 1 || dlq.records[0].Reason != ReasonRetryExhausted {
+		t.Fatalf("expected 1 DLQ retry_exhausted for m100, got %+v", dlq.records)
+	}
+	// 收集每分区最后 commit offset
+	lastByPart := make(map[int]int64)
+	for _, c := range src.commits {
+		if o, ok := lastByPart[c.Partition]; !ok || c.Offset > o {
+			lastByPart[c.Partition] = c.Offset
+		}
+	}
+	if lastByPart[0] != 101 {
+		t.Fatalf("partition 0 final commit should be 101 (after m100 DLQ), got %d", lastByPart[0])
+	}
+	if lastByPart[1] != 201 {
+		t.Fatalf("partition 1 final commit should be 201, got %d", lastByPart[1])
+	}
+	// 关键：分区 1 的 commit 出现应**早于**分区 0 的 m100 达终态（独立推进）
+	// 检验方法：src.commits 里第一次出现分区 1 offset 201 的时机应在分区 0 的 101 commit 之前
+	// 因为 m101/m200/m201 都是立刻 OK，第一轮就应该 commit p1=201；p0/100 要 3 轮 retry 才终态
+	firstP1_201 := -1
+	firstP0_101 := -1
+	for i, c := range src.commits {
+		if c.Partition == 1 && c.Offset == 201 && firstP1_201 == -1 {
+			firstP1_201 = i
+		}
+		if c.Partition == 0 && c.Offset == 101 && firstP0_101 == -1 {
+			firstP0_101 = i
+		}
+	}
+	if firstP1_201 < 0 {
+		t.Fatalf("partition 1 never committed to 201: %+v", src.commits)
+	}
+	if firstP0_101 >= 0 && firstP1_201 > firstP0_101 {
+		t.Fatalf("partition 1 should commit earlier than partition 0 (independent prefix); p1_201_at=%d p0_101_at=%d", firstP1_201, firstP0_101)
+	}
+}
+
+// TestProcessBatch_DLQWriteFailsFatal DLQ 写自身失败 → 硬停返 err（Run 停 worker，保 offset 未推进）。
+func TestProcessBatch_DLQWriteFailsFatal(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{writeErr: errors.New("kafka DLQ down")}
+	ext := newMockExtractor()
+	// parse_error 触发 DLQ，DLQ 写失败 → outcomeFatal
+	p := newRetryTestProcessor(t, src, dlq, ext, 10)
+
+	batch := []fetchedMessage{{
+		Topic: "t", Partition: 0, Offset: 500,
+		Key: []byte("bad"), Value: []byte("not json"),
+	}}
+	err := p.processBatch(context.Background(), batch)
+	if err == nil {
+		t.Fatalf("expected fatal error when DLQ write fails")
+	}
+	if len(src.commits) != 0 {
+		t.Fatalf("no commit on DLQ hard-stop, got %+v", src.commits)
+	}
+}
+
+// TestProcessBatch_CtxCancelDuringBackoff 退避时 ctx cancel → 立即返 nil，无泄漏。
+func TestProcessBatch_CtxCancelDuringBackoff(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	ext.defaultRes = extractResult{err: errDocNotYet} // 一直 transient 迫使 retry
+	p := newRetryTestProcessor(t, src, dlq, ext, 100)
+	// 覆盖 sleep 为"直接返 ctx.Err()"模拟 SIGTERM
+	p.sleep = func(ctx context.Context, d time.Duration) error {
+		return context.Canceled
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消，让 sleep 首次调用就返
+	batch := []fetchedMessage{mkFileMessage(t, "x", 0, 600)}
+	err := p.processBatch(ctx, batch)
+	if !errors.Is(err, context.Canceled) {
+		// 首次 attempt 是 attempts[i]=0 → 不走 sleep 而是直接 attemptOne → err.
+		// attempts[i]++ 后第 2 轮进入 sleep → 返 ctx.Canceled → processBatch return
+		t.Fatalf("expected ctx.Canceled after backoff sleep cancel, got %v", err)
+	}
+}
+
+// TestExpJitterBackoff_MonotoneAndCap 单元测试退避函数：值在 [0, cap] 内且指数递增。
+func TestExpJitterBackoff_MonotoneAndCap(t *testing.T) {
+	base := 10 * time.Millisecond
+	maxD := 100 * time.Millisecond
+	for attempt := 1; attempt <= 20; attempt++ {
+		d := expJitterBackoff(base, maxD, attempt)
+		if d < 0 || d > maxD {
+			t.Fatalf("attempt=%d: backoff %v out of [0, %v]", attempt, d, maxD)
+		}
+	}
+	// base<=0 → 0
+	if d := expJitterBackoff(0, maxD, 5); d != 0 {
+		t.Fatalf("base=0 must return 0, got %v", d)
+	}
+}
+
+// TestSleepCtx_CtxCancelEarly ctx 取消时 sleepCtx 立即返 ctx.Err()（不等满 d）。
+func TestSleepCtx_CtxCancelEarly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := sleepCtx(ctx, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sleepCtx must return canceled err, got %v", err)
+	}
+}

--- a/internal/fileextract/service.go
+++ b/internal/fileextract/service.go
@@ -1,0 +1,67 @@
+package fileextract
+
+import (
+	"context"
+	"fmt"
+	"log"
+)
+
+// Service 把 Kafka 消费侧 + DLQ + Extractor 组装成可运行单元。
+// cmd/file-extractor/main.go 用。
+type Service struct {
+	proc      *Processor
+	source    *kafkaSource
+	dlqSink   *kafkaDLQSink
+	extractor *Extractor
+}
+
+// NewService 装配真实组件（连 Kafka + OS，起 Tika HTTP client + download client）。
+func NewService(cfg ServiceConfig) (*Service, error) {
+	source, err := newKafkaSource(KafkaSourceConfig{
+		Brokers: cfg.Brokers,
+		Topic:   cfg.Topic,
+		GroupID: cfg.GroupID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fileextract: build kafka source: %w", err)
+	}
+	dlqSink, err := newKafkaDLQSink(cfg.Brokers, cfg.DLQTopic)
+	if err != nil {
+		if cerr := source.Close(); cerr != nil {
+			log.Printf("fileextract: close source after DLQ init failure: %v", cerr)
+		}
+		return nil, err
+	}
+	extractor, err := NewExtractor(cfg)
+	if err != nil {
+		if cerr := source.Close(); cerr != nil {
+			log.Printf("fileextract: close source after extractor init failure: %v", cerr)
+		}
+		if cerr := dlqSink.Close(); cerr != nil {
+			log.Printf("fileextract: close dlq after extractor init failure: %v", cerr)
+		}
+		return nil, fmt.Errorf("fileextract: build extractor: %w", err)
+	}
+	proc := NewProcessor(source, dlqSink, extractor, cfg)
+	return &Service{
+		proc:      proc,
+		source:    source,
+		dlqSink:   dlqSink,
+		extractor: extractor,
+	}, nil
+}
+
+// Run 运行到 ctx 取消。
+func (s *Service) Run(ctx context.Context) error { return s.proc.Run(ctx) }
+
+// Close 关闭底层 Kafka client（Reader + DLQ Writer）。
+func (s *Service) Close() error {
+	var firstErr error
+	if err := s.source.Close(); err != nil {
+		firstErr = err
+	}
+	if err := s.dlqSink.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}

--- a/internal/fileextract/ssrf.go
+++ b/internal/fileextract/ssrf.go
@@ -1,0 +1,174 @@
+package fileextract
+
+// ssrf.go — URL 前置校验 + SSRF-restricted transport（v1.13 Blocker #1 fix）。
+// 双闸门防御 SSRF：
+//   1. validateURL：scheme ∈ AllowedDownloadSchemes + host ∈ AllowedDownloadHosts
+//      前置校验（无 net I/O，最快拒绝）
+//   2. newSSRFRestrictedDialer：dial 时解析 IP，拒 private/link-local/loopback/metadata
+//      （防 DNS rebinding + 白名单绕过）
+// Redirect 时 http.Client.CheckRedirect 重跑 validateURL（防跳板攻击）。
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SSRF 校验错误 sentinel，供 errors.Is 分类。
+var (
+	// errSSRFScheme：URL scheme 不在白名单（默认只允 https）。
+	errSSRFScheme = errors.New("fileextract: url scheme not allowed")
+	// errSSRFHost：URL host 不在白名单（默认只允 cdn.deepminer.com.cn）。
+	errSSRFHost = errors.New("fileextract: url host not in allowlist")
+	// errSSRFPrivateIP：dial 解析后的 IP 是 private/link-local/loopback/metadata。
+	errSSRFPrivateIP = errors.New("fileextract: resolved IP is private/link-local/metadata")
+)
+
+// defaultAllowedDownloadHosts 是 SSRF host allowlist 的默认值（cfg 未设时用）。
+// 生产 file 消息 payload.file.url 由 octo-server 上传时写入，全部来自公网 CDN
+// cdn.deepminer.com.cn。future 切内网 COS 时通过 env ALLOWED_DOWNLOAD_HOSTS 扩展。
+var defaultAllowedDownloadHosts = []string{"cdn.deepminer.com.cn"}
+
+// defaultAllowedDownloadSchemes 是 URL scheme 白名单默认值。生产 CDN 走 https。
+var defaultAllowedDownloadSchemes = []string{"https"}
+
+// validateURL 前置校验 URL（scheme + host allowlist）。无 net I/O。
+// allowedHosts / allowedSchemes 为空时用 default。
+func validateURL(rawURL string, allowedHosts, allowedSchemes []string) error {
+	if len(allowedHosts) == 0 {
+		allowedHosts = defaultAllowedDownloadHosts
+	}
+	if len(allowedSchemes) == 0 {
+		allowedSchemes = defaultAllowedDownloadSchemes
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("%w: parse: %v", errSSRFScheme, err)
+	}
+	// scheme 校验（大小写不敏感）
+	scheme := strings.ToLower(u.Scheme)
+	schemeOK := false
+	for _, s := range allowedSchemes {
+		if scheme == strings.ToLower(s) {
+			schemeOK = true
+			break
+		}
+	}
+	if !schemeOK {
+		return fmt.Errorf("%w: got %q, allowed %v", errSSRFScheme, u.Scheme, allowedSchemes)
+	}
+	// host 校验：Hostname 去 port 后比较（allowlist 里存主机名，不含 port）
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("%w: empty host in %q", errSSRFHost, rawURL)
+	}
+	hostOK := false
+	for _, h := range allowedHosts {
+		if host == strings.ToLower(strings.TrimSpace(h)) {
+			hostOK = true
+			break
+		}
+	}
+	if !hostOK {
+		return fmt.Errorf("%w: %q not in allowlist %v", errSSRFHost, host, allowedHosts)
+	}
+	return nil
+}
+
+// isBlockedIP 判 IP 是否在 SSRF 黑名单：
+//   - private (RFC 1918)：10./172.16-31./192.168.
+//   - loopback：127./ ::1
+//   - link-local：169.254./ fe80::/10（含 cloud metadata 169.254.169.254）
+//   - unspecified：0.0.0.0 / ::
+//   - CGNAT：100.64.0.0/10（Go IsPrivate 不含）
+//   - IPv6 ULA：fc00::/7（Go IsPrivate 不含）
+//
+// net.IP.IsPrivate 只覆盖 RFC 1918，本函数显式扩展覆盖所有 SSRF 目标网段。
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true // 无效 IP 拒
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() || ip.IsInterfaceLocalMulticast() || ip.IsPrivate() {
+		return true
+	}
+	// CGNAT 100.64.0.0/10
+	if v4 := ip.To4(); v4 != nil {
+		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return true
+		}
+	}
+	// IPv6 ULA fc00::/7
+	if len(ip) == net.IPv6len && (ip[0]&0xfe) == 0xfc {
+		return true
+	}
+	return false
+}
+
+// ssrfRestrictedDialer 返回一个 DialContext，dial 前把 host 解析成 IP 集合，任一 IP 在
+// SSRF 黑名单则拒绝；防 DNS rebinding（第一次解析走白名单，dial 时另一 IP 已被切走）。
+//
+// 传入的 base 是底层 net.Dialer（Timeout/KeepAlive 等），本函数只在其外面套 IP 校验层。
+// allowLoopback：**仅测试用**，httptest server 走 127.0.0.1 需打开；生产必须 false。
+func ssrfRestrictedDialer(base *net.Dialer, allowLoopback bool) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	if base == nil {
+		base = &net.Dialer{Timeout: 30 * time.Second}
+	}
+	resolver := net.DefaultResolver
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("fileextract: split host port: %w", err)
+		}
+		ips, err := resolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("fileextract: resolve %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("%w: no IPs resolved for %s", errSSRFPrivateIP, host)
+		}
+		// 任一 IP 在黑名单 → 拒绝（保守：不选剩下的白名单 IP dial，防 DNS 双重返回）
+		for _, ipAddr := range ips {
+			if isBlockedIP(ipAddr.IP) {
+				// allowLoopback + IP 只是 loopback（非其他 blocked 类）时放行
+				if allowLoopback && ipAddr.IP.IsLoopback() && !isNonLoopbackBlocked(ipAddr.IP) {
+					continue
+				}
+				return nil, fmt.Errorf("%w: %s → %s", errSSRFPrivateIP, host, ipAddr.IP)
+			}
+		}
+		// 选第一个白名单 IP 直接 dial（避免 Transport 内再解析一次触发 TOCTOU）
+		return base.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+	}
+}
+
+// isNonLoopbackBlocked 判 IP 是否是"非 loopback 的"其他 blocked 类别（private/link-local/
+// metadata 等）。用于 SSRFAllowLoopback 场景下仍要拒非 loopback 的 blocked IP。
+func isNonLoopbackBlocked(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() {
+		return false
+	}
+	return isBlockedIP(ip)
+}
+
+// ssrfCheckRedirect 是 http.Client.CheckRedirect：redirect 时重跑 validateURL，
+// 防跳板攻击（第一跳合法，redirect 到 metadata IP 或非白名单 host）。
+func ssrfCheckRedirect(allowedHosts, allowedSchemes []string) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if err := validateURL(req.URL.String(), allowedHosts, allowedSchemes); err != nil {
+			return fmt.Errorf("redirect blocked: %w", err)
+		}
+		if len(via) >= 10 { // Go 默认上限也是 10
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+}

--- a/internal/fileextract/ssrf_test.go
+++ b/internal/fileextract/ssrf_test.go
@@ -1,0 +1,231 @@
+package fileextract
+
+// ssrf_test.go — Blocker #1 修复回归 test（v1.13）。
+// 覆盖 SSRF 双闸门：
+//   闸门 1 validateURL：scheme + host allowlist 前置校验（无 net I/O）
+//   闸门 2 ssrfRestrictedDialer：dial 时解析 IP + 拒 private/link-local/metadata
+//   Redirect 时 ssrfCheckRedirect 重跑闸门 1
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateURL_HTTPSAllowedHost 白名单 host + https → pass。
+func TestValidateURL_HTTPSAllowedHost(t *testing.T) {
+	err := validateURL("https://cdn.deepminer.com.cn/x.pdf", nil, nil) // 用默认
+	if err != nil {
+		t.Fatalf("expected pass, got %v", err)
+	}
+}
+
+// TestValidateURL_HTTPRejectedByScheme http scheme 拒（默认只 https）。
+func TestValidateURL_HTTPRejectedByScheme(t *testing.T) {
+	err := validateURL("http://cdn.deepminer.com.cn/x.pdf", nil, nil)
+	if !errors.Is(err, errSSRFScheme) {
+		t.Fatalf("expected errSSRFScheme, got %v", err)
+	}
+}
+
+// TestValidateURL_UnknownHostRejected 非白名单 host 拒。
+func TestValidateURL_UnknownHostRejected(t *testing.T) {
+	err := validateURL("https://evil.example.com/x.pdf", nil, nil)
+	if !errors.Is(err, errSSRFHost) {
+		t.Fatalf("expected errSSRFHost, got %v", err)
+	}
+}
+
+// TestValidateURL_MetadataHostRejected metadata IP 作为 host 也拒（host allowlist 层拦）。
+func TestValidateURL_MetadataHostRejected(t *testing.T) {
+	err := validateURL("https://169.254.169.254/latest/meta-data/", nil, nil)
+	if !errors.Is(err, errSSRFHost) {
+		t.Fatalf("expected errSSRFHost, got %v", err)
+	}
+}
+
+// TestValidateURL_MalformedURL parse 失败 → errSSRFScheme（不 panic）。
+func TestValidateURL_MalformedURL(t *testing.T) {
+	err := validateURL("://bad-url", nil, nil)
+	if !errors.Is(err, errSSRFScheme) {
+		t.Fatalf("expected errSSRFScheme for parse error, got %v", err)
+	}
+}
+
+// TestValidateURL_EmptyHost 无 host（例如 "https:///path"）→ errSSRFHost。
+func TestValidateURL_EmptyHost(t *testing.T) {
+	err := validateURL("https:///path", nil, nil)
+	if !errors.Is(err, errSSRFHost) {
+		t.Fatalf("expected errSSRFHost for empty host, got %v", err)
+	}
+}
+
+// TestValidateURL_CustomAllowlist env 传入自定义 allowlist → 两个 host 都放行。
+func TestValidateURL_CustomAllowlist(t *testing.T) {
+	hosts := []string{"a.example.com", "b.example.com"}
+	if err := validateURL("https://a.example.com/x", hosts, nil); err != nil {
+		t.Fatalf("a.example.com should pass: %v", err)
+	}
+	if err := validateURL("https://b.example.com/x", hosts, nil); err != nil {
+		t.Fatalf("b.example.com should pass: %v", err)
+	}
+	if err := validateURL("https://c.example.com/x", hosts, nil); !errors.Is(err, errSSRFHost) {
+		t.Fatalf("c.example.com should fail: %v", err)
+	}
+}
+
+// TestIsBlockedIP_CoversAllTargets 逐个校验 isBlockedIP 覆盖所有 SSRF 目标网段。
+func TestIsBlockedIP_CoversAllTargets(t *testing.T) {
+	blocked := []string{
+		"10.0.0.1",          // RFC 1918
+		"172.16.0.1",        // RFC 1918
+		"192.168.1.1",       // RFC 1918
+		"127.0.0.1",         // loopback
+		"169.254.169.254",   // cloud metadata (link-local)
+		"169.254.1.1",       // link-local
+		"0.0.0.0",           // unspecified
+		"100.64.0.1",        // CGNAT
+		"100.127.255.255",   // CGNAT 上界
+		"::1",               // IPv6 loopback
+		"fe80::1",           // IPv6 link-local
+		"fc00::1",           // IPv6 ULA
+		"fd12:3456:789a::1", // IPv6 ULA
+		"::",                // IPv6 unspecified
+	}
+	for _, s := range blocked {
+		ip := net.ParseIP(s)
+		if !isBlockedIP(ip) {
+			t.Errorf("expected %s to be blocked", s)
+		}
+	}
+	allowed := []string{
+		"1.1.1.1",              // public
+		"8.8.8.8",              // public
+		"2606:4700:4700::1111", // Cloudflare IPv6
+	}
+	for _, s := range allowed {
+		ip := net.ParseIP(s)
+		if isBlockedIP(ip) {
+			t.Errorf("expected %s to NOT be blocked", s)
+		}
+	}
+	// nil IP → 视为 blocked（防御性）
+	if !isBlockedIP(nil) {
+		t.Errorf("nil IP must be blocked")
+	}
+}
+
+// TestSSRFRestrictedDialer_PrivateIPBlocked mock resolver 让 host 解析到 private IP → 拒。
+// 由于 real DNS 依赖测试环境，本 test 用一个已知会解析到公网的域名 + 断言 dialer 行为
+// 走公网路径 —— 无法直接注入 mock resolver，故用 direct-IP address 触发校验。
+func TestSSRFRestrictedDialer_DirectPrivateIPBlocked(t *testing.T) {
+	dial := ssrfRestrictedDialer(&net.Dialer{Timeout: time.Second}, false)
+	// 直接给一个 private IP（DNS 解析步骤会返 [10.0.0.1] 因为已经是 IP literal）
+	_, err := dial(context.Background(), "tcp", "10.0.0.1:80")
+	if !errors.Is(err, errSSRFPrivateIP) {
+		t.Fatalf("expected errSSRFPrivateIP for 10.0.0.1, got %v", err)
+	}
+}
+
+// TestSSRFRestrictedDialer_MetadataIPBlocked cloud metadata IP 拒（关键 attack vector）。
+func TestSSRFRestrictedDialer_MetadataIPBlocked(t *testing.T) {
+	dial := ssrfRestrictedDialer(&net.Dialer{Timeout: time.Second}, false)
+	_, err := dial(context.Background(), "tcp", "169.254.169.254:80")
+	if !errors.Is(err, errSSRFPrivateIP) {
+		t.Fatalf("expected errSSRFPrivateIP for cloud metadata, got %v", err)
+	}
+}
+
+// TestSSRFRestrictedDialer_LoopbackBypassWhenAllowed allowLoopback=true 时放行 127.0.0.1
+// （测试专用），但仍拒 10.x/169.254.x（非 loopback 的其他 blocked 类别）。
+func TestSSRFRestrictedDialer_LoopbackBypassWhenAllowed(t *testing.T) {
+	dial := ssrfRestrictedDialer(&net.Dialer{Timeout: time.Second}, true)
+	// 127.0.0.1 应被允许（会真实 dial，因无监听会返 connection refused / no listener 而非 errSSRFPrivateIP）
+	_, err := dial(context.Background(), "tcp", "127.0.0.1:1")
+	if err != nil && errors.Is(err, errSSRFPrivateIP) {
+		t.Fatalf("loopback bypass expected: 127.0.0.1 must pass SSRF, got %v", err)
+	}
+	// 10.0.0.1 应仍被拒（loopback bypass 不放行其他 private）
+	_, err = dial(context.Background(), "tcp", "10.0.0.1:80")
+	if !errors.Is(err, errSSRFPrivateIP) {
+		t.Fatalf("loopback bypass must NOT allow 10.0.0.1, got %v", err)
+	}
+	// 169.254.169.254 metadata 也应仍被拒
+	_, err = dial(context.Background(), "tcp", "169.254.169.254:80")
+	if !errors.Is(err, errSSRFPrivateIP) {
+		t.Fatalf("loopback bypass must NOT allow metadata IP, got %v", err)
+	}
+}
+
+// TestFetch_SSRFPrecheckBlocksMalformedURL Fetch 入口 pre-check 拦 malformed URL，
+// 不重试（scheme/host 不变重试无意义）。
+func TestFetch_SSRFPrecheckBlocksMalformedURL(t *testing.T) {
+	dc := newDownloadClient(ServiceConfig{
+		DownloadTimeout: 100 * time.Millisecond,
+		HTTPRetries:     3,
+		MaxFileSize:     1024,
+	})
+	_, _, err := dc.Fetch(context.Background(), "http://cdn.deepminer.com.cn/x") // http 被默认 scheme 拒
+	if !errors.Is(err, errDownloadFailed) {
+		t.Fatalf("expected errDownloadFailed wrapping SSRF, got %v", err)
+	}
+}
+
+// TestFetch_SSRFDialerBlocksMetadataViaURL 通过 URL 传 metadata IP → dialer 层拒。
+// 前置：scheme=https + host=169.254.169.254（要过 validateURL）。默认 hosts 不含
+// metadata IP，所以先 pre-check 拒；本 test 通过给 allowlist 加 metadata host 直接绕过闸门 1
+// 触发闸门 2 —— 校验 dialer 层的独立拒绝能力。
+func TestFetch_SSRFDialerBlocksMetadataViaURL(t *testing.T) {
+	dc := newDownloadClient(ServiceConfig{
+		DownloadTimeout:        100 * time.Millisecond,
+		HTTPRetries:            0, // 不重试加速
+		MaxFileSize:            1024,
+		AllowedDownloadHosts:   []string{"169.254.169.254"}, // 故意放行 host，让闸门 2 拦
+		AllowedDownloadSchemes: []string{"http", "https"},
+	})
+	_, _, err := dc.Fetch(context.Background(), "http://169.254.169.254/latest/meta-data/")
+	if !errors.Is(err, errDownloadFailed) {
+		t.Fatalf("expected errDownloadFailed wrapping SSRF dialer block, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "private/link-local/metadata") {
+		t.Fatalf("expected dialer SSRF error mentioning IP block, got %v", err)
+	}
+}
+
+// TestSSRFCheckRedirect_BlocksNonWhitelistedRedirect redirect 到非白名单 host 时拒。
+// 用 httptest 起两个 server：srv1 返 302 → srv2；srv2 不在白名单 → CheckRedirect 拒。
+func TestSSRFCheckRedirect_BlocksNonWhitelistedRedirect(t *testing.T) {
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("should not reach")) //nolint:errcheck // handler write; test verifies redirect is blocked
+	}))
+	defer srv2.Close()
+
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// redirect 到 srv2（http://127.0.0.1:another_port/）—— 假设 allowlist 只放行
+		// specific srv1 host+port 会复杂；简化：只放行 "127.0.0.1" host 但校验 scheme
+		http.Redirect(w, r, "https://evil.example.com/target", http.StatusFound)
+	}))
+	defer srv1.Close()
+
+	dc := newDownloadClient(ServiceConfig{
+		DownloadTimeout:        500 * time.Millisecond,
+		HTTPRetries:            0,
+		MaxFileSize:            1024,
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	})
+	_, _, err := dc.Fetch(context.Background(), srv1.URL+"/x")
+	if err == nil {
+		t.Fatalf("expected redirect to be blocked (evil.example.com not in allowlist)")
+	}
+	// redirect 拒会走 http.Client.Do 返 err；被 tryFetch 包 err
+	if !strings.Contains(err.Error(), "redirect blocked") && !strings.Contains(err.Error(), "url host") {
+		t.Fatalf("expected redirect-related SSRF error, got %v", err)
+	}
+}

--- a/internal/fileextract/tika.go
+++ b/internal/fileextract/tika.go
@@ -1,0 +1,225 @@
+package fileextract
+
+// tika.go — Tika Server HTTP client（PUT /tika + Accept: text/plain）。
+// Tika 官方 docker `apache/tika:3.3.0.0` minimal 镜像 (165MB 压缩) 起服务监听 9998。
+//
+// 错误分类（v2 §6.1 DLQ reason 对齐）：
+//   - HTTP 200 + non-empty body → (content, truncated, nil)
+//   - HTTP 200 + empty body     → ("", false, nil)      → 上层判 empty_extract
+//   - HTTP 500 body 含 "EncryptedDocumentException" → errEncrypted → DLQ encrypted
+//   - HTTP 500 其他             → errExtractGeneric → DLQ extract_error
+//   - HTTP 422 (unsupported)   → errExtractGeneric（Tika 明确不支持）
+//   - ctx.DeadlineExceeded     → errExtractTimeout → DLQ extract_timeout
+//
+// 长文本截断：抽出 > MaxContentBytes 时截取 utf-8 边界安全的前缀 + truncated=true。
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// tika 错误哨兵（sentinel），上层用 errors.Is 分类。
+var (
+	errEncrypted      = errors.New("fileextract: tika encrypted document")
+	errExtractTimeout = errors.New("fileextract: tika extract timeout")
+	errExtractGeneric = errors.New("fileextract: tika extract error")
+)
+
+// tikaClient 调 Tika Server。
+type tikaClient struct {
+	hc              *http.Client
+	baseURL         string // e.g. "http://localhost:9998"
+	timeout         time.Duration
+	maxContentBytes int
+}
+
+// newTikaClient 构造。HTTP client 无 client-level Timeout（v1.13 P2-9）——
+// 老代码用 http.Client{Timeout} 与 ctx 独立，client timeout 触发时 ctx.Err() 是 nil，导致
+// 错误被误分类为 errExtractGeneric（DLQ extract_error, retry×1）而非 errExtractTimeout
+// (permanent, no retry)。改成 per-request context.WithTimeout 驱动，让 err 同时携带
+// context.DeadlineExceeded 语义。
+func newTikaClient(cfg ServiceConfig) *tikaClient {
+	max := cfg.MaxContentBytes
+	if max <= 0 {
+		max = 256 * 1024
+	}
+	url := cfg.TikaURL
+	if url == "" {
+		url = "http://localhost:9998"
+	}
+	return &tikaClient{
+		hc:              &http.Client{}, // v1.13 P2-9：不用 client-level Timeout
+		baseURL:         url,
+		timeout:         cfg.ExtractTimeout,
+		maxContentBytes: max,
+	}
+}
+
+// Extract 上传 file bytes 到 Tika（PUT /tika），返回抽出的纯文本。
+// filename 用作 sanitize 后的 Content-Disposition hint；extension 用于反查 MIME 设 Content-Type。
+//
+// 🔴 生产 blocker：Tika 3.3.0 收到 PUT /tika 请求若不带 Content-Type，会 fallback 到
+// EmptyParser 返 0 字节 body（HTTP 200 + Content-Length: 0），Content-Disposition 里的
+// filename 后缀 **不参与** Tika parser 选择。因此必须显式送 Content-Type。
+// Max 2026-07-02 部 Tika 到 dmwork-test 实测复现。
+//
+// filename 中的 CR/LF/双引号/控制字符会被剔除，避免 HTTP header 注入（filename 源头是
+// octo-server 上传时用户可控字段，未 sanitize 会破坏 Content-Disposition 头或走 CRLF smuggling）。
+// extension 为空时 fallback filename 后缀；仍为空 → application/octet-stream 让 Tika auto-detect。
+func (t *tikaClient) Extract(ctx context.Context, fileBytes []byte, filename, extension string) (string, bool, error) {
+	// v1.13 P2-9：per-request timeout by ctx，classifyOSErr → errExtractTimeout 精确。
+	// 用 parentCtx 判"是否 parent cancel"（区分调用方主动关停 vs 本次 Tika 超时）。
+	parentCtx := ctx
+	reqCtx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPut, t.baseURL+"/tika", bytes.NewReader(fileBytes))
+	if err != nil {
+		return "", false, err
+	}
+	req.Header.Set("Accept", "text/plain")
+	ext := extension
+	if ext == "" {
+		ext = filepath.Ext(filename)
+	}
+	req.Header.Set("Content-Type", mimeTypeForExtension(ext))
+	if safeName := sanitizeFilename(filename); safeName != "" {
+		// Tika 官方 header：Content-Disposition 传文件名 hint
+		req.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, safeName))
+	}
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		// P2-9：本次请求 ctx 超时 → errExtractTimeout（DLQ extract_timeout，permanent）
+		// parent ctx 取消（SIGTERM 等）→ 上抛 ctx.Err() 让 caller 优雅退出
+		if parentCtx.Err() != nil {
+			return "", false, parentCtx.Err()
+		}
+		if errors.Is(reqCtx.Err(), context.DeadlineExceeded) {
+			return "", false, errExtractTimeout
+		}
+		return "", false, fmt.Errorf("%w: %v", errExtractGeneric, err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // close-on-read: nothing to do with close err
+	// v1.13 P2-4：io.ReadAll 加 LimitReader 上限，避免 Tika 谎报 body 长度导致 OOM。
+	// 上限 = maxContentBytes+4（+4 冗余是 truncateContent 判断"是否超"用）
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, int64(t.maxContentBytes)+4))
+	if readErr != nil {
+		return "", false, fmt.Errorf("%w: read body: %v", errExtractGeneric, readErr)
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return truncateContent(string(body), t.maxContentBytes)
+	case http.StatusInternalServerError:
+		// Tika Server 5xx body 是 Java stack trace 纯文本；判 EncryptedDocumentException 字符串。
+		// v2 §7 #2：Tika 版本升级 body 格式可能变化 → 本单测锁死该字符串契约，升 Tika 主版本时同步 review。
+		if strings.Contains(string(body), "EncryptedDocumentException") {
+			return "", false, errEncrypted
+		}
+		return "", false, fmt.Errorf("%w: tika 500: %s", errExtractGeneric, snippet(body, 200))
+	case http.StatusUnprocessableEntity: // 422
+		return "", false, fmt.Errorf("%w: tika 422 unsupported media", errExtractGeneric)
+	default:
+		return "", false, fmt.Errorf("%w: tika status %d", errExtractGeneric, resp.StatusCode)
+	}
+}
+
+// sanitizeFilename 剔除 filename 中的 CR/LF/双引号/控制字符，防 HTTP header 注入。
+// 空 filename → 返 ""（caller 跳过设 Content-Disposition）。
+func sanitizeFilename(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '"' || r == '\r' || r == '\n' || r == '\\' || r < 0x20 || r == 0x7f {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// truncateContent 按 utf-8 边界截断到 maxBytes 之内，避免半个 UTF-8 字符导致后续 IK 分词失效。
+// 返回 (content, truncated, nil)。空 content 也返 (nil, false, nil) 由上层判 empty_extract。
+func truncateContent(s string, maxBytes int) (string, bool, error) {
+	if len(s) <= maxBytes {
+		return s, false, nil
+	}
+	// 从 maxBytes 位置回退到最近的 utf-8 rune 边界
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end], true, nil
+}
+
+// snippet 截 body 前 N 字节做错误 detail（避免 Tika 5xx stack trace 塞爆日志）。
+func snippet(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "..."
+}
+
+// mimeTypeForExtension 反查文件扩展名到 MIME type，用于 Tika PUT 请求的 Content-Type。
+// 覆盖 v2 §6 白名单 19 种可抽取扩展名。ext 大小写不敏感，允许带/不带 '.' 前缀。
+//
+// Fallback 策略（v2 §7 #4 "宁抽多不漏"）：未知扩展名 → application/octet-stream。
+// Tika 收到 octet-stream 会走 magic-number auto-detect（AutoDetectParser），能识别文件真实类型
+// 后走对应 parser。相比不送 Content-Type（Tika fallback 到 EmptyParser 返 0 字节），auto-detect
+// 至少给了一次机会；识别失败也是走正常的 EmptyParser → 由 caller 判 empty_extract 走 DLQ。
+func mimeTypeForExtension(ext string) string {
+	e := strings.ToLower(strings.TrimSpace(ext))
+	if e == "" {
+		return "application/octet-stream"
+	}
+	if !strings.HasPrefix(e, ".") {
+		e = "." + e
+	}
+	switch e {
+	case ".pdf":
+		return "application/pdf"
+	case ".doc":
+		return "application/msword"
+	case ".docx":
+		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case ".xls":
+		return "application/vnd.ms-excel"
+	case ".xlsx":
+		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	case ".ppt":
+		return "application/vnd.ms-powerpoint"
+	case ".pptx":
+		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case ".txt":
+		return "text/plain"
+	case ".csv":
+		return "text/csv"
+	case ".rtf":
+		return "application/rtf"
+	case ".odt":
+		return "application/vnd.oasis.opendocument.text"
+	case ".ods":
+		return "application/vnd.oasis.opendocument.spreadsheet"
+	case ".md":
+		return "text/markdown"
+	case ".html", ".htm":
+		return "text/html"
+	case ".json":
+		return "application/json"
+	case ".xml":
+		return "application/xml"
+	case ".yaml", ".yml":
+		return "application/x-yaml"
+	default:
+		return "application/octet-stream"
+	}
+}

--- a/internal/fileextract/tombstone_whitelist_test.go
+++ b/internal/fileextract/tombstone_whitelist_test.go
@@ -1,0 +1,238 @@
+package fileextract
+
+// tombstone_whitelist_test.go — Round-4 Should-Fix (lml2468 review) 回归：
+// tombstone 只对 permanent 类 DLQ reason 写；transient 类 (download_failed / extract_timeout)
+// 不写，保留 backfill recovery safety net。
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestTombstoneReasons_Whitelist 契约锁：tombstoneReasons 集合必须包含全部**文件本身永久不可抽取**
+// 类 reason，且**不含**任何 transient 类 reason。future 加新 DLQ reason 时必须审慎归类。
+func TestTombstoneReasons_Whitelist(t *testing.T) {
+	// permanent 类必须在白名单内
+	permanent := []string{
+		ReasonBlacklistExt,
+		ReasonOversize,
+		ReasonEncrypted,
+		ReasonEmptyExtract,
+		ReasonExtractError,
+	}
+	for _, r := range permanent {
+		if !isTombstoneReason(r) {
+			t.Errorf("reason %q must be in tombstoneReasons whitelist (permanent DLQ), got not tombstoned", r)
+		}
+	}
+	// transient 类必须**不在**白名单内
+	transient := []string{
+		ReasonDownloadFailed, // CDN 5xx / 网络抖动
+		ReasonExtractTimeout, // Tika 临时资源紧张
+	}
+	for _, r := range transient {
+		if isTombstoneReason(r) {
+			t.Errorf("reason %q must NOT be in tombstoneReasons (transient can retry via backfill), got tombstoned", r)
+		}
+	}
+	// consumer.processBatch 直接写 DLQ 的 reason (不经 extractor.defer) 白名单里也不能有
+	// (避免误导；这些 reason extractor 层永远不返，不会触发 defer)
+	notReturnedByExtractor := []string{
+		ReasonParseError,     // Kafka unmarshal — doc 不存在 OS 也无需 tombstone
+		ReasonRetryExhausted, // in-place retry 耗尽 — transient 保守，让 backfill 重试
+		ReasonOSPermanent,    // OS 4xx — 编程 bug；tombstone 由 consumer 层单独处理（audit-flagged）
+	}
+	for _, r := range notReturnedByExtractor {
+		if isTombstoneReason(r) {
+			t.Errorf("reason %q is not produced by extractor.ExtractAndWrite; should not appear in whitelist to avoid confusion, got tombstoned", r)
+		}
+	}
+	// 未知 reason 不 tombstone (保守默认)
+	if isTombstoneReason("") {
+		t.Error("empty reason must not be tombstoned")
+	}
+	if isTombstoneReason("some_new_unknown_reason") {
+		t.Error("unknown reason must default to NOT tombstoned (conservative)")
+	}
+}
+
+// TestExtractor_TransientDLQ_NoTombstone Round-4 Should-Fix 核心回归：download_failed
+// (transient CDN 5xx) 走 permanent DLQ 分支时，**不写** tombstone，保留下次 backfill 兜底能力。
+func TestExtractor_TransientDLQ_NoTombstone_DownloadFailed(t *testing.T) {
+	var tombstoneCalls atomic.Int32
+	var tombstoneBody string
+	// mock OS：任何 update 请求都记录（如果 defer 写 tombstone 会被这里捕获）
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tombstoneCalls.Add(1)
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Errorf("read body: %v", rerr)
+		}
+		tombstoneBody = string(b)
+		_, _ = w.Write([]byte(`{"result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	// mock CDN：一直 5xx → extractor 走 download_failed 分支
+	cdnSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer cdnSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{osSrv.URL},
+		ESIndex:                "octo-message",
+		DownloadTimeout:        200 * time.Millisecond,
+		ExtractTimeout:         200 * time.Millisecond,
+		MaxFileSize:            1024,
+		MaxContentBytes:        1024,
+		HTTPRetries:            1, // 加速 test：只 2 次总尝试
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	fp := &filePayload{URL: cdnSrv.URL + "/x.pdf", Name: "x.pdf", Extension: ".pdf"}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if err != nil {
+		t.Fatalf("ExtractAndWrite: err=%v cause=%v", err, cause)
+	}
+	if reason != ReasonDownloadFailed {
+		t.Fatalf("expected download_failed reason, got %q (cause=%v)", reason, cause)
+	}
+	// 🔴 关键断言：transient reason 不应写 tombstone
+	if tombstoneCalls.Load() != 0 {
+		t.Errorf("download_failed is transient; tombstone must NOT be written (would break backfill retry), got %d writes body=%s", tombstoneCalls.Load(), tombstoneBody)
+	}
+}
+
+// TestExtractor_TransientDLQ_NoTombstone_ExtractTimeout Round-4 Should-Fix：extract_timeout
+// (Tika 超时) 也不写 tombstone。
+func TestExtractor_TransientDLQ_NoTombstone_ExtractTimeout(t *testing.T) {
+	var tombstoneCalls atomic.Int32
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tombstoneCalls.Add(1)
+		_, _ = w.Write([]byte(`{"result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cdnSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		if _, werr := w.Write([]byte("pdf bytes")); werr != nil {
+			t.Errorf("cdn write: %v", werr)
+		}
+	}))
+	defer cdnSrv.Close()
+
+	// Tika 故意慢 → per-request timeout 触发 → errExtractTimeout → ReasonExtractTimeout
+	tikaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer tikaSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{osSrv.URL},
+		ESIndex:                "octo-message",
+		TikaURL:                tikaSrv.URL,
+		DownloadTimeout:        time.Second,
+		ExtractTimeout:         50 * time.Millisecond, // 短到必超
+		MaxFileSize:            1024,
+		MaxContentBytes:        1024,
+		HTTPRetries:            1,
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	fp := &filePayload{URL: cdnSrv.URL + "/x.pdf", Name: "x.pdf", Extension: ".pdf"}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if err != nil {
+		t.Fatalf("ExtractAndWrite: err=%v cause=%v", err, cause)
+	}
+	if reason != ReasonExtractTimeout {
+		t.Fatalf("expected extract_timeout reason, got %q (cause=%v)", reason, cause)
+	}
+	if !errors.Is(cause, errExtractTimeout) {
+		t.Errorf("cause must wrap errExtractTimeout, got %v", cause)
+	}
+	if tombstoneCalls.Load() != 0 {
+		t.Errorf("extract_timeout is transient; tombstone must NOT be written, got %d writes", tombstoneCalls.Load())
+	}
+}
+
+// TestExtractor_PermanentDLQ_WritesTombstone 交叉验证：permanent 类 (encrypted) 依然写 tombstone
+// —— 白名单没误伤 permanent 类。
+func TestExtractor_PermanentDLQ_WritesTombstone_Encrypted(t *testing.T) {
+	var tombstoneBody string
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Errorf("read body: %v", rerr)
+		}
+		tombstoneBody = string(b)
+		_, _ = w.Write([]byte(`{"result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cdnSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		if _, werr := w.Write([]byte("pdf bytes")); werr != nil {
+			t.Errorf("cdn write: %v", werr)
+		}
+	}))
+	defer cdnSrv.Close()
+
+	// Tika 返 500 + EncryptedDocumentException → errEncrypted → ReasonEncrypted (permanent)
+	tikaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		if _, werr := w.Write([]byte("org.apache.tika.exception.EncryptedDocumentException: encrypted PDF")); werr != nil {
+			t.Errorf("tika write: %v", werr)
+		}
+	}))
+	defer tikaSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{osSrv.URL},
+		ESIndex:                "octo-message",
+		TikaURL:                tikaSrv.URL,
+		DownloadTimeout:        time.Second,
+		ExtractTimeout:         time.Second,
+		MaxFileSize:            1024,
+		MaxContentBytes:        1024,
+		HTTPRetries:            1,
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	fp := &filePayload{URL: cdnSrv.URL + "/x.pdf", Name: "x.pdf", Extension: ".pdf"}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if err != nil {
+		t.Fatalf("ExtractAndWrite: err=%v cause=%v", err, cause)
+	}
+	if reason != ReasonEncrypted {
+		t.Fatalf("expected encrypted reason, got %q (cause=%v)", reason, cause)
+	}
+	if !strings.Contains(tombstoneBody, `"status":"unextractable"`) {
+		t.Errorf("encrypted (permanent) must write tombstone, got body: %s", tombstoneBody)
+	}
+	if !strings.Contains(tombstoneBody, `"reason":"encrypted"`) {
+		t.Errorf("tombstone must carry reason=encrypted, got: %s", tombstoneBody)
+	}
+}


### PR DESCRIPTION
## What

End-to-end file content search for octo message payload.type=8 (files).

Extract text from PDF/Office/etc files via Apache Tika, index into OpenSearch
under payload.file.content (text, ik_max_word analyzer), and expose through
backfill (one-shot Job for existing files) and the message-consumer pipeline
(new file-extractor service for incoming messages).

## Why

Product requirement (PRD `Octo搜索需求文档 v1.0`): users need to search
for keywords within file contents (not just filenames) and locate the
containing message. Current search only indexes message text; file bodies
are opaque.

## Design

See `docs/file-content-indexing-feasibility.md` and
`docs/file-content-indexing-implementation.md` for full technical design
(architecture, tool selection, DLQ topology, safety controls).

## Testing

- Unit + integration tests for all new packages (fileextract, filebackfill,
  esindex partial-update)
- Race-tested (`go test -race`)
- Mapping-compat startup fail-closed gate: file-extractor refuses to start
  if live OS mapping lacks required fields or contains forbidden
  `_source.excludes` over preserved paths
- Post-merge acceptance: manual real-OS validation in test env before prod
  rollout (validates scripted_upsert preserve, tombstone marker + backfill
  exclude, deployment-order gate)

## Deployment

**Requires one-time admin action before rolling pods**:

```
PUT /<current-backing-index>/_mapping
{
  "_source": { "excludes": [] },
  "properties": {
    "payload": { "properties": { "file": { "properties": {
      "contentMeta": { "properties": {
        "status": { "type": "keyword", "ignore_above": 32 },
        "reason": { "type": "keyword", "ignore_above": 64 }
      }}
    }}}}
  }
}
```

Then rollout es-indexer + file-extractor Deployments. If mapping PUT is
skipped, pods will CrashLoop on startup (mapping-compat gate) with a
message pointing to this runbook.

Full runbook + tombstone semantics in `internal/esindex/mapping/README.md`.

## Supersedes

Consolidation of #46 (25+ reviews / 5 review rounds). Prior discussion
remains as reference. All previously-flagged blocking findings are addressed
in this consolidated commit:

- SSRF protection on file downloader
- `_source.excludes` compatibility with `scripted_upsert` preserve
- 409 version-conflict classified transient (matches sibling writer)
- Backfill tombstone marker prevents unbounded DLQ growth on rerun
- Tombstone whitelist distinguishes permanent-fail vs transient-nature reasons
- mapping-compat startup gate prevents deployment-order errors

Deferred to follow-up PRs (tracked in workspace):
- OSPermanent alerter (observability, low severity)
- CDN 404 split from download_failed (backfill efficiency, bounded impact)
- sourceExcludesContains wildcard defense-in-depth

/cc @yujiawei @mochashanyao @Jerry-Xin @OctoBoooot
