### PR TITLE
feat(fileextract): split invalid_url from download_failed for SSRF pre-check permanent reject

### DIFF
--- a/internal/fileextract/dlq.go
+++ b/internal/fileextract/dlq.go
@@ -11,6 +11,7 @@ package fileextract
 //	| oversize            | 文件 > MaxFileSize                            | ❌      |
 //	| blacklist_ext       | 扩展名在黑名单（不该走这里，是设计正常跳过） | ❌      |
 //	| download_failed     | HTTP GET CDN 5xx 或连接超时（重试耗尽）        | ✅ 3 次 |
+//	| invalid_url         | SSRF pre-check 拒 URL（scheme/host allowlist）| ❌      |
 //	| extract_timeout     | Tika 抽取 > ExtractTimeout                    | ❌      |
 //	| encrypted           | Tika 抛 EncryptedDocumentException             | ❌      |
 //	| empty_extract       | Tika 返回空串或空白                           | ❌      |
@@ -26,6 +27,11 @@ const (
 	ReasonEncrypted      = "encrypted"
 	ReasonEmptyExtract   = "empty_extract"
 	ReasonExtractError   = "extract_error"
+
+	// ReasonInvalidURL：SSRF pre-check 拒绝 URL（scheme/host 不在 allowlist）。
+	// 归 permanent DLQ + tombstone：allowlist 是硬 policy 边界，同 URL rerun 结果不变。
+	// 典型触发：老历史 file 消息 URL 是已淘汰的 CDN/COS 直连域名，不在现役 allowlist 内。
+	ReasonInvalidURL = "invalid_url"
 
 	// ReasonRetryExhausted：单条消息 in-place bounded retry N 次仍未成功
 	// (errDocNotYet / errOSTransient 长期未收敛) → 强制 DLQ 并 commit offset，避免

--- a/internal/fileextract/download.go
+++ b/internal/fileextract/download.go
@@ -31,6 +31,12 @@ var errOversize = errors.New("fileextract: file size exceeds MaxFileSize cutoff"
 // errDownloadFailed 是重试耗尽或 4xx 非 429 permanent 失败（触发 DLQ reason=download_failed）。
 var errDownloadFailed = errors.New("fileextract: download exhausted retries or 4xx permanent")
 
+// errInvalidURL 是 SSRF pre-check（validateURL）拒绝 URL 的 sentinel（触发 DLQ reason=invalid_url）。
+// 与 errDownloadFailed 分开：pre-check 拒是 policy 硬约束（scheme/host allowlist 不变，同 URL
+// 无论重试或 backfill rerun 结果不变），归 permanent tombstone；errDownloadFailed 保留给
+// CDN 5xx / 4xx expired 等 transient/URL-specific 故障（rerun 可能成功，不写 tombstone）。
+var errInvalidURL = errors.New("fileextract: url rejected by SSRF pre-check")
+
 // downloadClient 从 URL 拉文件 bytes。
 type downloadClient struct {
 	hc             *http.Client
@@ -94,8 +100,10 @@ func (c ServiceConfig) RetryBackoffBase() time.Duration {
 // URL 不变重试无意义）。
 func (d *downloadClient) Fetch(ctx context.Context, url string) ([]byte, string, error) {
 	if err := validateURL(url, d.allowedHosts, d.allowedSchemes); err != nil {
-		// SSRF pre-check 拒绝 → download_failed（不重试；host/scheme 不变重试无意义）
-		return nil, "", fmt.Errorf("%w: %v", errDownloadFailed, err)
+		// SSRF pre-check 拒绝 → invalid_url（不重试；host/scheme allowlist 是硬约束，同 URL rerun 无益）。
+		// 归 permanent tombstone reason（extractor.go tombstoneReasons），backfill scroll 会过滤，
+		// 避免老 URL（如已下线的历史 COS 直连）被 rerun 无限重试。
+		return nil, "", fmt.Errorf("%w: %v", errInvalidURL, err)
 	}
 	var lastErr error
 	for attempt := 0; attempt <= d.retries; attempt++ {

--- a/internal/fileextract/extractor.go
+++ b/internal/fileextract/extractor.go
@@ -59,6 +59,11 @@ func firstNonZero(a, b int64) int64 {
 // 跳过 → **永远不再重试**。commit message 声称的"permanent DLQ"列表也漏了 extract_timeout →
 // intent vs impl 不一致，本轮修 impl 匹配 intent（不改 intent）。
 //
+// v1.14：invalid_url 是从 download_failed 拆出的**永久** SSRF policy 类（validateURL pre-check
+// 拒），归 tombstone —— 与 download_failed 语义相反：URL host/scheme allowlist 是硬约束，
+// 同 URL rerun 结果不变（typical: 老历史消息带已淘汰的 CDN/COS 直连域名），需 tombstone
+// 让 backfill 跳过避免无限重复失败。
+//
 // 白名单只覆盖 extractor.ExtractAndWrite 内部返回的 permanent 类（不含 ParseError /
 // RetryExhausted / OSPermanent — 这些 reason 由 consumer.processBatch 直接 writeDLQ，不经
 // extractor.defer；ParseError 场景 doc 不存在于 OS 也不需要 tombstone）。
@@ -68,6 +73,7 @@ var tombstoneReasons = map[string]bool{
 	ReasonEncrypted:    true, // 加密 PDF：无密码无解
 	ReasonEmptyExtract: true, // Tika 抽出空/纯空白：文件真无文本
 	ReasonExtractError: true, // Tika 报 exception：内容/格式问题，重试无益
+	ReasonInvalidURL:   true, // SSRF pre-check 拒 URL：allowlist 硬约束，同 URL rerun 无益
 	// 明确排除：ReasonDownloadFailed（CDN 5xx / 网络抖动，rerun 可能成功）
 	// 明确排除：ReasonExtractTimeout（Tika 临时资源紧张 / 大文件超时，rerun 可能成功）
 }
@@ -130,6 +136,11 @@ func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *f
 	if derr != nil {
 		if errors.Is(derr, errOversize) {
 			return ReasonOversize, derr, nil
+		}
+		if errors.Is(derr, errInvalidURL) {
+			// SSRF pre-check 拒 → permanent (走 tombstone)。放在 errDownloadFailed 前判断，
+			// 否则 wrap 顺序变化时可能被更宽松的分支吃掉。
+			return ReasonInvalidURL, derr, nil
 		}
 		if errors.Is(derr, errDownloadFailed) {
 			return ReasonDownloadFailed, derr, nil

--- a/internal/fileextract/ssrf_test.go
+++ b/internal/fileextract/ssrf_test.go
@@ -163,7 +163,8 @@ func TestSSRFRestrictedDialer_LoopbackBypassWhenAllowed(t *testing.T) {
 }
 
 // TestFetch_SSRFPrecheckBlocksMalformedURL Fetch 入口 pre-check 拦 malformed URL，
-// 不重试（scheme/host 不变重试无意义）。
+// 不重试（scheme/host 不变重试无意义）。v1.14 起 pre-check 失败归 errInvalidURL
+// （从 errDownloadFailed 拆分，SSRF policy permanent 类，走 tombstone）。
 func TestFetch_SSRFPrecheckBlocksMalformedURL(t *testing.T) {
 	dc := newDownloadClient(ServiceConfig{
 		DownloadTimeout: 100 * time.Millisecond,
@@ -171,8 +172,8 @@ func TestFetch_SSRFPrecheckBlocksMalformedURL(t *testing.T) {
 		MaxFileSize:     1024,
 	})
 	_, _, err := dc.Fetch(context.Background(), "http://cdn.deepminer.com.cn/x") // http 被默认 scheme 拒
-	if !errors.Is(err, errDownloadFailed) {
-		t.Fatalf("expected errDownloadFailed wrapping SSRF, got %v", err)
+	if !errors.Is(err, errInvalidURL) {
+		t.Fatalf("expected errInvalidURL wrapping SSRF pre-check, got %v", err)
 	}
 }
 

--- a/internal/fileextract/tombstone_whitelist_test.go
+++ b/internal/fileextract/tombstone_whitelist_test.go
@@ -26,6 +26,7 @@ func TestTombstoneReasons_Whitelist(t *testing.T) {
 		ReasonEncrypted,
 		ReasonEmptyExtract,
 		ReasonExtractError,
+		ReasonInvalidURL, // v1.14：SSRF pre-check 拒 URL（scheme/host allowlist policy 硬约束）
 	}
 	for _, r := range permanent {
 		if !isTombstoneReason(r) {
@@ -234,5 +235,108 @@ func TestExtractor_PermanentDLQ_WritesTombstone_Encrypted(t *testing.T) {
 	}
 	if !strings.Contains(tombstoneBody, `"reason":"encrypted"`) {
 		t.Errorf("tombstone must carry reason=encrypted, got: %s", tombstoneBody)
+	}
+}
+
+// TestExtractor_PermanentDLQ_WritesTombstone_InvalidURLHost v1.14 新分支：URL host 不在
+// SSRF allowlist → validateURL 拒 → errInvalidURL → ReasonInvalidURL → tombstone 写入。
+// 覆盖典型生产场景：老历史 file 消息 URL 是已淘汰的 CDN/COS 直连域名，不在现役 allowlist 内，
+// 归 permanent 让 backfill 跳过避免无限重复失败（不是 transient download_failed）。
+func TestExtractor_PermanentDLQ_WritesTombstone_InvalidURLHost(t *testing.T) {
+	var tombstoneBody string
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Errorf("read body: %v", rerr)
+		}
+		tombstoneBody = string(b)
+		_, _ = w.Write([]byte(`{"result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{osSrv.URL},
+		ESIndex:                "octo-message",
+		DownloadTimeout:        200 * time.Millisecond,
+		ExtractTimeout:         200 * time.Millisecond,
+		MaxFileSize:            1024,
+		MaxContentBytes:        1024,
+		HTTPRetries:            1,
+		AllowedDownloadHosts:   []string{"cdn.example.com"}, // 明确 host allowlist
+		AllowedDownloadSchemes: []string{"https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	// URL host 不在 allowlist → pre-check 拒（不会真去 dial）
+	fp := &filePayload{URL: "https://not-in-allowlist.example.org/x.pdf", Name: "x.pdf", Extension: ".pdf"}
+	reason, cause, rerr := e.ExtractAndWrite(context.Background(), "42", fp)
+	if rerr != nil {
+		t.Fatalf("ExtractAndWrite: err=%v cause=%v", rerr, cause)
+	}
+	if reason != ReasonInvalidURL {
+		t.Fatalf("expected invalid_url reason, got %q (cause=%v)", reason, cause)
+	}
+	if !errors.Is(cause, errInvalidURL) {
+		t.Errorf("cause must wrap errInvalidURL, got %v", cause)
+	}
+	if !strings.Contains(tombstoneBody, `"status":"unextractable"`) {
+		t.Errorf("invalid_url (permanent) must write tombstone, got body: %s", tombstoneBody)
+	}
+	if !strings.Contains(tombstoneBody, `"reason":"invalid_url"`) {
+		t.Errorf("tombstone must carry reason=invalid_url, got: %s", tombstoneBody)
+	}
+}
+
+// TestExtractor_PermanentDLQ_WritesTombstone_InvalidURLScheme v1.14：URL scheme 非白名单
+// （空 scheme / http / ftp 等）→ validateURL 拒 → errInvalidURL → ReasonInvalidURL → tombstone。
+// 覆盖脏数据场景：payload.file.url 为空或 scheme 异常。
+func TestExtractor_PermanentDLQ_WritesTombstone_InvalidURLScheme(t *testing.T) {
+	var tombstoneBody string
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			t.Errorf("read body: %v", rerr)
+		}
+		tombstoneBody = string(b)
+		_, _ = w.Write([]byte(`{"result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{osSrv.URL},
+		ESIndex:                "octo-message",
+		DownloadTimeout:        200 * time.Millisecond,
+		ExtractTimeout:         200 * time.Millisecond,
+		MaxFileSize:            1024,
+		MaxContentBytes:        1024,
+		HTTPRetries:            1,
+		AllowedDownloadHosts:   []string{"cdn.example.com"},
+		AllowedDownloadSchemes: []string{"https"}, // 只放 https，http/ftp/空全拒
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	// scheme=ftp 不在 allowlist → pre-check 拒（走 errSSRFScheme → wrap errInvalidURL）
+	fp := &filePayload{URL: "ftp://cdn.example.com/x.pdf", Name: "x.pdf", Extension: ".pdf"}
+	reason, cause, rerr := e.ExtractAndWrite(context.Background(), "42", fp)
+	if rerr != nil {
+		t.Fatalf("ExtractAndWrite: err=%v cause=%v", rerr, cause)
+	}
+	if reason != ReasonInvalidURL {
+		t.Fatalf("expected invalid_url reason, got %q (cause=%v)", reason, cause)
+	}
+	if !errors.Is(cause, errInvalidURL) {
+		t.Errorf("cause must wrap errInvalidURL, got %v", cause)
+	}
+	if !strings.Contains(tombstoneBody, `"status":"unextractable"`) {
+		t.Errorf("invalid_url (permanent) must write tombstone, got body: %s", tombstoneBody)
+	}
+	if !strings.Contains(tombstoneBody, `"reason":"invalid_url"`) {
+		t.Errorf("tombstone must carry reason=invalid_url, got: %s", tombstoneBody)
 	}
 }


### PR DESCRIPTION
## Bug

SSRF pre-check（`validateURL`: scheme/host allowlist）拒绝的 URL 被归到 `reason=download_failed`，而 `download_failed` 在 `tombstoneReasons` 白名单外（transient 保留 backfill retry safety net，见 `internal/fileextract/extractor.go` Round-4 review 注释）。结果 SSRF pre-check 拒的 URL 每次 backfill rerun 都会重复失败，无法收敛。典型触发场景：老历史 file 消息 URL 是已淘汰的 CDN/COS 域名，不在现役 allowlist 内。

## Fix

把 SSRF pre-check 拒绝拆到独立 permanent reason `invalid_url`：

- `internal/fileextract/download.go`: 新增 sentinel `errInvalidURL`
- `internal/fileextract/download.go` `Fetch()`: pre-check 失败改 wrap `errInvalidURL`（而非 `errDownloadFailed`）
- `internal/fileextract/extractor.go` `ExtractAndWrite()`: 在 `errDownloadFailed` 分支之前新增 `errors.Is(derr, errInvalidURL)` 分支返 `ReasonInvalidURL`
- `internal/fileextract/dlq.go`: 新增常量 `ReasonInvalidURL = "invalid_url"` + 表格文档
- `internal/fileextract/extractor.go` `tombstoneReasons`: 加 `ReasonInvalidURL: true`（allowlist 是硬 policy 边界，同 URL rerun 结果不变）

**未改**：dialer 层 SSRF 拒（`errSSRFPrivateIP` via `ssrfRestrictedDialer`）仍归 `download_failed` —— 走 tryFetch retry path，DNS/网络条件可能变化保守留 transient。仅 **前置 `validateURL` pre-check** 归 `invalid_url`。

## Test plan

- 新增 `TestExtractor_PermanentDLQ_WritesTombstone_InvalidURLHost` — URL host 不在 allowlist → reason=invalid_url + tombstone 写入 `status=unextractable` + `reason=invalid_url`
- 新增 `TestExtractor_PermanentDLQ_WritesTombstone_InvalidURLScheme` — URL scheme=ftp 非白名单 → 同上断言
- `TestTombstoneReasons_Whitelist` 契约锁 permanent list 加 `ReasonInvalidURL`
- `TestFetch_SSRFPrecheckBlocksMalformedURL` expect 从 `errDownloadFailed` 更新为 `errInvalidURL`
- `go vet ./...` + `go build ./...` 全绿
- `go test -race -timeout 120s ./internal/fileextract/... ./internal/filebackfill/...` 全绿

## 同仓 refs

- Round-4 `lml2468` review 关于 tombstoneReasons transient/permanent 拆分的注释：`internal/fileextract/extractor.go` `tombstoneReasons` var block 上方注释
- SSRF 双闸门实现：`internal/fileextract/ssrf.go` `validateURL` (闸门 1) + `ssrfRestrictedDialer` (闸门 2)
- DLQ reason 常量表：`internal/fileextract/dlq.go`
