### PR TITLE
feat(fileextract): add Prometheus observability for file-extractor

### DIFF
--- a/cmd/file-extractor/main.go
+++ b/cmd/file-extractor/main.go
@@ -50,8 +50,12 @@ func main() {
 
 func run(ctx context.Context) error {
 	cfg, enabled := loadConfig()
+	obsAddr := envOr("FILE_EXTRACTOR_OBS_ADDR", ":9090")
 	if !enabled {
 		log.Printf("file-extractor: FILE_EXTRACTOR_ENABLED not true (or brokers/ES unset); idling (no backend connection)")
+		// 对齐 es-indexer：空转态也起 obs server（/healthz + /readyz 200，/metrics 空），
+		// 让被刻意停用的 pod 不在编排器 HTTP 探针下 crashloop。不连任何后端（metrics=nil）。
+		serveIdleObs(ctx, obsAddr)
 		<-ctx.Done()
 		return nil
 	}
@@ -71,9 +75,44 @@ func run(ctx context.Context) error {
 			log.Printf("file-extractor: close error: %v", cerr)
 		}
 	}()
-	log.Printf("file-extractor running: topic=%s group=%s dlq=%s es_index=%s tika=%s",
-		cfg.Topic, cfg.GroupID, cfg.DLQTopic, cfg.ESIndex, cfg.TikaURL)
+
+	// Observability server（healthz/readyz/metrics）。运行循环起后置 ready。
+	if obsAddr != "" {
+		obs := fileextract.NewObsServer(obsAddr, svc.Metrics(), nil)
+		obs.Start(log.Printf)
+		obs.SetReady(true)
+		defer func() {
+			sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if serr := obs.Shutdown(sctx); serr != nil {
+				log.Printf("file-extractor: obs shutdown: %v", serr)
+			}
+		}()
+	}
+	log.Printf("file-extractor running: topic=%s group=%s dlq=%s es_index=%s tika=%s obs=%s",
+		cfg.Topic, cfg.GroupID, cfg.DLQTopic, cfg.ESIndex, cfg.TikaURL, obsAddr)
 	return svc.Run(ctx)
+}
+
+// serveIdleObs 在空转（停用）态起 obs HTTP server：/healthz 与 /readyz 均返回 200，
+// /metrics 空。对齐 es-indexer 的 idle obs，保证被停用的 pod 在探针下不 crashloop。
+// 不连任何后端（metrics=nil），ctx 取消时优雅停机。
+func serveIdleObs(ctx context.Context, addr string) {
+	if addr == "" {
+		return
+	}
+	obs := fileextract.NewObsServer(addr, nil, nil)
+	obs.SetReady(true) // 空转正常即 ready（未拨任何后端）
+	obs.Start(log.Printf)
+	go func() {
+		<-ctx.Done()
+		sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if serr := obs.Shutdown(sctx); serr != nil {
+			log.Printf("file-extractor: idle obs shutdown: %v", serr)
+		}
+	}()
+	log.Printf("file-extractor: idle observability server on %s (/healthz + /readyz 200, idle)", addr)
 }
 
 // assertLiveMapping 用 esindex.Writer 复用 mapping-compat 校验（P2-10）。

--- a/cmd/file-extractor/main_test.go
+++ b/cmd/file-extractor/main_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -205,5 +209,46 @@ func TestLoadConfig_ProdTopicOverride(t *testing.T) {
 	}
 	if cfg.DLQTopic != "octo.message.v1.file-extract.dlq.prod" {
 		t.Errorf("DLQTopic override: got %q", cfg.DLQTopic)
+	}
+}
+
+// TestServeIdleObs_HealthReadyMetrics verifies the idle (disabled) posture serves
+// /healthz + /readyz as 200 and /metrics as an empty 200, so a deliberately-off pod
+// does not crashloop under HTTP liveness/readiness probes. Mirrors the producer's
+// TestServeIdleObs_HealthAndReady template.
+func TestServeIdleObs_HealthReadyMetrics(t *testing.T) {
+	// Grab a free localhost port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if cerr := ln.Close(); cerr != nil {
+		t.Fatalf("close probe listener: %v", cerr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveIdleObs(ctx, addr)
+
+	base := fmt.Sprintf("http://%s", addr)
+	deadline := time.Now().Add(3 * time.Second)
+	for _, path := range []string{"/healthz", "/readyz", "/metrics"} {
+		var got int
+		for time.Now().Before(deadline) {
+			resp, gerr := http.Get(base + path) //nolint:noctx // short-lived test probe
+			if gerr != nil {
+				time.Sleep(20 * time.Millisecond)
+				continue
+			}
+			got = resp.StatusCode
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Fatalf("close body: %v", cerr)
+			}
+			break
+		}
+		if got != http.StatusOK {
+			t.Fatalf("idle %s = %d, want 200", path, got)
+		}
 	}
 }

--- a/internal/fileextract/consumer.go
+++ b/internal/fileextract/consumer.go
@@ -38,6 +38,9 @@ type Processor struct {
 	sleep func(context.Context, time.Duration) error
 }
 
+// Metrics 暴露 Processor 的可观测计数集，供 Service/obs server 拿 registry 暴露 /metrics。
+func (p *Processor) Metrics() *counters { return p.metrics }
+
 // extractorService 抽象「抽取 + OS partial update」核心行为，供 Processor 测试注入 mock。
 // 生产实现是 *Extractor（extractor.go），本 interface 只暴露 processOne/attemptOne 需要的
 // 单个方法，便于最小化 test surface。
@@ -73,7 +76,7 @@ func NewProcessor(src messageSource, dlq dlqSink, ext extractorService, cfg Serv
 		source:    src,
 		dlqSink:   dlq,
 		dlq:       handler,
-		metrics:   &counters{},
+		metrics:   newCounters(),
 		extractor: ext,
 		cfg:       cfg,
 		sleep:     sleepCtx,
@@ -206,7 +209,7 @@ func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) er
 					return werr // DLQ 硬停 fatal
 				}
 				p.metrics.IncRetryExhausted()
-				p.metrics.IncDLQ()
+				p.metrics.IncDLQ(ReasonRetryExhausted)
 				dispositions[i] = dispDLQResolved
 				changed = true
 				continue
@@ -260,7 +263,7 @@ func (p *Processor) processBatch(ctx context.Context, batch []fetchedMessage) er
 func (p *Processor) attemptOne(ctx context.Context, m fetchedMessage) (attemptOutcome, error) {
 	var msg searchmsg.Message
 	if err := json.Unmarshal(m.Value, &msg); err != nil {
-		p.metrics.IncDLQ()
+		p.metrics.IncDLQ(ReasonParseError)
 		if werr := p.writeDLQ(ctx, m, ReasonParseError, "", nil, err); werr != nil {
 			return outcomeFatal, werr
 		}
@@ -276,7 +279,7 @@ func (p *Processor) attemptOne(ctx context.Context, m fetchedMessage) (attemptOu
 	if err != nil {
 		// P2-2：OS permanent 4xx → 走 DLQ ReasonOSPermanent（不走 transient retry）
 		if errors.Is(err, errOSPermanent) {
-			p.metrics.IncDLQ()
+			p.metrics.IncDLQ(ReasonOSPermanent)
 			p.metrics.IncOSPermanent()
 			if werr := p.writeDLQ(ctx, m, ReasonOSPermanent, msg.MessageID, fp, err); werr != nil {
 				return outcomeFatal, werr
@@ -290,7 +293,7 @@ func (p *Processor) attemptOne(ctx context.Context, m fetchedMessage) (attemptOu
 		return outcomeTransient, nil
 	}
 	if dlqReason != "" {
-		p.metrics.IncDLQ()
+		p.metrics.IncDLQ(dlqReason)
 		if werr := p.writeDLQ(ctx, m, dlqReason, msg.MessageID, fp, cause); werr != nil {
 			return outcomeFatal, werr
 		}

--- a/internal/fileextract/consumer.go
+++ b/internal/fileextract/consumer.go
@@ -67,16 +67,18 @@ func NewProcessor(src messageSource, dlq dlqSink, ext extractorService, cfg Serv
 	// v1.13 P2-1：dlqHandler 有界重试 + spill 逃逸（yujiawei review fix）。缺 SpillDir 时
 	// DLQ 写耗尽 → errDLQHardStop → outcomeFatal → Run 停 worker + K8s 重启（保 offset 不推进）。
 	// 配 SpillDir 后转成落盘 + 告警 + offset 越过（绝不永久卡 partition）。
+	metrics := newCounters()
 	handler := newDLQHandler(dlq, newLogAlerter(log.Printf), dlqHandlerConfig{
 		MaxRetries:   cfg.DLQMaxRetries,
 		RetryBackoff: cfg.DLQRetryBackoff,
 		SpillDir:     cfg.DLQSpillDir,
 	})
+	handler.metrics = metrics // P1：DLQ 写失败逃逸埋点注入
 	return &Processor{
 		source:    src,
 		dlqSink:   dlq,
 		dlq:       handler,
-		metrics:   newCounters(),
+		metrics:   metrics,
 		extractor: ext,
 		cfg:       cfg,
 		sleep:     sleepCtx,

--- a/internal/fileextract/consumer_test.go
+++ b/internal/fileextract/consumer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -105,8 +106,8 @@ func TestProcessOne_SkipNonFileMessages(t *testing.T) {
 		if len(dlq.records) != 0 {
 			t.Errorf("ct=%d: expected 0 DLQ records, got %d: %+v", ct, len(dlq.records), dlq.records)
 		}
-		if p.metrics.skippedNonFile.Load() != 1 {
-			t.Errorf("ct=%d: skippedNonFile expected 1, got %d", ct, p.metrics.skippedNonFile.Load())
+		if got := dumpMetrics(t, p.metrics); !strings.Contains(got, `fileextract_skipped_non_file_total 1`) {
+			t.Errorf("ct=%d: skippedNonFile expected 1 in:\n%s", ct, got)
 		}
 	}
 }
@@ -132,8 +133,8 @@ func TestProcessOne_ParseErrorToDLQ(t *testing.T) {
 	if dlq.records[0].Reason != ReasonParseError {
 		t.Errorf("reason: got %q want %q", dlq.records[0].Reason, ReasonParseError)
 	}
-	if p.metrics.dlqTotal.Load() != 1 {
-		t.Errorf("dlqTotal expected 1, got %d", p.metrics.dlqTotal.Load())
+	if got := dumpMetrics(t, p.metrics); !strings.Contains(got, `fileextract_dlq_total{reason="parse_error"} 1`) {
+		t.Errorf("dlqTotal parse_error expected 1 in:\n%s", got)
 	}
 }
 

--- a/internal/fileextract/dlq_handler.go
+++ b/internal/fileextract/dlq_handler.go
@@ -55,6 +55,9 @@ type dlqHandler struct {
 	cfg     dlqHandlerConfig
 	sleep   func(context.Context, time.Duration) error // ctx-aware，测试注入即时返
 	nowUnix func() int64
+	// metrics 为 P1 埋点注入的计数集，可为 nil（老 test 直接 newDLQHandler 不设）；
+	// nil-receiver 安全，nil 时跳过埋点。由 NewProcessor 装配时设为 processor 的 metrics。
+	metrics *counters
 }
 
 // newDLQHandler 组装 handler。sleep 走本包 backoff.go 的 sleepCtx，nowUnix 走 time.Now。
@@ -110,6 +113,8 @@ func (h *dlqHandler) Send(ctx context.Context, rec dlqRecord) error {
 // escape 执行终态逃逸：SpillDir 非空 → 落盘 + 告警 + 返 nil 允许越过；否则返 errDLQHardStop。
 // 落盘文件名 `dlq-spill-<partition>-<offset>-<epoch>.json`（partition+offset 保证唯一，epoch 便于排序）。
 func (h *dlqHandler) escape(rec dlqRecord, detail string) error {
+	// P1：DLQ 写重试耗尽逃逸（spill 或 hard stop）计一次。P0 告警依赖项。
+	h.metrics.IncDLQWriteError()
 	if h.cfg.SpillDir == "" {
 		return errDLQHardStop
 	}

--- a/internal/fileextract/extractor.go
+++ b/internal/fileextract/extractor.go
@@ -25,6 +25,10 @@ type Extractor struct {
 	os             *osWriter
 	maxFileSize    int64
 	extractorLabel string // 写进 contentMeta.extractor (e.g. "tika/3.3.0")
+	// metrics 为 P1 埋点注入的计数集，可为 nil（老 test 手工装配 Extractor 不传）；
+	// 所有 counters 方法 nil-receiver 安全，nil 时跳过埋点。由 service.go 装配时传入
+	// processor 的 metrics（不改 metrics 所有权/透传链，只加字段注入）。
+	metrics *counters
 }
 
 // NewExtractor 构造。所有下游 client 均在这里装配，consumer.Service / backfill Runner 各自 New 一份。
@@ -113,7 +117,9 @@ func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *f
 			//  backfill 再次拉到同 doc 时会重新触发 tombstone 写入）。
 			log.Printf("file-extractor: WriteTombstone messageID=%s reason=%s failed (backfill will retry): %v",
 				messageID, dlqReason, terr)
+			return
 		}
+		e.metrics.IncTombstone(dlqReason)
 	}()
 
 	// 1. 扩展名白名单前置校验（黑名单 → skip 不 DLQ，白名单外 → DLQ blacklist_ext）
@@ -126,8 +132,11 @@ func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *f
 		return ReasonOversize, errors.New("file size exceeds cutoff"), nil
 	}
 	// 3. 下载
+	dlStart := time.Now()
 	body, _, derr := e.download.Fetch(ctx, fp.URL)
+	e.metrics.ObserveIO("download", time.Since(dlStart))
 	if derr != nil {
+		e.metrics.IncIOError("download")
 		if errors.Is(derr, errOversize) {
 			return ReasonOversize, derr, nil
 		}
@@ -144,7 +153,9 @@ func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *f
 	start := time.Now()
 	content, truncated, terr := e.tika.Extract(ctx, body, fp.Name, ext)
 	extractMs := time.Since(start).Milliseconds()
+	e.metrics.ObserveIO("tika_extract", time.Since(start))
 	if terr != nil {
+		e.metrics.IncIOError("tika_extract")
 		switch {
 		case errors.Is(terr, errEncrypted):
 			return ReasonEncrypted, terr, nil
@@ -159,6 +170,11 @@ func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *f
 		// scanned/empty PDF 常返 "\n\n" / 空格串，会漏过 → 无意义 doc 被误 commit）
 		return ReasonEmptyExtract, errors.New("tika returned empty or whitespace-only content"), nil
 	}
+	// 抽取成功：记正文字节数 + 截断计数。
+	e.metrics.ObserveContentBytes(len(content))
+	if truncated {
+		e.metrics.IncTruncated()
+	}
 	// 5. OS partial update
 	meta := esindex.FileContentMeta{
 		ExtractedAt: time.Now().Unix(),
@@ -166,7 +182,15 @@ func (e *Extractor) ExtractAndWrite(ctx context.Context, messageID string, fp *f
 		Truncated:   &truncated, // v1.13 P2-5：指针便于清除 stale true
 		ExtractMs:   &extractMs, // Round-4 TKT-5：同 P2-5 pattern，显式落盘允许 0ms 覆盖 stale
 	}
-	if uerr := e.os.UpdateContent(ctx, messageID, content, meta); uerr != nil {
+	osStart := time.Now()
+	uerr := e.os.UpdateContent(ctx, messageID, content, meta)
+	e.metrics.ObserveIO("os_update", time.Since(osStart))
+	if uerr != nil {
+		// errDocNotYet 是主 doc 未落的正常时序竞态（上层 consumer 已用 IncDocNotYet() 单独计数），
+		// 不该再计入 os_update IO 错误，否则会污染错误率。只上抛让 caller 重试整批。
+		if !errors.Is(uerr, errDocNotYet) {
+			e.metrics.IncIOError("os_update")
+		}
 		// 主 doc 未落 → 上抛让 caller 重试整批（consumer 走 kafka rebalance 重取）
 		return "", nil, uerr
 	}

--- a/internal/fileextract/metrics.go
+++ b/internal/fileextract/metrics.go
@@ -1,35 +1,103 @@
 package fileextract
 
-// metrics.go — file-extractor 计数器骨架（IDX-3 只做 log 打印，IDX-4+ 接 Prometheus 阶段 7 独立任务）。
-// 名字对齐 feasibility.md v2 §11 里提到的观察指标：processed / skipped_non_file / dlq_total[reason] /
-// extract_duration_ms / doc_not_yet（时序竞态触发次数）。
+// metrics.go — file-extractor Prometheus 指标（阶段 7：从 atomic stub 升级为 client_golang 私有 registry）。
+//
+// 设计对齐 sibling internal/consumer/metrics.go：
+//   - 私有 registry（不用 global default registry，避免多 binary 交叉注册）。
+//   - namespace = "fileextract"（与 indexer_* / searchetl_producer_* 对称）。
+//   - 由 obs.go 的 ObsServer 通过 Registry() 暴露 /metrics。
+//
+// 指标（全部 fileextract_ 前缀）：
+//   - processed_total          counter          抽取+回写成功数（核心吞吐）
+//   - skipped_non_file_total   counter          非 type=8 跳过数
+//   - dlq_total{reason}        counter          dead-letter 数 by reason
+//   - doc_not_yet_total        counter          主 doc 未落时序竞态触发数
+//   - retry_exhausted_total    counter          原地重试耗尽转 DLQ 数
+//   - os_permanent_total       counter          OS 4xx permanent 转 DLQ 数
+//
+// 兼容说明：本次（P0）只把已有 6 个计数点接到 client_golang 私有 registry，方法签名尽量不动 consumer 调用点，
+// 唯一变更是 IncDLQ 增加 reason 参数（调用点旁边本就有 reason 变量）。
+// 更细粒度指标（io_op_duration{op} / tika / download / content_bytes / tombstone /
+// dlq_write_errors）需新增埋点、涉及 download/tika/oswriter/dlq_handler 多文件，
+// 留待 P1 增量补齐（见 .omc/monitoring/file-extractor-monitoring-plan.md §3）。
 
 import (
-	"log"
-	"sync/atomic"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-// counters 是一组进程内简单计数（uint64 atomic），无并发风险且零依赖。
+// metricsNamespace 给所有 series 加 fileextract_ 前缀。
+const metricsNamespace = "fileextract"
+
+// counters 是 file-extractor 的可观测集，backed by prometheus client_golang，
+// 绑定在一个私有 registry 上（同 consumer.Metrics 惯例）。
 type counters struct {
-	processed      atomic.Uint64
-	skippedNonFile atomic.Uint64
-	dlqTotal       atomic.Uint64
-	docNotYet      atomic.Uint64 // v2 §7 #1 时序竞态触发计数，观察 Phase 2 独立 retry topic 是否要上
-	retryExhausted atomic.Uint64 // v1.13 Blocker #2：in-place retry N 次未成功 → DLQ 触发计数
-	osPermanent    atomic.Uint64 // v1.13 P2-2：OS 4xx permanent → DLQ 触发计数
+	reg *prometheus.Registry
+
+	processed      prometheus.Counter
+	skippedNonFile prometheus.Counter
+	dlqTotal       *prometheus.CounterVec
+	docNotYet      prometheus.Counter
+	retryExhausted prometheus.Counter
+	osPermanent    prometheus.Counter
 }
 
-func (c *counters) IncProcessed()      { c.processed.Add(1) }
-func (c *counters) IncSkippedNonFile() { c.skippedNonFile.Add(1) }
-func (c *counters) IncDLQ()            { c.dlqTotal.Add(1) }
-func (c *counters) IncDocNotYet()      { c.docNotYet.Add(1) }
-func (c *counters) IncRetryExhausted() { c.retryExhausted.Add(1) }
-func (c *counters) IncOSPermanent()    { c.osPermanent.Add(1) }
-
-// LogSnapshot 打印当前累计计数（周期性调用，比如每 N 秒或 debug 时）。
-// IDX-3 stub 版：只 log；阶段 7 接 Prometheus counter 替换。
-func (c *counters) LogSnapshot() {
-	log.Printf("file-extractor metrics: processed=%d skipped_non_file=%d dlq_total=%d doc_not_yet=%d retry_exhausted=%d os_permanent=%d",
-		c.processed.Load(), c.skippedNonFile.Load(), c.dlqTotal.Load(), c.docNotYet.Load(),
-		c.retryExhausted.Load(), c.osPermanent.Load())
+// newCounters 构造并注册所有指标到私有 registry。
+func newCounters() *counters {
+	reg := prometheus.NewRegistry()
+	c := &counters{
+		reg: reg,
+		processed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "processed_total",
+			Help:      "Files extracted and written back to OpenSearch successfully.",
+		}),
+		skippedNonFile: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "skipped_non_file_total",
+			Help:      "Non type=8 messages skipped.",
+		}),
+		dlqTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "dlq_total",
+			Help:      "Messages dead-lettered by reason.",
+		}, []string{"reason"}),
+		docNotYet: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "doc_not_yet_total",
+			Help:      "Timing-race hits where the main doc was not yet indexed by es-indexer (404).",
+		}),
+		retryExhausted: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "retry_exhausted_total",
+			Help:      "In-place retries exhausted, forced to DLQ.",
+		}),
+		osPermanent: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "os_permanent_total",
+			Help:      "OpenSearch 4xx permanent errors routed to DLQ.",
+		}),
+	}
+	reg.MustRegister(
+		c.processed, c.skippedNonFile, c.dlqTotal,
+		c.docNotYet, c.retryExhausted, c.osPermanent,
+	)
+	return c
 }
+
+// Registry 暴露私有 registry 供 obs /metrics handler 使用。
+func (c *counters) Registry() *prometheus.Registry { return c.reg }
+
+func (c *counters) IncProcessed()      { c.processed.Inc() }
+func (c *counters) IncSkippedNonFile() { c.skippedNonFile.Inc() }
+
+// IncDLQ 记一次 dead-letter，reason 为空时归到 "unknown" 避免空 label。
+func (c *counters) IncDLQ(reason string) {
+	if reason == "" {
+		reason = "unknown"
+	}
+	c.dlqTotal.WithLabelValues(reason).Inc()
+}
+
+func (c *counters) IncDocNotYet()      { c.docNotYet.Inc() }
+func (c *counters) IncRetryExhausted() { c.retryExhausted.Inc() }
+func (c *counters) IncOSPermanent()    { c.osPermanent.Inc() }

--- a/internal/fileextract/metrics.go
+++ b/internal/fileextract/metrics.go
@@ -22,11 +22,20 @@ package fileextract
 // 留待 P1 增量补齐（见 .omc/monitoring/file-extractor-monitoring-plan.md §3）。
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // metricsNamespace 给所有 series 加 fileextract_ 前缀。
 const metricsNamespace = "fileextract"
+
+// latencyBuckets 是 IO-op 耗时 Histogram 分桶（5ms~5s），对齐 sibling
+// internal/consumer/metrics.go 的同名变量。
+var latencyBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}
+
+// contentBytesBuckets 是抽出正文字节数 Histogram 分桶（1KB~1MB，指数）。
+var contentBytesBuckets = prometheus.ExponentialBuckets(1024, 4, 6)
 
 // counters 是 file-extractor 的可观测集，backed by prometheus client_golang，
 // 绑定在一个私有 registry 上（同 consumer.Metrics 惯例）。
@@ -39,6 +48,14 @@ type counters struct {
 	docNotYet      prometheus.Counter
 	retryExhausted prometheus.Counter
 	osPermanent    prometheus.Counter
+
+	// P1 增量埋点（见 .omc/monitoring/file-extractor-monitoring-plan.md §3）。
+	ioOpDuration     *prometheus.HistogramVec
+	ioOpErrors       *prometheus.CounterVec
+	dlqWriteErrors   prometheus.Counter
+	tombstoneTotal   *prometheus.CounterVec
+	truncatedTotal   prometheus.Counter
+	extractContentBy prometheus.Histogram
 }
 
 // newCounters 构造并注册所有指标到私有 registry。
@@ -76,10 +93,44 @@ func newCounters() *counters {
 			Name:      "os_permanent_total",
 			Help:      "OpenSearch 4xx permanent errors routed to DLQ.",
 		}),
+		ioOpDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "io_op_duration_seconds",
+			Help:      "IO operation latency by op (download/tika_extract/os_update).",
+			Buckets:   latencyBuckets,
+		}, []string{"op"}),
+		ioOpErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "io_op_errors_total",
+			Help:      "IO operation failures by op (download/tika_extract/os_update).",
+		}, []string{"op"}),
+		dlqWriteErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "dlq_write_errors_total",
+			Help:      "DLQ writes that exhausted bounded retries and escaped (spill or hard stop).",
+		}),
+		tombstoneTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "tombstone_total",
+			Help:      "Tombstone markers written for permanently-unextractable files by reason.",
+		}, []string{"reason"}),
+		truncatedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "truncated_total",
+			Help:      "Extractions whose content was truncated at MaxContentBytes.",
+		}),
+		extractContentBy: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "extract_content_bytes",
+			Help:      "Extracted content size in bytes on successful extraction.",
+			Buckets:   contentBytesBuckets,
+		}),
 	}
 	reg.MustRegister(
 		c.processed, c.skippedNonFile, c.dlqTotal,
 		c.docNotYet, c.retryExhausted, c.osPermanent,
+		c.ioOpDuration, c.ioOpErrors, c.dlqWriteErrors,
+		c.tombstoneTotal, c.truncatedTotal, c.extractContentBy,
 	)
 	return c
 }
@@ -101,3 +152,57 @@ func (c *counters) IncDLQ(reason string) {
 func (c *counters) IncDocNotYet()      { c.docNotYet.Inc() }
 func (c *counters) IncRetryExhausted() { c.retryExhausted.Inc() }
 func (c *counters) IncOSPermanent()    { c.osPermanent.Inc() }
+
+// 以下 P1 埋点方法均 nil-receiver 安全：Extractor / dlqHandler 的 counters 字段可为 nil
+// （老 test 手工装配不传 metrics），nil 时跳过埋点不 panic。
+
+// ObserveIO 记一次 IO op 耗时（op ∈ {download, tika_extract, os_update}）。
+func (c *counters) ObserveIO(op string, d time.Duration) {
+	if c == nil {
+		return
+	}
+	c.ioOpDuration.WithLabelValues(op).Observe(d.Seconds())
+}
+
+// IncIOError 记一次 IO op 失败。
+func (c *counters) IncIOError(op string) {
+	if c == nil {
+		return
+	}
+	c.ioOpErrors.WithLabelValues(op).Inc()
+}
+
+// IncDLQWriteError 记一次 DLQ 写重试耗尽逃逸（spill 或 hard stop）。P0 告警依赖项。
+func (c *counters) IncDLQWriteError() {
+	if c == nil {
+		return
+	}
+	c.dlqWriteErrors.Inc()
+}
+
+// IncTombstone 记一次 tombstone 写入成功，reason 为空归到 "unknown"。
+func (c *counters) IncTombstone(reason string) {
+	if c == nil {
+		return
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	c.tombstoneTotal.WithLabelValues(reason).Inc()
+}
+
+// IncTruncated 记一次抽取内容被截断。
+func (c *counters) IncTruncated() {
+	if c == nil {
+		return
+	}
+	c.truncatedTotal.Inc()
+}
+
+// ObserveContentBytes 记一次成功抽取的正文字节数。
+func (c *counters) ObserveContentBytes(n int) {
+	if c == nil {
+		return
+	}
+	c.extractContentBy.Observe(float64(n))
+}

--- a/internal/fileextract/metrics_p1_test.go
+++ b/internal/fileextract/metrics_p1_test.go
@@ -1,0 +1,291 @@
+package fileextract
+
+// metrics_p1_test.go — P1 增量埋点最小断言覆盖（io_op / dlq_write_errors / tombstone /
+// truncated / content_bytes）。只验证埋点被触发，阈值/分桶精度不管。
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// counterVal 从私有 registry 取某 counter series（可带 label）的当前值，取不到返回 -1。
+func counterVal(t *testing.T, c *counters, name string, labels map[string]string) float64 {
+	t.Helper()
+	families, err := c.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if m.Counter != nil && labelsMatch(m.Label, labels) {
+				return m.Counter.GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+// histSampleCount 从私有 registry 取某 histogram series 的样本数，取不到返回 -1。
+func histSampleCount(t *testing.T, c *counters, name string, labels map[string]string) int64 {
+	t.Helper()
+	families, err := c.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if m.Histogram != nil && labelsMatch(m.Label, labels) {
+				return int64(m.Histogram.GetSampleCount())
+			}
+		}
+	}
+	return -1
+}
+
+func labelsMatch(lps []*dto.LabelPair, want map[string]string) bool {
+	got := make(map[string]string, len(lps))
+	for _, lp := range lps {
+		got[lp.GetName()] = lp.GetValue()
+	}
+	if len(got) != len(want) {
+		return false
+	}
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TestMetrics_DLQWriteErrors DLQ 写重试耗尽走 escape（无论 spill 还是 hard stop）→
+// dlq_write_errors_total inc。P0 告警依赖项。
+func TestMetrics_DLQWriteErrors(t *testing.T) {
+	m := newCounters()
+
+	// hard stop 路径（未配 SpillDir）
+	h := newTestDLQHandler(&fakeDLQSink{alwaysErr: true}, &recordAlerter{}, "")
+	h.metrics = m
+	if err := h.Send(context.Background(), sampleDLQRec()); err == nil {
+		t.Fatal("expected errDLQHardStop on exhausted + no spill")
+	}
+	if got := counterVal(t, m, "fileextract_dlq_write_errors_total", nil); got != 1 {
+		t.Fatalf("dlq_write_errors_total after hard stop: got %v want 1", got)
+	}
+
+	// spill 路径（配 SpillDir）也应 inc
+	h2 := newTestDLQHandler(&fakeDLQSink{alwaysErr: true}, &recordAlerter{}, t.TempDir())
+	h2.metrics = m
+	if err := h2.Send(context.Background(), sampleDLQRec()); err != nil {
+		t.Fatalf("escape to spill should return nil, got %v", err)
+	}
+	if got := counterVal(t, m, "fileextract_dlq_write_errors_total", nil); got != 2 {
+		t.Fatalf("dlq_write_errors_total after spill: got %v want 2", got)
+	}
+}
+
+// TestMetrics_DLQWriteErrors_NotIncOnSuccess DLQ 写首次成功不 inc dlq_write_errors_total。
+func TestMetrics_DLQWriteErrors_NotIncOnSuccess(t *testing.T) {
+	m := newCounters()
+	h := newTestDLQHandler(&fakeDLQSink{}, &recordAlerter{}, "")
+	h.metrics = m
+	if err := h.Send(context.Background(), sampleDLQRec()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := counterVal(t, m, "fileextract_dlq_write_errors_total", nil); got != -1 && got != 0 {
+		t.Fatalf("dlq_write_errors_total on success: got %v want 0", got)
+	}
+}
+
+// TestMetrics_ExtractorHappyPath_IOAndContent 抽取全流程走通 → 三处 io_op_duration 各 observe
+// 一次 + content_bytes observe 一次；io_op_errors 保持 0。
+func TestMetrics_ExtractorHappyPath_IOAndContent(t *testing.T) {
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("pdf bytes")) //nolint:errcheck // test handler write
+	}))
+	defer cdn.Close()
+	tika := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("extracted content 抽出内容")) //nolint:errcheck // test handler write
+	}))
+	defer tika.Close()
+	os := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body) //nolint:errcheck
+		_, _ = w.Write([]byte(`{"_id":"42","result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer os.Close()
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{os.URL},
+		ESIndex:                "octo-message",
+		TikaURL:                tika.URL,
+		DownloadTimeout:        time.Second,
+		ExtractTimeout:         time.Second,
+		MaxFileSize:            1024 * 1024,
+		MaxContentBytes:        1024 * 1024,
+		HTTPRetries:            2,
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	m := newCounters()
+	e.metrics = m
+
+	fp := &filePayload{URL: cdn.URL + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if err != nil || reason != "" {
+		t.Fatalf("ExtractAndWrite: reason=%q cause=%v err=%v", reason, cause, err)
+	}
+
+	for _, op := range []string{"download", "tika_extract", "os_update"} {
+		if got := histSampleCount(t, m, "fileextract_io_op_duration_seconds", map[string]string{"op": op}); got != 1 {
+			t.Errorf("io_op_duration_seconds{op=%q} sample count: got %d want 1", op, got)
+		}
+	}
+	if got := histSampleCount(t, m, "fileextract_extract_content_bytes", nil); got != 1 {
+		t.Errorf("extract_content_bytes sample count: got %d want 1", got)
+	}
+	// happy path 无 IO 错误
+	for _, op := range []string{"download", "tika_extract", "os_update"} {
+		if got := counterVal(t, m, "fileextract_io_op_errors_total", map[string]string{"op": op}); got != -1 && got != 0 {
+			t.Errorf("io_op_errors_total{op=%q}: got %v want 0", op, got)
+		}
+	}
+}
+
+// TestMetrics_TombstoneOnPermanentFail permanent-fail (oversize) → WriteTombstone 成功后
+// tombstone_total{reason} inc。
+func TestMetrics_TombstoneOnPermanentFail(t *testing.T) {
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body) //nolint:errcheck
+		_, _ = w.Write([]byte(`{"_id":"42","result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	defer osSrv.Close()
+
+	cfg := ServiceConfig{ESAddresses: []string{osSrv.URL}, ESIndex: "octo-message", MaxFileSize: 1024}
+	osw, err := newOSWriter(cfg)
+	if err != nil {
+		t.Fatalf("newOSWriter: %v", err)
+	}
+	m := newCounters()
+	e := &Extractor{os: osw, maxFileSize: 1024, extractorLabel: "tika/test", metrics: m}
+
+	fp := &filePayload{URL: "http://x/y.pdf", Name: "y.pdf", Extension: ".pdf", Size: 2048}
+	reason, _, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if reason != ReasonOversize || err != nil {
+		t.Fatalf("expected oversize DLQ, got reason=%q err=%v", reason, err)
+	}
+	if got := counterVal(t, m, "fileextract_tombstone_total", map[string]string{"reason": ReasonOversize}); got != 1 {
+		t.Fatalf("tombstone_total{reason=oversize}: got %v want 1", got)
+	}
+}
+
+// TestMetrics_NilSafe Extractor / dlqHandler 的 metrics 为 nil 时埋点跳过不 panic。
+func TestMetrics_NilSafe(t *testing.T) {
+	var c *counters
+	c.ObserveIO("download", time.Millisecond)
+	c.IncIOError("download")
+	c.IncDLQWriteError()
+	c.IncTombstone("oversize")
+	c.IncTruncated()
+	c.ObserveContentBytes(100)
+}
+
+// newTestExtractor 装配一个走真实 download/tika/os HTTP 链路的 Extractor：OS 返回 osStatus
+// 状态码，tikaBody 为 Tika 抽出正文，maxContentBytes 控制截断阈值。返回 Extractor / counters
+// 及 cdn 基址（供构造 filePayload.URL）。供 io_op_errors / truncated 失败路径断言复用。
+func newTestExtractor(t *testing.T, osStatus int, tikaBody string, maxContentBytes int) (*Extractor, *counters, string) {
+	t.Helper()
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("pdf bytes")) //nolint:errcheck // test handler write
+	}))
+	t.Cleanup(cdn.Close)
+	tika := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(tikaBody)) //nolint:errcheck // test handler write
+	}))
+	t.Cleanup(tika.Close)
+	osSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body) //nolint:errcheck
+		if osStatus != http.StatusOK {
+			w.WriteHeader(osStatus)
+		}
+		_, _ = w.Write([]byte(`{"_id":"42","result":"updated"}`)) //nolint:errcheck // test handler write
+	}))
+	t.Cleanup(osSrv.Close)
+
+	cfg := ServiceConfig{
+		ESAddresses:            []string{osSrv.URL},
+		ESIndex:                "octo-message",
+		TikaURL:                tika.URL,
+		DownloadTimeout:        time.Second,
+		ExtractTimeout:         time.Second,
+		MaxFileSize:            1024 * 1024,
+		MaxContentBytes:        maxContentBytes,
+		HTTPRetries:            0,
+		AllowedDownloadHosts:   []string{"127.0.0.1"},
+		AllowedDownloadSchemes: []string{"http", "https"},
+		SSRFAllowLoopback:      true,
+	}
+	e, err := NewExtractor(cfg)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+	m := newCounters()
+	e.metrics = m
+	return e, m, cdn.URL
+}
+
+// TestMetrics_IOError_OSUpdate os_update 返回非 errDocNotYet 的真错误（OS 4xx permanent）→
+// io_op_errors_total{op="os_update"} 加 1；errDocNotYet（OS 404 时序竞态）→【不】加 1。
+// 后者正好覆盖第 1 条修复。
+func TestMetrics_IOError_OSUpdate(t *testing.T) {
+	// 真错误：OS 400 → errOSPermanent（非 errDocNotYet）→ io_op_errors_total{os_update} 加 1
+	e, m, cdnURL := newTestExtractor(t, http.StatusBadRequest, "extracted content 抽出内容", 1024*1024)
+	fp := &filePayload{URL: cdnURL + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
+	if _, _, err := e.ExtractAndWrite(context.Background(), "42", fp); err == nil {
+		t.Fatal("expected OS permanent error, got nil")
+	}
+	if got := counterVal(t, m, "fileextract_io_op_errors_total", map[string]string{"op": "os_update"}); got != 1 {
+		t.Fatalf("io_op_errors_total{op=os_update} on real error: got %v want 1", got)
+	}
+
+	// errDocNotYet：OS 404 时序竞态 → io_op_errors_total{os_update}【不】加 1（第 1 条修复）
+	e2, m2, cdnURL2 := newTestExtractor(t, http.StatusNotFound, "extracted content 抽出内容", 1024*1024)
+	fp2 := &filePayload{URL: cdnURL2 + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
+	if _, _, err := e2.ExtractAndWrite(context.Background(), "42", fp2); err == nil {
+		t.Fatal("expected errDocNotYet, got nil")
+	}
+	if got := counterVal(t, m2, "fileextract_io_op_errors_total", map[string]string{"op": "os_update"}); got != -1 && got != 0 {
+		t.Fatalf("io_op_errors_total{op=os_update} on errDocNotYet: got %v want 0 (第1条修复)", got)
+	}
+}
+
+// TestMetrics_Truncated Tika 抽出正文超过 MaxContentBytes → truncated=true → truncated_total 加 1。
+func TestMetrics_Truncated(t *testing.T) {
+	// MaxContentBytes=5，Tika 返回更长正文 → truncateContent 置 truncated=true；OS 200 成功回写
+	e, m, cdnURL := newTestExtractor(t, http.StatusOK, "extracted content much longer than limit", 5)
+	fp := &filePayload{URL: cdnURL + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
+	reason, cause, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	if err != nil || reason != "" {
+		t.Fatalf("ExtractAndWrite: reason=%q cause=%v err=%v", reason, cause, err)
+	}
+	if got := counterVal(t, m, "fileextract_truncated_total", nil); got != 1 {
+		t.Fatalf("truncated_total: got %v want 1", got)
+	}
+}
+

--- a/internal/fileextract/metrics_p1_test.go
+++ b/internal/fileextract/metrics_p1_test.go
@@ -186,7 +186,7 @@ func TestMetrics_TombstoneOnPermanentFail(t *testing.T) {
 	e := &Extractor{os: osw, maxFileSize: 1024, extractorLabel: "tika/test", metrics: m}
 
 	fp := &filePayload{URL: "http://x/y.pdf", Name: "y.pdf", Extension: ".pdf", Size: 2048}
-	reason, _, err := e.ExtractAndWrite(context.Background(), "42", fp)
+	reason, _, err := e.ExtractAndWrite(context.Background(), "42", fp) //nolint:errcheck // cause 供 DLQ 记录用，测试只断言 reason/err
 	if reason != ReasonOversize || err != nil {
 		t.Fatalf("expected oversize DLQ, got reason=%q err=%v", reason, err)
 	}
@@ -257,7 +257,7 @@ func TestMetrics_IOError_OSUpdate(t *testing.T) {
 	// 真错误：OS 400 → errOSPermanent（非 errDocNotYet）→ io_op_errors_total{os_update} 加 1
 	e, m, cdnURL := newTestExtractor(t, http.StatusBadRequest, "extracted content 抽出内容", 1024*1024)
 	fp := &filePayload{URL: cdnURL + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
-	if _, _, err := e.ExtractAndWrite(context.Background(), "42", fp); err == nil {
+	if _, _, err := e.ExtractAndWrite(context.Background(), "42", fp); err == nil { //nolint:errcheck // cause 供 DLQ 记录用，测试只断言 err
 		t.Fatal("expected OS permanent error, got nil")
 	}
 	if got := counterVal(t, m, "fileextract_io_op_errors_total", map[string]string{"op": "os_update"}); got != 1 {
@@ -267,7 +267,7 @@ func TestMetrics_IOError_OSUpdate(t *testing.T) {
 	// errDocNotYet：OS 404 时序竞态 → io_op_errors_total{os_update}【不】加 1（第 1 条修复）
 	e2, m2, cdnURL2 := newTestExtractor(t, http.StatusNotFound, "extracted content 抽出内容", 1024*1024)
 	fp2 := &filePayload{URL: cdnURL2 + "/x.pdf", Name: "x.pdf", Extension: ".pdf", Size: 100}
-	if _, _, err := e2.ExtractAndWrite(context.Background(), "42", fp2); err == nil {
+	if _, _, err := e2.ExtractAndWrite(context.Background(), "42", fp2); err == nil { //nolint:errcheck // cause 供 DLQ 记录用，测试只断言 err
 		t.Fatal("expected errDocNotYet, got nil")
 	}
 	if got := counterVal(t, m2, "fileextract_io_op_errors_total", map[string]string{"op": "os_update"}); got != -1 && got != 0 {

--- a/internal/fileextract/metrics_test.go
+++ b/internal/fileextract/metrics_test.go
@@ -1,0 +1,51 @@
+package fileextract
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// dumpMetrics 把私有 registry 渲染成稳定文本（每 series 一行，含 label），
+// 供断言精确匹配 series 而不依赖 expfmt 格式（惯例对齐 sibling internal/consumer/metrics_test.go）。
+func dumpMetrics(t *testing.T, c *counters) string {
+	t.Helper()
+	families, err := c.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var lines []string
+	for _, mf := range families {
+		name := mf.GetName()
+		for _, metric := range mf.Metric {
+			if metric.Counter == nil {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("%s%s %s", name, formatLabels(metric.Label), formatVal(metric.Counter.GetValue())))
+		}
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+func formatLabels(lps []*dto.LabelPair) string {
+	if len(lps) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(lps))
+	for _, lp := range lps {
+		parts = append(parts, fmt.Sprintf("%s=%q", lp.GetName(), lp.GetValue()))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// formatVal 把整数值样本渲染成无小数点形式。
+func formatVal(v float64) string {
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d", int64(v))
+	}
+	return fmt.Sprintf("%g", v)
+}

--- a/internal/fileextract/obs.go
+++ b/internal/fileextract/obs.go
@@ -1,0 +1,87 @@
+package fileextract
+
+// obs.go — file-extractor 的最小可观测 HTTP 端点（/healthz /readyz /metrics）。
+// 照搬 sibling internal/consumer/obs.go 的形态：liveness / readiness / Prometheus /metrics
+// （走 counters 的私有 registry）。metrics 为 nil 时（idle 停用态）暴露空 /metrics，
+// 保证探针拿 200 且无 series。
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// writeBody 写响应体，写失败只 log 不 fail（health/metrics 端点的断连不可处理）。
+func writeBody(w http.ResponseWriter, body string) {
+	if _, err := w.Write([]byte(body)); err != nil {
+		log.Printf("file-extractor: obs write: %v", err)
+	}
+}
+
+// ObsServer 提供 /healthz（liveness）/readyz（readiness）/metrics（Prometheus）。
+type ObsServer struct {
+	srv   *http.Server
+	ready atomic.Bool
+}
+
+// ReadyCheck 报告依赖是否可达（供 /readyz 用）。
+type ReadyCheck func(ctx context.Context) error
+
+// NewObsServer 构造绑定到 addr 的可观测 server。metrics 为 nil 时 /metrics 空转。
+func NewObsServer(addr string, metrics *counters, ready ReadyCheck) *ObsServer {
+	o := &ObsServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		writeBody(w, "ok\n")
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if !o.ready.Load() {
+			http.Error(w, "starting\n", http.StatusServiceUnavailable)
+			return
+		}
+		if ready != nil {
+			ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+			defer cancel()
+			if err := ready(ctx); err != nil {
+				http.Error(w, "not ready: "+err.Error()+"\n", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		writeBody(w, "ready\n")
+	})
+	// /metrics 走 client_golang handler + counters 私有 registry；metrics 为 nil 时
+	// 暴露空 handler（idle 态探针仍拿 200，无 series）。
+	if metrics != nil {
+		mux.Handle("/metrics", promhttp.HandlerFor(metrics.Registry(), promhttp.HandlerOpts{}))
+	} else {
+		mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		})
+	}
+	o.srv = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	return o
+}
+
+// SetReady 翻转就绪标志（运行循环启动后调一次）。
+func (o *ObsServer) SetReady(v bool) { o.ready.Store(v) }
+
+// Start 后台起 HTTP server；非优雅关闭的错误经 logf 上报。
+func (o *ObsServer) Start(logf func(string, ...any)) {
+	go func() {
+		if err := o.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logf("file-extractor: obs server error: %v", err)
+		}
+	}()
+}
+
+// Shutdown 优雅停止 HTTP server。
+func (o *ObsServer) Shutdown(ctx context.Context) error {
+	return o.srv.Shutdown(ctx)
+}

--- a/internal/fileextract/retry_test.go
+++ b/internal/fileextract/retry_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -160,8 +161,9 @@ func TestProcessBatch_RetryExhaustedToDLQ(t *testing.T) {
 	if len(dlq.records) != 1 || dlq.records[0].Reason != ReasonRetryExhausted {
 		t.Fatalf("expected 1 DLQ retry_exhausted, got %+v", dlq.records)
 	}
-	if p.metrics.retryExhausted.Load() != 1 {
-		t.Fatalf("retryExhausted counter should be 1, got %d", p.metrics.retryExhausted.Load())
+	if got := dumpMetrics(t, p.metrics); !strings.Contains(got, `fileextract_dlq_total{reason="retry_exhausted"} 1`) ||
+		!strings.Contains(got, "fileextract_retry_exhausted_total 1") {
+		t.Fatalf("dlq_total{reason=retry_exhausted} and retry_exhausted_total should both be 1 in:\n%s", got)
 	}
 	if len(src.commits) != 1 || src.commits[0].Offset != 200 {
 		t.Fatalf("offset must be committed after DLQ retry_exhausted, got %+v", src.commits)
@@ -217,8 +219,32 @@ func TestProcessBatch_OSPermanentToDLQ(t *testing.T) {
 	if len(dlq.records) != 1 || dlq.records[0].Reason != ReasonOSPermanent {
 		t.Fatalf("expected 1 DLQ os_permanent, got %+v", dlq.records)
 	}
-	if p.metrics.osPermanent.Load() != 1 {
-		t.Fatalf("osPermanent counter should be 1, got %d", p.metrics.osPermanent.Load())
+	if got := dumpMetrics(t, p.metrics); !strings.Contains(got, `fileextract_dlq_total{reason="os_permanent"} 1`) ||
+		!strings.Contains(got, "fileextract_os_permanent_total 1") {
+		t.Fatalf("dlq_total{reason=os_permanent} and os_permanent_total should both be 1 in:\n%s", got)
+	}
+}
+
+// TestProcessBatch_DynamicReasonLabel extractor 动态返回的 dlqReason（此处 empty_extract）
+// 必须原样透传到 fileextract_dlq_total 的 reason label。区别于 retry_exhausted/os_permanent/
+// parse_error 那三个静态常量分支，这条覆盖 attemptOne 里 `p.metrics.IncDLQ(dlqReason)` 路径。
+func TestProcessBatch_DynamicReasonLabel(t *testing.T) {
+	src := &mockSource{}
+	dlq := &mockDLQSink{}
+	ext := newMockExtractor()
+	// extractor 判定文件抽取为空 → 返回非空 dlqReason（不 retry，直接 DLQ）
+	ext.queue("empty", extractResult{reason: ReasonEmptyExtract})
+	p := newRetryTestProcessor(t, src, dlq, ext, 10)
+
+	batch := []fetchedMessage{mkFileMessage(t, "empty", 0, 500)}
+	if err := p.processBatch(context.Background(), batch); err != nil {
+		t.Fatalf("processBatch: %v", err)
+	}
+	if len(dlq.records) != 1 || dlq.records[0].Reason != ReasonEmptyExtract {
+		t.Fatalf("expected 1 DLQ empty_extract, got %+v", dlq.records)
+	}
+	if got := dumpMetrics(t, p.metrics); !strings.Contains(got, `fileextract_dlq_total{reason="empty_extract"} 1`) {
+		t.Fatalf("dynamic reason must pass through to dlq_total label, want reason=empty_extract in:\n%s", got)
 	}
 }
 

--- a/internal/fileextract/service.go
+++ b/internal/fileextract/service.go
@@ -54,6 +54,9 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 // Run 运行到 ctx 取消。
 func (s *Service) Run(ctx context.Context) error { return s.proc.Run(ctx) }
 
+// Metrics 暴露底层计数集的私有 registry，供 obs server 走 /metrics。
+func (s *Service) Metrics() *counters { return s.proc.Metrics() }
+
 // Close 关闭底层 Kafka client（Reader + DLQ Writer）。
 func (s *Service) Close() error {
 	var firstErr error

--- a/internal/fileextract/service.go
+++ b/internal/fileextract/service.go
@@ -43,6 +43,9 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, fmt.Errorf("fileextract: build extractor: %w", err)
 	}
 	proc := NewProcessor(source, dlqSink, extractor, cfg)
+	// P1 埋点注入：extractor 的 io_op / tombstone / truncated / content_bytes 埋点写进
+	// processor 的私有 registry（同一 counters）。不改 metrics 所有权/透传链，只加字段注入。
+	extractor.metrics = proc.Metrics()
 	return &Service{
 		proc:      proc,
 		source:    source,


### PR DESCRIPTION
给 file-extractor 补齐 Prometheus 可观测能力(分 P0/P1 两批完成)。

Closes #51

## 改动

### P0 — 指标接入 client_golang
- `metrics.go` 从 atomic stub 升级为 client_golang 私有 registry(不用 global default,避免多 binary 交叉注册),namespace=`fileextract`,对齐 sibling `internal/consumer`。
- 已有 6 个计数点接入:`processed_total` / `skipped_non_file_total` / `dlq_total{reason}` / `doc_not_yet_total` / `retry_exhausted_total` / `os_permanent_total`。
- 新增 `obs.go`(ObsServer):暴露 `/healthz`(liveness)/ `/readyz`(readiness)/ `/metrics`,默认监听 `:9090`(可 `FILE_EXTRACTOR_OBS_ADDR` 覆盖)。
- `main.go`:运行态起 obs;idle 停用态也起(healthz/readyz 200、metrics 空),对齐 es-indexer,防被停用 pod 在探针下 crashloop。

### P1 — 细粒度埋点
- 新增:`io_op_duration_seconds{op}` + `io_op_errors_total{op}`(download / tika_extract / os_update)、`dlq_write_errors_total`(DLQ 写耗尽逃逸,P0 告警依赖)、`tombstone_total{reason}`、`truncated_total`、`extract_content_bytes`(histogram)。
- 注入链:service 把 extractor / dlq_handler 的 metrics 指向同一 processor registry。埋点方法全部 nil-receiver 安全。
- `os_update` 的 `errDocNotYet`(时序竞态)不计入 io 错误率,避免污染。

## 测试
新增 `metrics_p1_test.go` / `metrics_test.go` / `main_test.go` 等覆盖新埋点,build + 全量 test 通过。
