### PR TITLE
fix(file-extractor): support ES_TLS_INSECURE_SKIP_VERIFY env

### DIFF
--- a/cmd/file-content-backfill/main.go
+++ b/cmd/file-content-backfill/main.go
@@ -52,6 +52,7 @@ func run() error {
 		esIndex     = flag.String("es-index", envOr("BACKFILL_ES_INDEX", "octo-message"), "OpenSearch index / alias")
 		esUser      = flag.String("es-user", os.Getenv("BACKFILL_ES_USER"), "OS username (optional)")
 		esPass      = flag.String("es-pass", os.Getenv("BACKFILL_ES_PASS"), "OS password (optional)")
+		esTLSSkip   = flag.Bool("es-tls-insecure", envBool("BACKFILL_ES_TLS_INSECURE_SKIP_VERIFY"), "skip TLS cert verification for HTTPS OpenSearch (self-signed); default off")
 		tikaURL     = flag.String("tika-url", envOr("BACKFILL_TIKA_URL", "http://tika-service:9998"), "Tika Server URL")
 		rate        = flag.Float64("rate", envFloat("BACKFILL_RATE", 50), "extraction rate limit (docs/s; <=0 = unlimited)")
 		scrollSize  = flag.Int("scroll-size", envInt("BACKFILL_SCROLL_SIZE", 500), "OS scroll batch size")
@@ -71,20 +72,21 @@ func run() error {
 	}
 
 	cfg := fbf.Config{
-		ESAddresses:     splitCSV(*esAddrs),
-		ESIndex:         *esIndex,
-		ESUsername:      *esUser,
-		ESPassword:      *esPass,
-		TikaURL:         *tikaURL,
-		DownloadTimeout: time.Duration(*downloadMS) * time.Millisecond,
-		ExtractTimeout:  time.Duration(*extractMS) * time.Millisecond,
-		MaxFileSize:     *maxSize,
-		MaxContentBytes: *maxContent,
-		HTTPRetries:     *httpRetries,
-		Rate:            *rate,
-		ScrollSize:      *scrollSize,
-		ScrollTTL:       *scrollTTL,
-		Timeout:         *timeout,
+		ESAddresses:             splitCSV(*esAddrs),
+		ESIndex:                 *esIndex,
+		ESUsername:              *esUser,
+		ESPassword:              *esPass,
+		ESTLSInsecureSkipVerify: *esTLSSkip,
+		TikaURL:                 *tikaURL,
+		DownloadTimeout:         time.Duration(*downloadMS) * time.Millisecond,
+		ExtractTimeout:          time.Duration(*extractMS) * time.Millisecond,
+		MaxFileSize:             *maxSize,
+		MaxContentBytes:         *maxContent,
+		HTTPRetries:             *httpRetries,
+		Rate:                    *rate,
+		ScrollSize:              *scrollSize,
+		ScrollTTL:               *scrollTTL,
+		Timeout:                 *timeout,
 	}
 
 	runner, err := fbf.NewRunner(cfg)
@@ -123,6 +125,12 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool 解析布尔型 env（fail-closed：仅 "true"/"TRUE" 等 → true，其余一律 false）。
+// 与 cmd/backfill / cmd/reconcile 同实现，方便运维在 K8s Job env 里开 self-signed TLS 跳过。
+func envBool(k string) bool {
+	return strings.EqualFold(os.Getenv(k), "true")
 }
 
 func envInt(key string, def int) int {

--- a/cmd/file-extractor/main.go
+++ b/cmd/file-extractor/main.go
@@ -24,6 +24,7 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -78,12 +79,19 @@ func run(ctx context.Context) error {
 
 // assertLiveMapping 用 esindex.Writer 复用 mapping-compat 校验（P2-10）。
 // 写完立即 Close 释放 client（本调用只做健康检查，主流程另建自己的 osWriter）。
+// 与主 osWriter 同规则：cfg.ESTLSInsecureSkipVerify=true 时注入 InsecureSkipVerifyTransport，
+// 否则健康检查在自签证书 OS 上会先于主流程失败。
 func assertLiveMapping(ctx context.Context, cfg fileextract.ServiceConfig) error {
+	var transport http.RoundTripper
+	if cfg.ESTLSInsecureSkipVerify {
+		transport = esindex.InsecureSkipVerifyTransport()
+	}
 	w, err := esindex.NewWriter(esindex.Config{
 		Addresses: cfg.ESAddresses,
 		Index:     cfg.ESIndex,
 		Username:  cfg.ESUsername,
 		Password:  cfg.ESPassword,
+		Transport: transport,
 	})
 	if err != nil {
 		return err
@@ -100,22 +108,23 @@ func assertLiveMapping(ctx context.Context, cfg fileextract.ServiceConfig) error
 // 开通条件：FILE_EXTRACTOR_ENABLED (可解析为 true) 且 brokers / ES 地址均已配置。
 func loadConfig() (fileextract.ServiceConfig, bool) {
 	cfg := fileextract.ServiceConfig{
-		Brokers:             splitCSV(os.Getenv("KAFKA_BROKERS")),
-		Topic:               envOr("KAFKA_TOPIC", "octo.message.v1"),
-		DLQTopic:            envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.file-extract.dlq"),
-		GroupID:             envOr("KAFKA_GROUP_ID", "file-extractor"),
-		BatchSize:           envInt("EXTRACTOR_BATCH_SIZE", 50),
-		ESAddresses:         splitCSV(os.Getenv("ES_ADDRESSES")),
-		ESIndex:             envOr("ES_INDEX", "octo-message"),
-		ESUsername:          os.Getenv("ES_USERNAME"),
-		ESPassword:          os.Getenv("ES_PASSWORD"),
-		TikaURL:             envOr("TIKA_URL", "http://localhost:9998"),
-		DownloadTimeout:     time.Duration(envInt("EXTRACTOR_DOWNLOAD_TIMEOUT_MS", 30000)) * time.Millisecond,
-		ExtractTimeout:      time.Duration(envInt("EXTRACTOR_EXTRACT_TIMEOUT_MS", 30000)) * time.Millisecond,
-		MaxFileSize:         int64(envInt("EXTRACTOR_MAX_FILE_SIZE_BYTES", 20*1024*1024)),
-		MaxContentBytes:     envInt("EXTRACTOR_MAX_CONTENT_BYTES", 256*1024),
-		HTTPRetries:         envInt("EXTRACTOR_HTTP_RETRIES", 3),
-		ExtractStartupDelay: time.Duration(envInt("EXTRACT_STARTUP_DELAY_SECONDS", 5)) * time.Second,
+		Brokers:                 splitCSV(os.Getenv("KAFKA_BROKERS")),
+		Topic:                   envOr("KAFKA_TOPIC", "octo.message.v1"),
+		DLQTopic:                envOr("KAFKA_DLQ_TOPIC", "octo.message.v1.file-extract.dlq"),
+		GroupID:                 envOr("KAFKA_GROUP_ID", "file-extractor"),
+		BatchSize:               envInt("EXTRACTOR_BATCH_SIZE", 50),
+		ESAddresses:             splitCSV(os.Getenv("ES_ADDRESSES")),
+		ESIndex:                 envOr("ES_INDEX", "octo-message"),
+		ESUsername:              os.Getenv("ES_USERNAME"),
+		ESPassword:              os.Getenv("ES_PASSWORD"),
+		ESTLSInsecureSkipVerify: strings.EqualFold(os.Getenv("ES_TLS_INSECURE_SKIP_VERIFY"), "true"),
+		TikaURL:                 envOr("TIKA_URL", "http://localhost:9998"),
+		DownloadTimeout:         time.Duration(envInt("EXTRACTOR_DOWNLOAD_TIMEOUT_MS", 30000)) * time.Millisecond,
+		ExtractTimeout:          time.Duration(envInt("EXTRACTOR_EXTRACT_TIMEOUT_MS", 30000)) * time.Millisecond,
+		MaxFileSize:             int64(envInt("EXTRACTOR_MAX_FILE_SIZE_BYTES", 20*1024*1024)),
+		MaxContentBytes:         envInt("EXTRACTOR_MAX_CONTENT_BYTES", 256*1024),
+		HTTPRetries:             envInt("EXTRACTOR_HTTP_RETRIES", 3),
+		ExtractStartupDelay:     time.Duration(envInt("EXTRACT_STARTUP_DELAY_SECONDS", 5)) * time.Second,
 
 		// v1.13 Blocker #2 fix — in-place bounded retry 参数。生产运维按 OS SLA 与业务
 		// 延迟容忍度调整；未设 env 时走 fileextract 包内 default（10 / 1s / 60s）。

--- a/internal/filebackfill/config.go
+++ b/internal/filebackfill/config.go
@@ -27,6 +27,10 @@ type Config struct {
 	ESIndex     string // e.g. "octo-message" (alias 或 backing index)
 	ESUsername  string
 	ESPassword  string
+	// ESTLSInsecureSkipVerify 为 true 时跳过 OpenSearch HTTPS 证书校验（自签证书场景）。
+	// 默认 false。与 es-indexer / file-extractor / reconcile 同开关语义（共用
+	// esindex.InsecureSkipVerifyTransport helper）。
+	ESTLSInsecureSkipVerify bool
 
 	// TikaURL / DownloadTimeout / ExtractTimeout / MaxFileSize / MaxContentBytes / HTTPRetries
 	// 转发给 fileextract.NewExtractor 复用同一套抽取核心。
@@ -50,16 +54,17 @@ type Config struct {
 // ToExtractorConfig 转换成 fileextract.ServiceConfig（extractor 只用其中一部分字段）。
 func (c Config) ToExtractorConfig() fileextract.ServiceConfig {
 	return fileextract.ServiceConfig{
-		ESAddresses:     c.ESAddresses,
-		ESIndex:         c.ESIndex,
-		ESUsername:      c.ESUsername,
-		ESPassword:      c.ESPassword,
-		TikaURL:         c.TikaURL,
-		DownloadTimeout: c.DownloadTimeout,
-		ExtractTimeout:  c.ExtractTimeout,
-		MaxFileSize:     c.MaxFileSize,
-		MaxContentBytes: c.MaxContentBytes,
-		HTTPRetries:     c.HTTPRetries,
+		ESAddresses:             c.ESAddresses,
+		ESIndex:                 c.ESIndex,
+		ESUsername:              c.ESUsername,
+		ESPassword:              c.ESPassword,
+		ESTLSInsecureSkipVerify: c.ESTLSInsecureSkipVerify,
+		TikaURL:                 c.TikaURL,
+		DownloadTimeout:         c.DownloadTimeout,
+		ExtractTimeout:          c.ExtractTimeout,
+		MaxFileSize:             c.MaxFileSize,
+		MaxContentBytes:         c.MaxContentBytes,
+		HTTPRetries:             c.HTTPRetries,
 	}
 }
 

--- a/internal/filebackfill/source.go
+++ b/internal/filebackfill/source.go
@@ -22,8 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
 	"github.com/opensearch-project/opensearch-go/v3"
 	"github.com/opensearch-project/opensearch-go/v3/opensearchapi"
 )
@@ -54,11 +56,16 @@ type osScrollSource struct {
 }
 
 func newOSScrollSource(cfg Config) (*osScrollSource, error) {
+	var transport http.RoundTripper
+	if cfg.ESTLSInsecureSkipVerify {
+		transport = esindex.InsecureSkipVerifyTransport()
+	}
 	client, err := opensearchapi.NewClient(opensearchapi.Config{
 		Client: opensearch.Config{
 			Addresses: cfg.ESAddresses,
 			Username:  cfg.ESUsername,
 			Password:  cfg.ESPassword,
+			Transport: transport,
 		},
 	})
 	if err != nil {

--- a/internal/filebackfill/source_tls_test.go
+++ b/internal/filebackfill/source_tls_test.go
@@ -1,0 +1,75 @@
+package filebackfill
+
+// source_tls_test.go — 验证 filebackfill.Config.ESTLSInsecureSkipVerify 正确传到
+// newOSScrollSource 的 opensearch.Transport，backfill Job 也能连自签证书 OS。
+// 与 internal/fileextract/oswriter_tls_test.go 同一 bug 覆盖（PR-C）。
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestNewOSScrollSource_TLSInsecureAllowsSelfSignedServer 证明：
+// ESTLSInsecureSkipVerify=true 时 scroll source 能连 httptest.NewTLSServer。
+func TestNewOSScrollSource_TLSInsecureAllowsSelfSignedServer(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 首批 scroll = POST /<index>/_search?scroll=<TTL>
+		w.Header().Set("Content-Type", "application/json")
+		if _, werr := w.Write([]byte(`{"_scroll_id":"s1","hits":{"hits":[]}}`)); werr != nil {
+			t.Errorf("write: %v", werr)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		ESAddresses:             []string{srv.URL},
+		ESIndex:                 "octo-message",
+		ESTLSInsecureSkipVerify: true,
+	}
+	src, err := newOSScrollSource(cfg)
+	if err != nil {
+		t.Fatalf("newOSScrollSource: %v", err)
+	}
+	if _, err := src.Next(context.Background()); err != nil {
+		t.Fatalf("Next against TLS test server: %v", err)
+	}
+}
+
+// TestNewOSScrollSource_TLSStrictRejectsSelfSignedServer 反证：flag=false 走默认 transport，
+// 必须因 x509 校验失败而报错。防未来重构误把 skip 变默认。
+func TestNewOSScrollSource_TLSStrictRejectsSelfSignedServer(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		ESAddresses:             []string{srv.URL},
+		ESIndex:                 "octo-message",
+		ESTLSInsecureSkipVerify: false,
+	}
+	src, err := newOSScrollSource(cfg)
+	if err != nil {
+		t.Fatalf("newOSScrollSource: %v", err)
+	}
+	_, err = src.Next(context.Background())
+	if err == nil {
+		t.Fatalf("expected TLS handshake error, got nil")
+	}
+	if !strings.Contains(err.Error(), "certificate") && !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "unknown authority") {
+		t.Fatalf("expected x509/certificate error, got: %v", err)
+	}
+}
+
+// TestConfig_ToExtractorConfig_ForwardsTLSFlag 证明 backfill Config → fileextract.ServiceConfig
+// 时 ESTLSInsecureSkipVerify 被转发（防漏字段导致 backfill Job 的 extractor 侧写 OS 又崩）。
+func TestConfig_ToExtractorConfig_ForwardsTLSFlag(t *testing.T) {
+	cfg := Config{ESTLSInsecureSkipVerify: true}
+	out := cfg.ToExtractorConfig()
+	if !out.ESTLSInsecureSkipVerify {
+		t.Fatalf("expected ESTLSInsecureSkipVerify=true forwarded, got false")
+	}
+}

--- a/internal/fileextract/config.go
+++ b/internal/fileextract/config.go
@@ -32,6 +32,10 @@ type ServiceConfig struct {
 	ESIndex     string
 	ESUsername  string
 	ESPassword  string
+	// ESTLSInsecureSkipVerify 为 true 时跳过 OpenSearch HTTPS 证书校验（自签证书场景）。
+	// 默认 false：使用默认 transport，强制校验，行为不变。与 es-indexer / reconcile / backfill
+	// 同一开关语义（共用 esindex.InsecureSkipVerifyTransport helper）。
+	ESTLSInsecureSkipVerify bool
 
 	// Tika / Download / Extract
 	TikaURL         string        // http://localhost:9998（sidecar 部署方案 α）

--- a/internal/fileextract/oswriter.go
+++ b/internal/fileextract/oswriter.go
@@ -41,6 +41,8 @@ type osWriter struct {
 }
 
 // newOSWriter 构造 OpenSearch 客户端（复用 esindex.NewWriter 相同 dial 参数形态便于运维一致）。
+// cfg.ESTLSInsecureSkipVerify=true 时注入 esindex.InsecureSkipVerifyTransport() 跳过自签
+// 证书校验（与 es-indexer / reconcile / backfill 同一 helper，避免各自实现漂移）。
 func newOSWriter(cfg ServiceConfig) (*osWriter, error) {
 	if len(cfg.ESAddresses) == 0 {
 		return nil, errors.New("fileextract: at least one OS address required")
@@ -48,11 +50,16 @@ func newOSWriter(cfg ServiceConfig) (*osWriter, error) {
 	if cfg.ESIndex == "" {
 		return nil, errors.New("fileextract: OS index required")
 	}
+	var transport http.RoundTripper
+	if cfg.ESTLSInsecureSkipVerify {
+		transport = esindex.InsecureSkipVerifyTransport()
+	}
 	client, err := opensearchapi.NewClient(opensearchapi.Config{
 		Client: opensearch.Config{
 			Addresses: cfg.ESAddresses,
 			Username:  cfg.ESUsername,
 			Password:  cfg.ESPassword,
+			Transport: transport,
 		},
 	})
 	if err != nil {

--- a/internal/fileextract/oswriter_tls_test.go
+++ b/internal/fileextract/oswriter_tls_test.go
@@ -1,0 +1,75 @@
+package fileextract
+
+// oswriter_tls_test.go — 验证 ESTLSInsecureSkipVerify 开关正确切换到 esindex.InsecureSkipVerifyTransport。
+// 覆盖 v1.13 生产 bug：file-extractor 起来后 mapping-compat gate 校验 OS 时
+// x509 "certificate signed by unknown authority" → CrashLoop（file-extractor
+// 之前不读 ES_TLS_INSECURE_SKIP_VERIFY env，与 es-indexer 不对称）。
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-search-indexer/internal/esindex"
+)
+
+// TestNewOSWriter_TLSInsecureAllowsSelfSignedServer 证明：ESTLSInsecureSkipVerify=true
+// 时 newOSWriter 构造出的 client 能直连 httptest.NewTLSServer (self-signed cert)，
+// 校验 helper 已被真正注入到 opensearch.Config.Transport 链上。
+func TestNewOSWriter_TLSInsecureAllowsSelfSignedServer(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Update API path: /<index>/_update/<id>
+		if !strings.Contains(r.URL.Path, "/_update/") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, werr := w.Write([]byte(`{"_id":"m1","result":"updated"}`)); werr != nil {
+			t.Errorf("write: %v", werr)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:             []string{srv.URL},
+		ESIndex:                 "octo-message",
+		ESTLSInsecureSkipVerify: true,
+	}
+	w, err := newOSWriter(cfg)
+	if err != nil {
+		t.Fatalf("newOSWriter: %v", err)
+	}
+	if err := w.UpdateContent(context.Background(), "m1", "hello", esindex.FileContentMeta{}); err != nil {
+		t.Fatalf("UpdateContent against TLS test server: %v", err)
+	}
+}
+
+// TestNewOSWriter_TLSStrictRejectsSelfSignedServer 反证：ESTLSInsecureSkipVerify=false
+// 时使用默认 transport，dial httptest self-signed 服务器必须 x509 校验失败。
+// 保护 flag=false 走默认 transport（校验开启），避免未来重构误把 skip 变成默认。
+func TestNewOSWriter_TLSStrictRejectsSelfSignedServer(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:             []string{srv.URL},
+		ESIndex:                 "octo-message",
+		ESTLSInsecureSkipVerify: false,
+	}
+	w, err := newOSWriter(cfg)
+	if err != nil {
+		t.Fatalf("newOSWriter: %v", err)
+	}
+	err = w.UpdateContent(context.Background(), "m1", "hello", esindex.FileContentMeta{})
+	if err == nil {
+		t.Fatalf("expected TLS handshake error against self-signed server, got nil")
+	}
+	if !strings.Contains(err.Error(), "certificate") && !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "unknown authority") {
+		t.Fatalf("expected x509/certificate error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Bug

`file-extractor` 起来时 `mapping-compat` 启动 gate 走 `esindex.NewWriter` 调 OpenSearch mapping API 校验字段齐备。如果 OpenSearch 是 HTTPS + self-signed cert，client 缺 TLS insecure skip verify 支持时 x509 校验失败 → pod CrashLoop。

错误信息：

```
esindex: mapping-compat get live mapping for "<index>" failed:
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## 根因

PR #47 引入 `file-extractor` 时漏了 TLS insecure skip verify 支持。同仓 `es-indexer` 已有对应 fix：

- `cmd/es-indexer/main.go`:读 `ES_TLS_INSECURE_SKIP_VERIFY` env
- `internal/esindex/transport.go`:提供 `InsecureSkipVerifyTransport()` helper 返回跳过校验的 `http.RoundTripper`

`file-extractor` 代码路径完全不读这个 env,不复用 helper,3 处 `opensearchapi.NewClient` 初始化 + 1 处 `esindex.NewWriter` 调用都直接用默认 transport → self-signed cert 场景必然失败。

## 修法(复用现有 helper,不重造轮子)

**新增字段**:

- `internal/fileextract/config.go`:`ServiceConfig` 加 `ESTLSInsecureSkipVerify bool`
- `internal/filebackfill/config.go`:`Config` 加同名 field + `ToExtractorConfig` 转发

**Transport 注入 4 处**(按 flag 走 `esindex.InsecureSkipVerifyTransport()`):

- `internal/fileextract/oswriter.go`:`newOSWriter` 初始化 `opensearchapi.Client`
- `internal/filebackfill/source.go`:`newOSScrollSource` 初始化 `opensearchapi.Client`
- `cmd/file-extractor/main.go::assertLiveMapping`:调 `esindex.NewWriter` 时传 `Transport`(否则健康检查先崩,走不到主流程)
- 3 处外的 `opensearchapi.NewClient` 已 grep 全仓 verify(其余 3 处在 esindex/writer.go + cmd/backfill + cmd/reconcile 都已有 TLS 支持,本 PR 不动)

**env / flag wiring**:

- `cmd/file-extractor/main.go::loadConfig`:从 `ES_TLS_INSECURE_SKIP_VERIFY` env 读
- `cmd/file-content-backfill/main.go`:加 `-es-tls-insecure` flag + `BACKFILL_ES_TLS_INSECURE_SKIP_VERIFY` env(同 `cmd/backfill` / `cmd/reconcile` pattern)

## Test plan

新增 5 个测试用例(`httptest.NewTLSServer` self-signed cert):

- `TestNewOSWriter_TLSInsecureAllowsSelfSignedServer`:flag=true → `UpdateContent` 握手通过
- `TestNewOSWriter_TLSStrictRejectsSelfSignedServer`:flag=false → x509 报错(防未来重构误把 skip 变默认)
- `TestNewOSScrollSource_TLSInsecureAllowsSelfSignedServer`:backfill 侧 flag=true → `Next` 通
- `TestNewOSScrollSource_TLSStrictRejectsSelfSignedServer`:backfill 侧 flag=false → x509 报错
- `TestConfig_ToExtractorConfig_ForwardsTLSFlag`:`Config→ServiceConfig` 转发校验(防漏字段)

全 5 用例本地跑通;`go vet ./... && go build ./... && go test -race ./...` 全绿。
