### PR TITLE
build(dockerfile): add file-extractor + file-content-backfill build targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,23 @@ RUN go mod download
 
 COPY . .
 # Build all pipeline binaries:
-#   es-indexer        — the long-running Kafka→OpenSearch consumer (default entrypoint).
-#   searchetl-producer — the long-running MySQL→Kafka polling ETL producer (realtime write side).
-#   backfill          — one-shot historical loader (MySQL shards → OpenSearch, bypass Kafka).
-#   reconcile         — MySQL-vs-OpenSearch count/sample correctness gate (exit 2 on mismatch).
-# backfill + reconcile are on-demand ops tools the deployment upgrade flow runs as
-# one-shot jobs; shipping them in the same image means operators do not need a
-# separate Go toolchain or a second image to turn search on. searchetl-producer is
-# a separate long-running worker (opt-in via PRODUCER_ENABLED) selected by overriding
-# the image entrypoint/command in its own Deployment.
+#   es-indexer            — the long-running Kafka→OpenSearch consumer (default entrypoint).
+#   searchetl-producer    — the long-running MySQL→Kafka polling ETL producer (realtime write side).
+#   backfill              — one-shot historical loader (MySQL shards → OpenSearch, bypass Kafka).
+#   reconcile             — MySQL-vs-OpenSearch count/sample correctness gate (exit 2 on mismatch).
+#   file-extractor        — the long-running Kafka→Tika→OpenSearch file content extractor (payload.type=8 → partial _update).
+#   file-content-backfill — one-shot backfill for file-content extraction over historical payload.type=8 docs missing content.
+# backfill + reconcile + file-content-backfill are on-demand ops tools the deployment
+# upgrade flow runs as one-shot jobs; shipping them in the same image means operators
+# do not need a separate Go toolchain or a second image. searchetl-producer and
+# file-extractor are separate long-running workers selected by overriding the image
+# entrypoint/command in their own Deployments.
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /es-indexer ./cmd/es-indexer \
   && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /searchetl-producer ./cmd/searchetl-producer \
   && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /backfill ./cmd/backfill \
-  && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /reconcile ./cmd/reconcile
+  && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /reconcile ./cmd/reconcile \
+  && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /file-extractor ./cmd/file-extractor \
+  && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /file-content-backfill ./cmd/file-content-backfill
 
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates tzdata wget \
@@ -31,6 +35,8 @@ COPY --from=builder /es-indexer /usr/local/bin/es-indexer
 COPY --from=builder /searchetl-producer /usr/local/bin/searchetl-producer
 COPY --from=builder /backfill /usr/local/bin/backfill
 COPY --from=builder /reconcile /usr/local/bin/reconcile
+COPY --from=builder /file-extractor /usr/local/bin/file-extractor
+COPY --from=builder /file-content-backfill /usr/local/bin/file-content-backfill
 
 USER appuser
 


### PR DESCRIPTION
## Summary

PR #47（feat: file content indexing）引入了 `cmd/file-extractor` 和 `cmd/file-content-backfill` 两个新 binary，但 Dockerfile 漏改 —— 对应的 `go build` target 和 alpine stage 的 `COPY` 都没追加。本 PR 补齐 Dockerfile，让 CI build 出的 image 内含全部 6 个 binary。

## Background

PR #47 已 merged @ 2026-07-08 14:41 GMT+8（merge commit `6e16af2`），Lucy 已 sync 到 codex，codex CI 已 build 出新 image —— 但这一版 image 里只有老 4 个 binary（`es-indexer` / `searchetl-producer` / `backfill` / `reconcile`），**不含 `file-extractor` 和 `file-content-backfill`**。

如果不先修 Dockerfile 就把后续 codex PR-B（`manifests/deploy.yaml` 加 `file-extractor` Deploy）apply 到集群，file-extractor Pod 会 CrashLoop：

```
exec: "/usr/local/bin/file-extractor": stat /usr/local/bin/file-extractor: no such file or directory
```

**本 PR merge → Lucy 再 sync codex → codex CI 再 build 一版 image → 新 image 含全 6 个 binary → 后续 codex PR-B 才能安全 apply。**

## Diff

`Dockerfile` 三处改动，全部延续现有 pattern：

1. **build 注释段**：新增 2 行说明 `file-extractor` / `file-content-backfill` 的角色 + 冒号对齐（4 空格 → 12 空格），并把 backfill/reconcile/file-content-backfill 归入「on-demand ops tools」段，long-running workers 段追加 `file-extractor`
2. **RUN 链**：追加 2 行 `go build`，与现有 4 个 binary 同 flags 一致（`CGO_ENABLED=0 -trimpath -ldflags="-s -w"`）
3. **alpine stage COPY**：追加 2 行 `COPY --from=builder`，把新 binary 装到 `/usr/local/bin/`

不改：`ENTRYPOINT`（保持 `es-indexer` 默认）、`EXPOSE`、`USER`、Go / alpine base image 版本。

## Test plan

- [x] 本地 `docker build .` 通过（golang:1.25-alpine builder，alpine:3.19 final），42s
- [x] `docker run --rm --entrypoint sh <image> -c 'ls /usr/local/bin/'` 验证 6 个 binary 全在：
  - `backfill` (6.5 MB)
  - `es-indexer` (10.4 MB)
  - `file-content-backfill` (7.2 MB)
  - `file-extractor` (7.7 MB)
  - `reconcile` (6.4 MB)
  - `searchetl-producer` (9.9 MB)
- [ ] GitHub Actions Test/Build stage 全绿
- [ ] Merge 后：Lucy sync codex → codex CI package stage 再 build 一版 image → 手动确认新 image 内含 6 个 binary

## Non-goals

- **不含** `manifests/deploy.yaml` 改动（新增 `file-extractor` Deploy / Tika Service / `file-content-backfill` Job）—— 归属 codex 仓，后续独立 codex PR-B 处理
- **不含** `manifests/configmap.example.yaml` 或环境 configmap 改动 —— 同上，codex PR-B
- **不改** `ENTRYPOINT` —— `file-extractor` 是独立 Deploy，通过 Deploy 内 `command` override（同 `searchetl-producer` pattern）

## Refs

- 前置 PR：#47（feat: file content indexing）
- 实施任务书：`docs/file-content-indexing-implementation.md`